### PR TITLE
DCNG-864 Set imagePullPolicy=Always

### DIFF
--- a/src/test/scripts/helm_install.sh
+++ b/src/test/scripts/helm_install.sh
@@ -51,6 +51,7 @@ done
 
 [ -n "$DOCKER_IMAGE_REGISTRY" ] && valueOverrides+="--set image.registry=$DOCKER_IMAGE_REGISTRY "
 [ -n "$DOCKER_IMAGE_VERSION" ] && valueOverrides+="--set image.tag=$DOCKER_IMAGE_VERSION "
+valueOverrides+="--set image.pullPolicy=Always "
 
 # Ask Helm to generate the YAML that it will send to Kubernetes in the "install" step later, so
 # that we can look at it for diagnostics.


### PR DESCRIPTION
Changes the `helm_install.sh` script to set the image pull policy to "always". This should cover both ad-hoc and CI installations, whilst keeping the chart default as if-not-present.