### PR TITLE
Issue/dckube 670 fix synchrony ingress path

### DIFF
--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
                 port:
                   number: {{ $.Values.confluence.service.port }}
           {{ if .Values.synchrony.enabled }}
-          - path: {{ trimSuffix "/" (include "confluence.ingressPath" .) }}/synchrony"
+          - path: {{ trimSuffix "/" (include "confluence.ingressPath" .) }}/synchrony
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
Synchrony path of the Ingress has been broken after pull request #263 

This pull request changes the unit tests to verify **all** paths of **all** ingresses, which exposes the current problem (CI fails on first commit). Also, this PR fixes the issue by removing the extra quote in the ingress file.