### PR TITLE
DCKUBE-658 Upgrade Bitbucket charts to use the AWS Load Balancer Cont…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,10 @@
         <kitt.ingress.domain>${kubernetes.ingress.domain}</kitt.ingress.domain>
 <!--        <eks.ingress.domain>eks.k8s.bbsperf.com</eks.ingress.domain>-->
         <eks.ingress.domain>dcngkube.bbsperf.com</eks.ingress.domain>
-        <eks.ssh.internal>true</eks.ssh.internal>
+        <!-- ARN of an ACM issued certificate for the above domain -->
+        <eks.ingress.certificate/>
+        <!-- Can be either 'internal' or 'internet-facing' -->
+        <eks.ssh.loadbalancer.scheme>internal</eks.ssh.loadbalancer.scheme>
         <custom.ingress.uri />
 
         <shared.pvc.name>atlassian-dc-shared-home-pvc</shared.pvc.name>

--- a/src/test/config/bitbucket/values-EKS.yaml
+++ b/src/test/config/bitbucket/values-EKS.yaml
@@ -5,6 +5,14 @@ serviceAccount:
 
 ingress:
   create: true
+  nginx: false
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/certificate-arn: ${eks.ingress.certificate}
+    alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/healthcheck-path: /status
   host: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
 
 bitbucket:
@@ -12,7 +20,9 @@ bitbucket:
     enabled: true
     annotations:
       external-dns.alpha.kubernetes.io/hostname: ${helm.release.prefix}-bitbucket-ssh.${eks.ingress.domain}
-      service.beta.kubernetes.io/aws-load-balancer-internal: '${eks.ssh.internal}'
+      service.beta.kubernetes.io/aws-load-balancer-type: external
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+      service.beta.kubernetes.io/aws-load-balancer-scheme: ${eks.ssh.loadbalancer.scheme}
   additionalEnvironmentVariables:
     - name: PLUGIN_SSH_BASEURL
       value: ssh://${helm.release.prefix}-bitbucket-ssh.${eks.ingress.domain}/


### PR DESCRIPTION
…roller with ALB/NLBs instead of nginx for testing.

Previously, for CI we had a AWS Classic Load Balancer in HTTP mode in front of the nginx-ingress for TLS termination. This essentially created a series of 2 HTTP reverse proxies, which caused problems for Git when cloning big repositories. I wasn't able to get to the bottom of this, but it's bad practice anyway. This way we are making use of the AWS Load Balancer Controller, which allows us to use an AWS ALB as an ingress for Bitbucket.