### PR TITLE
DCKUBE-686: decrease Confluence failover time

### DIFF
--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -42,7 +42,7 @@ Kubernetes: `>=1.19.x-0`
 | confluence.license.secretName | string | `nil` | The name of the K8s Secret that contains the Confluence license key. If specified, then the license will be automatically populated during Confluence setup. Otherwise, it will need to be provided via the browser after initial startup. An Example of creating a K8s secret for the license below: 'kubectl create secret generic <secret-name> --from-literal=license-key=<license> https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets |
 | confluence.ports.hazelcast | int | `5701` | The port on which the Confluence container listens for Hazelcast traffic |
 | confluence.ports.http | int | `8090` | The port on which the Confluence container listens for HTTP traffic |
-| confluence.readinessProbe.failureThreshold | int | `30` | The number of consecutive failures of the Confluence container readiness probe before the pod fails readiness checks. |
+| confluence.readinessProbe.failureThreshold | int | `6` | The number of consecutive failures of the Confluence container readiness probe before the pod fails readiness checks. |
 | confluence.readinessProbe.initialDelaySeconds | int | `10` | The initial delay (in seconds) for the Confluence container readiness probe, after which the probe will start running. |
 | confluence.readinessProbe.periodSeconds | int | `5` | How often (in seconds) the Confluence container readiness probe will run |
 | confluence.resources.container.requests.cpu | string | `"2"` | Initial CPU request by Confluence pod. If changing the cpu value update additional JVM arg 'ActiveProcessorCount' below |
@@ -102,7 +102,7 @@ Kubernetes: `>=1.19.x-0`
 | synchrony.ingressUrl | string | `nil` | The base URL of the Synchrony service. This will be the URL that users' browsers will be given to communicate with Synchrony, as well as the URL that the Confluence service will use to communicate directly with Synchrony, so the URL must be resolvable both from inside and outside the Kubernetes cluster. |
 | synchrony.ports.hazelcast | int | `5701` | The port on which the Synchrony container listens for Hazelcast traffic |
 | synchrony.ports.http | int | `8091` | The port on which the Synchrony container listens for HTTP traffic |
-| synchrony.readinessProbe.failureThreshold | int | `30` | The number of consecutive failures of the Synchrony container readiness probe before the pod fails readiness checks. |
+| synchrony.readinessProbe.failureThreshold | int | `10` | The number of consecutive failures of the Synchrony container readiness probe before the pod fails readiness checks. |
 | synchrony.readinessProbe.initialDelaySeconds | int | `5` | The initial delay (in seconds) for the Synchrony container readiness probe, after which the probe will start running. |
 | synchrony.readinessProbe.periodSeconds | int | `1` | How often (in seconds) the Synchrony container readiness probe will run |
 | synchrony.resources.container.requests.cpu | string | `"2"` | Initial CPU request by Synchrony pod |

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -503,7 +503,7 @@ confluence:
     # -- The number of consecutive failures of the Confluence container readiness probe
     # before the pod fails readiness checks.
     #
-    failureThreshold: 30
+    failureThreshold: 6
 
   # Confluence log configuration
   #
@@ -714,7 +714,7 @@ synchrony:
     # -- The number of consecutive failures of the Synchrony container readiness probe
     # before the pod fails readiness checks.
     #
-    failureThreshold: 30
+    failureThreshold: 10
   
   # Synchrony Pod resource requests
   #

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -157,7 +157,7 @@ spec:
               path: /heartbeat
             initialDelaySeconds: 5
             periodSeconds: 1
-            failureThreshold: 30
+            failureThreshold: 10
           resources:
             requests:
               cpu: "2"
@@ -239,7 +239,7 @@ spec:
               path: /status
             initialDelaySeconds: 10
             periodSeconds: 5
-            failureThreshold: 30
+            failureThreshold: 6
           resources:
             requests:
               cpu: "2"


### PR DESCRIPTION
If the Confluence node becomes unhealthy, it takes 2.5 minutes of failing `/status` checks for load balancer to exclude the node.
It's because the readiness probe has a period of 5 seconds and `failureThreshold` of 30. The product of those values is 150 seconds, which corresponds to 2 minutes and 30 seconds
In practice this means that the customer, whose session was pointing to the failed node, will continue experiencing errors for at least 2 minutes and 30 seconds until they can work with the application again.
2:30 seems like too much. There is no reason I know failover should be this long. In this pull request I'm changing the chart defaults to have 30 seconds of failover - this coincides with the reasonable timeout for HTTP request and seems like a better value for failover.
This change can also be useful for other products (Jira, BBS, Crowd).