### PR TITLE
DCNG-861 Specify additionalBundledPlugins for testing confluence chart

### DIFF
--- a/src/test/config/confluence/helm_parameters
+++ b/src/test/config/confluence/helm_parameters
@@ -7,6 +7,7 @@ DB_NAME=confluence
 POSTGRES_CHART_VERSION=9.4.1
 POSTGRES_APP_VERSION=10
 LOG_DOWNLOAD_DIR=${project.build.directory}/logs
+ADDITIONAL_PLUGINS_DIR=${project.build.directory}/additional-plugins
 TARGET_NAMESPACE=${kubernetes.target.namespace}
 DOCKER_IMAGE_REGISTRY=${dockerImage.registry}
 DOCKER_IMAGE_VERSION=${dockerImage.version}

--- a/src/test/config/confluence/values.yaml
+++ b/src/test/config/confluence/values.yaml
@@ -12,6 +12,19 @@ confluence:
     container:
       requests:
         memory: 2G
+  additionalBundledPlugins:
+    - volumeName: shared-home
+      subDirectory: ${helm.release.prefix}-confluence
+      fileName: confluence-functestrpc-plugin-7.10.0-SNAPSHOT.jar
+    - volumeName: shared-home
+      subDirectory: ${helm.release.prefix}-confluence
+      fileName: confluence-functest-rest-plugin-7.10.0-SNAPSHOT.jar
+    - volumeName: shared-home
+      subDirectory: ${helm.release.prefix}-confluence
+      fileName: confluence-scriptsfinished-plugin-7.10.0-SNAPSHOT.jar
+    - volumeName: shared-home
+      subDirectory: ${helm.release.prefix}-confluence
+      fileName: atlassian-universal-plugin-manager-javascript-tests-4.2.6.jar
 
 database:
   type: postgresql

--- a/src/test/scripts/helm_install.sh
+++ b/src/test/scripts/helm_install.sh
@@ -45,6 +45,12 @@ helm install -n "${TARGET_NAMESPACE}" --wait \
 
 mkdir -p "$LOG_DOWNLOAD_DIR"
 
+if [[ -d $ADDITIONAL_PLUGINS_DIR ]]
+then
+  "$THISDIR"/shared_home_browser_install.sh "${TARGET_NAMESPACE}"
+  kubectl cp "$ADDITIONAL_PLUGINS_DIR"/* shared-home-browser:/shared-home/"$PRODUCT_RELEASE_NAME"
+fi
+
 for file in ${PRODUCT_CHART_VALUES_FILES}.yaml ${PRODUCT_CHART_VALUES_FILES}-${clusterType}.yaml ; do
   [ -f "$file" ] && valueOverrides+="--values $file "
 done


### PR DESCRIPTION
Starting to test the new mechanism for uploading product test plugins as part of the helm install process, using Confluence as the guinea pig.

Confluence has 4 test plugins. The plugin JAR files will be uploaded to the shared-home volume by `helm_install.sh`, and then the test `values.yaml` file references them there. Conflunce should then start up with those test plugins mounted into the correct directory in the container.

Note that this will require a change to the Confluence mavens, to actually copy the test plugins into the diretory expected by `helm_install.sh`.