### PR TITLE
DCKUBE-664: Added a recommendation to report product bugs in Atlassian Support page

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-issue.md
@@ -29,7 +29,7 @@ Please report only helm chart issues here. To report a product specific bug use 
 **Screenshots (if applicable)**
 
 **More Input (optional):**
-please run of the following relevant commands and report the output.
+please run the following relevant commands and report the output.
 ```
 $ kubectl get pods
 $ kubectl describe pods

--- a/.github/ISSUE_TEMPLATE/report-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-issue.md
@@ -10,9 +10,9 @@ assignees: ''
 ### NOTE:
 Please report only Helm Chart issues here. To report a product specific bug use [Atlassian Support Page](https://jira.atlassian.com/secure/Dashboard.jspa)
 
-### Report the bug:
+### Report the issue:
 
-**Describe the bug**
+**Describe the issue**
 
 
 **Existing Behaviour**

--- a/.github/ISSUE_TEMPLATE/report-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-issue.md
@@ -28,7 +28,7 @@ Please report only Helm chart issues here. To report a product-specific bug use 
 
 **Screenshots (if applicable)**
 
-**More input (optional)**
+**More input (if applicable)**
 Please run the following relevant commands and report the output:
 ```
 $ kubectl get pods

--- a/.github/ISSUE_TEMPLATE/report-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-issue.md
@@ -1,11 +1,16 @@
 ---
-name: Report Issue
-about: Report an issue to help us improve
+name: Report A Helm Chart Issue
+about: Report helm chart issues to help us improve
 title: "[ISSUE]"
 labels: bug
 assignees: ''
 
 ---
+
+### NOTE:
+Please report only helm chart issues here. To report a product specific bug use [Attlassian Support Page](https://jira.atlassian.com/secure/Dashboard.jspa)
+
+### Report the bug:
 
 **Describe the bug**
 
@@ -14,21 +19,24 @@ assignees: ''
 
 
 **Steps to Reproduce**
-1.
-2.
-3.
+1. 
+2. 
+3. 
 
 **Expected Behaviour**
 
 
 **Screenshots (if applicable)**
 
-**More Input(please run and report the output of the relevant commands):**
+**More Input (optional):**
+please run of the following relevant commands and report the output.
+```
 $ kubectl get pods
 $ kubectl describe pods
 $ kubectl describe sts
 $ kubectl describe pv
 $ kubectl describe pvc
-$kubectl logs [relevant pod name]
+$ kubectl logs [relevant pod name]
+```
 
 **Additional Context**

--- a/.github/ISSUE_TEMPLATE/report-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-issue.md
@@ -1,6 +1,6 @@
 ---
 name: Report Helm Chart Issue
-about: Report Helm Chart issues and help us improve
+about: Report Helm chart issues and help us improve
 title: "[ISSUE]"
 labels: bug
 assignees: ''
@@ -8,28 +8,28 @@ assignees: ''
 ---
 
 ### NOTE:
-Please report only Helm Chart issues here. To report a product specific bug use [Atlassian Support Page](https://jira.atlassian.com/secure/Dashboard.jspa)
+Please report only Helm chart issues here. To report a product-specific bug use the [Atlassian Support Page](https://jira.atlassian.com/secure/Dashboard.jspa)
 
 ### Report the issue:
 
 **Describe the issue**
 
 
-**Existing Behaviour**
+**Existing behaviour**
 
 
-**Steps to Reproduce**
+**Steps to reproduce**
 1. 
 2. 
 3. 
 
-**Expected Behaviour**
+**Expected behaviour**
 
 
 **Screenshots (if applicable)**
 
-**More Input (optional):**
-please run the following relevant commands and report the output.
+**More input (optional):**
+Please run the following relevant commands and report the output:
 ```
 $ kubectl get pods
 $ kubectl describe pods
@@ -39,4 +39,4 @@ $ kubectl describe pvc
 $ kubectl logs [relevant pod name]
 ```
 
-**Additional Context**
+**Additional context**

--- a/.github/ISSUE_TEMPLATE/report-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-issue.md
@@ -28,7 +28,7 @@ Please report only Helm chart issues here. To report a product-specific bug use 
 
 **Screenshots (if applicable)**
 
-**More input (optional):**
+**More input (optional)**
 Please run the following relevant commands and report the output:
 ```
 $ kubectl get pods

--- a/.github/ISSUE_TEMPLATE/report-issue.md
+++ b/.github/ISSUE_TEMPLATE/report-issue.md
@@ -1,6 +1,6 @@
 ---
-name: Report A Helm Chart Issue
-about: Report helm chart issues to help us improve
+name: Report Helm Chart Issue
+about: Report Helm Chart issues and help us improve
 title: "[ISSUE]"
 labels: bug
 assignees: ''
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ### NOTE:
-Please report only helm chart issues here. To report a product specific bug use [Attlassian Support Page](https://jira.atlassian.com/secure/Dashboard.jspa)
+Please report only Helm Chart issues here. To report a product specific bug use [Atlassian Support Page](https://jira.atlassian.com/secure/Dashboard.jspa)
 
 ### Report the bug:
 


### PR DESCRIPTION
Recommended to report product bugs in Atlassian Support page instead of GitHub itself