### PR TITLE
DCNG-856 Add NOTES.txt

### DIFF
--- a/src/main/charts/bitbucket/templates/NOTES.txt
+++ b/src/main/charts/bitbucket/templates/NOTES.txt
@@ -1,16 +1,16 @@
 Thank you for installing {{ .Chart.Name }}.
 
-Your release is named {{ .Release.Name }}.
+Your release is named {{ .Release.Name }}, and resides in namespace {{ .Release.Namespace }}.
 
 Please run sanity tests against the release to verify it's healthy:
 
-  $ helm test {{ .Release.Name }} --logs
+  $ helm test {{ .Release.Name }} --logs -n {{ .Release.Namespace }}
 
 If the Kubernetes resources in the release are still starting up, then the tests may fail, so it
 is advisable to wait for the tests to pass before continuing.
 
 To see the custom values you used for this release:
 
-  $ helm get values {{ .Release.Name }}
+  $ helm get values {{ .Release.Name }} -n {{ .Release.Namespace }}
 
 For further documentation, see https://github.com/atlassian-labs/data-center-helm-charts/tree/master/docs

--- a/src/main/charts/confluence/templates/NOTES.txt
+++ b/src/main/charts/confluence/templates/NOTES.txt
@@ -1,16 +1,16 @@
 Thank you for installing {{ .Chart.Name }}.
 
-Your release is named {{ .Release.Name }}.
+Your release is named {{ .Release.Name }}, and resides in namespace {{ .Release.Namespace }}.
 
 Please run sanity tests against the release to verify it's healthy:
 
-  $ helm test {{ .Release.Name }} --logs
+  $ helm test {{ .Release.Name }} --logs -n {{ .Release.Namespace }}
 
 If the Kubernetes resources in the release are still starting up, then the tests may fail, so it
 is advisable to wait for the tests to pass before continuing.
 
 To see the custom values you used for this release:
 
-  $ helm get values {{ .Release.Name }}
+  $ helm get values {{ .Release.Name }} -n {{ .Release.Namespace }}
 
 For further documentation, see https://github.com/atlassian-labs/data-center-helm-charts/tree/master/docs

--- a/src/main/charts/jira/templates/NOTES.txt
+++ b/src/main/charts/jira/templates/NOTES.txt
@@ -1,16 +1,16 @@
 Thank you for installing {{ .Chart.Name }}.
 
-Your release is named {{ .Release.Name }}.
+Your release is named {{ .Release.Name }}, and resides in namespace {{ .Release.Namespace }}.
 
 Please run sanity tests against the release to verify it's healthy:
 
-  $ helm test {{ .Release.Name }} --logs
+  $ helm test {{ .Release.Name }} --logs -n {{ .Release.Namespace }}
 
 If the Kubernetes resources in the release are still starting up, then the tests may fail, so it
 is advisable to wait for the tests to pass before continuing.
 
 To see the custom values you used for this release:
 
-  $ helm get values {{ .Release.Name }}
+  $ helm get values {{ .Release.Name }} -n {{ .Release.Namespace }}
 
 For further documentation, see https://github.com/atlassian-labs/data-center-helm-charts/tree/master/docs


### PR DESCRIPTION
Adds a basic `NOTES.txt` file to each chart. This will be printed out to the console when the chart is installed.

Each chart has an identical `NOTES.txt` (for now)