### PR TITLE
DCNG-867 Document the presense of  bitbucket.additionalJvmArgs

### DIFF
--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -12,6 +12,7 @@ A chart for installing Bitbucket DC on Kubernetes
 | additionalInitContainers | list | `[]` | Additional initContainer definitions that will be added to all Bitbucket pods |
 | affinity | object | `{}` | Standard Kubernetes affinities that will be applied to all Bitbucket pods |
 | bitbucket.additionalBundledPlugins | list | `[]` | Specifies a list of additional Bitbucket plugins that should be added to the Bitbucket container. These are specified in the same manner as the additionalLibraries field, but the files will be loaded as bundled plugins rather than as libraries. |
+| bitbucket.additionalJvmArgs | string | `nil` | Specifies a list of additional arguments that can be passed to the Bitbucket JVM, e.g. system properties |
 | bitbucket.additionalLibraries | list | `[]` | Specifies a list of additional Java libraries that should be added to the Bitbucket container. Each item in the list should specify the name of the volume which contain the library, as well as the name of the library file within that volume's root directory. Optionally, a subDirectory field can be included to specify which directory in the volume contains the library file. |
 | bitbucket.gid | string | `"2003"` | The GID used by the Bitbucket docker image |
 | bitbucket.license.secretKey | string | `"license-key"` | The key in the Kubernetes Secret which contains the Bitbucket license key |

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -82,6 +82,11 @@ bitbucket:
     #    cpu: "4"
     #    memory: "2G"
 
+  # -- Specifies a list of additional arguments that can be passed to the Bitbucket JVM, e.g. system properties
+  additionalJvmArgs:
+  #    - -Dfoo=bar
+  #    - -Dfruit=lemon
+
   # -- Specifies a list of additional Java libraries that should be added to the Bitbucket container.
   # Each item in the list should specify the name of the volume which contain the library, as well as the name of the
   # library file within that volume's root directory. Optionally, a subDirectory field can be included to specify which


### PR DESCRIPTION
We're already using `bitbucket.additionalJvmArgs` in the Helm chart, but it's not documented correctly.