### PR TITLE
DCKUBE-677: Make securityContext more flexible

### DIFF
--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -32,6 +32,7 @@ Kubernetes: `>=1.19.x-0`
 | bitbucket.additionalLibraries | list | `[]` | Specifies a list of additional Java libraries that should be added to the Bitbucket container. Each item in the list should specify the name of the volume that contains the library, as well as the name of the library file within that volume's root directory. Optionally, a subDirectory field can be included to specify which directory in the volume contains the library file. Additional details: https://atlassian.github.io/data-center-helm-charts/examples/external_libraries/EXTERNAL_LIBS/ |
 | bitbucket.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Bitbucket container. These can refer to existing volumes, or new volumes can be defined via 'volumes.additional'. |
 | bitbucket.clustering.enabled | bool | `false` | Set to 'true' if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
+| bitbucket.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. |
 | bitbucket.elasticSearch.baseUrl | string | `nil` | The base URL of the external Elasticsearch instance to be used. If this is defined, then Bitbucket will disable its internal Elasticsearch instance. |
 | bitbucket.elasticSearch.credentials.passwordSecretKey | string | `"password"` | The key in the Kubernetes Secret that contains the Elasticsearch password. |
 | bitbucket.elasticSearch.credentials.secretName | string | `nil` | The name of the Kubernetes Secret that contains the Elasticsearch credentials. Example of creating a credentials K8s secret below: 'kubectl create secret generic <secret-name> --from-literal=username=<username> \ --from-literal=password=<password>' https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets |
@@ -45,8 +46,7 @@ Kubernetes: `>=1.19.x-0`
 | bitbucket.resources.container.requests.memory | string | `"2G"` | Initial Memory request by Bitbucket pod |
 | bitbucket.resources.jvm.maxHeap | string | `"1g"` | The maximum amount of heap memory that will be used by the Bitbucket JVM The same value will be used by the Elasticsearch JVM. |
 | bitbucket.resources.jvm.minHeap | string | `"512m"` | The minimum amount of heap memory that will be used by the Bitbucket JVM The same value will be used by the Elasticsearch JVM. |
-| bitbucket.securityContext.enabled | bool | `true` | Set to 'true' to enable the security context |
-| bitbucket.securityContext.gid | string | `"2003"` | The GID used by the Bitbucket docker image |
+| bitbucket.securityContext.fsGroup | int | `2003` | The GID used by the Bitbucket docker image |
 | bitbucket.service.annotations | object | `{}` | Additional annotations to apply to the Service |
 | bitbucket.service.port | int | `80` | The port on which the Bitbucket K8s Service will listen |
 | bitbucket.service.type | string | `"ClusterIP"` | The type of K8s service to use for Bitbucket |

--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -119,7 +119,7 @@ The command that should be run by the nfs-fixer init container to correct the pe
 {{- if .Values.volumes.sharedHome.nfsPermissionFixer.command }}
 {{ .Values.volumes.sharedHome.nfsPermissionFixer.command }}
 {{- else }}
-{{- printf "(chgrp %s %s; chmod g+w %s)" .Values.bitbucket.securityContext.gid .Values.volumes.sharedHome.nfsPermissionFixer.mountPath .Values.volumes.sharedHome.nfsPermissionFixer.mountPath }}
+{{- printf "(chgrp %v %s; chmod g+w %s)" .Values.bitbucket.securityContext.fsGroup .Values.volumes.sharedHome.nfsPermissionFixer.mountPath .Values.volumes.sharedHome.nfsPermissionFixer.mountPath }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -26,12 +26,8 @@ spec:
     spec:
       serviceAccountName: {{ include "bitbucket.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.bitbucket.shutdown.terminationGracePeriodSeconds }}
-      {{ if .Values.bitbucket.securityContext.enabled }}
       securityContext:
-        # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Bitbucket container.
-        # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
-        fsGroup: {{ .Values.bitbucket.securityContext.gid }} # Makes sure that the shared-home volume mount is writeable by the bitbucket user's GID
-      {{ end }}
+        {{ toYaml .Values.bitbucket.securityContext | nindent 8 }}
       initContainers:
         {{- include "bitbucket.additionalInitContainers" . | nindent 8 }}
         {{- if .Values.volumes.sharedHome.nfsPermissionFixer.enabled }}
@@ -69,6 +65,10 @@ spec:
             periodSeconds: 5
             failureThreshold: 60
             initialDelaySeconds: 10
+          {{- with .Values.bitbucket.containerSecurityContext}}
+          securityContext:
+            {{- toYaml . | nindent 12}}
+          {{- end}}
           volumeMounts:
             - name: local-home
               mountPath: {{ .Values.volumes.localHome.mountPath | quote }}

--- a/src/main/charts/bitbucket/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/bitbucket/templates/tests/test-shared-home-permissions.yaml
@@ -17,8 +17,8 @@ spec:
       imagePullPolicy: IfNotPresent
       securityContext:
         # Slightly dodgy; we assume that the UID and GID used by the product images are the same, which in practice they are
-        runAsUser: {{ .Values.bitbucket.securityContext.gid }}
-        runAsGroup: {{ .Values.bitbucket.securityContext.gid }}
+        runAsUser: {{ .Values.bitbucket.securityContext.fsGroup }}
+        runAsGroup: {{ .Values.bitbucket.securityContext.fsGroup }}
       volumeMounts:
         - name: shared-home
           mountPath: /shared-home

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -445,20 +445,27 @@ bitbucket:
     # needs extra annotations.
     #
     annotations: {}
-    
-  # Enable or disable security context in StatefulSet template spec.
-  # Enabled by default with UID 2003. Disable when deploying to OpenShift,
-  # unless anyuid policy is attached to service account.
+
+  # Standard K8s field that holds pod-level security attributes and common container settings.
   #
   securityContext:
-    
-    # -- Set to 'true' to enable the security context
-    #
-    enabled: true
-    
+
     # -- The GID used by the Bitbucket docker image
     #
-    gid: "2003"
+    fsGroup: 2003
+
+#    # -- Set to 'true' to enable the security context (Deprecated)
+#    #
+#    enabled: true
+#
+#    # -- The GID used by the Bitbucket docker image (Deprecated)
+#    #
+#    gid: "2003"
+
+
+  # -- Standard K8s field that holds security configurations that will be applied to a container.
+  #
+  containerSecurityContext: {}
 
   # -- Boolean to define whether to set local home directory permissions on startup
   # of Bitbucket container. Set to 'false' to disable this behaviour.

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -37,6 +37,7 @@ Kubernetes: `>=1.19.x-0`
 | confluence.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Confluence container. These can refer to existing volumes, or new volumes can be defined via 'volumes.additional'. |
 | confluence.clustering.enabled | bool | `false` | Set to 'true' if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
 | confluence.clustering.usePodNameAsClusterNodeName | bool | `true` | Set to 'true' if the K8s pod name should be used as the end-user-visible name of the Data Center cluster node. |
+| confluence.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. |
 | confluence.jvmDebug.enabled | bool | `false` | Set to 'true' for remote debugging. Confluence JVM will be started with debugging port 5005 open. |
 | confluence.license.secretKey | string | `"license-key"` | The key in the K8s Secret that contains the Confluence license key |
 | confluence.license.secretName | string | `nil` | The name of the K8s Secret that contains the Confluence license key. If specified, then the license will be automatically populated during Confluence setup. Otherwise, it will need to be provided via the browser after initial startup. An Example of creating a K8s secret for the license below: 'kubectl create secret generic <secret-name> --from-literal=license-key=<license> https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets |
@@ -50,8 +51,7 @@ Kubernetes: `>=1.19.x-0`
 | confluence.resources.jvm.maxHeap | string | `"1g"` | The maximum amount of heap memory that will be used by the Confluence JVM |
 | confluence.resources.jvm.minHeap | string | `"1g"` | The minimum amount of heap memory that will be used by the Confluence JVM |
 | confluence.resources.jvm.reservedCodeCache | string | `"256m"` | The memory reserved for the Confluence JVM code cache |
-| confluence.securityContext.enabled | bool | `true` | Set to 'true' to enable the security context |
-| confluence.securityContext.gid | string | `"2002"` | The GID used by the Confluence docker image |
+| confluence.securityContext.fsGroup | int | `2002` | The GID used by the Confluence docker image |
 | confluence.service.annotations | object | `{}` | Additional annotations to apply to the Service |
 | confluence.service.contextPath | string | `nil` | The Tomcat context path that Confluence will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically. |
 | confluence.service.port | int | `80` | The port on which the Confluence K8s Service will listen |

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -183,7 +183,7 @@ The command that should be run by the nfs-fixer init container to correct the pe
 {{- if .Values.volumes.sharedHome.nfsPermissionFixer.command }}
 {{ .Values.volumes.sharedHome.nfsPermissionFixer.command }}
 {{- else }}
-{{- printf "(chgrp %s %s; chmod g+w %s)" .Values.confluence.securityContext.gid .Values.volumes.sharedHome.nfsPermissionFixer.mountPath .Values.volumes.sharedHome.nfsPermissionFixer.mountPath }}
+{{- printf "(chgrp %v %s; chmod g+w %s)" .Values.confluence.securityContext.fsGroup .Values.volumes.sharedHome.nfsPermissionFixer.mountPath .Values.volumes.sharedHome.nfsPermissionFixer.mountPath }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -21,12 +21,8 @@ spec:
     spec:
       serviceAccountName: {{ include "confluence.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.confluence.shutdown.terminationGracePeriodSeconds }}
-      {{ if .Values.confluence.securityContext.enabled }}
       securityContext:
-        # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Confluence container.
-        # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
-        fsGroup: {{ .Values.confluence.securityContext.gid }}
-      {{ end }}
+        {{ toYaml .Values.confluence.securityContext | nindent 8 }}
       hostAliases:
         {{- include "confluence.additionalHosts" . | nindent 8 }}
       initContainers:
@@ -63,6 +59,10 @@ spec:
             initialDelaySeconds: {{ .Values.confluence.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.confluence.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.confluence.readinessProbe.failureThreshold }}
+          {{- with .Values.confluence.containerSecurityContext}}
+          securityContext:
+          {{- toYaml . | nindent 12}}
+          {{- end}}
           {{- with .Values.confluence.resources.container }}
           resources:
           {{- toYaml . | nindent 12 }}

--- a/src/main/charts/confluence/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/confluence/templates/tests/test-shared-home-permissions.yaml
@@ -17,8 +17,8 @@ spec:
       imagePullPolicy: IfNotPresent
       securityContext:
         # Slightly dodgy; we assume that the UID and GID used by the product images are the same, which in practice they are
-        runAsUser: {{ .Values.confluence.securityContext.gid }}
-        runAsGroup: {{ .Values.confluence.securityContext.gid }}
+        runAsUser: {{ .Values.confluence.securityContext.fsGroup }}
+        runAsGroup: {{ .Values.confluence.securityContext.fsGroup }}
       volumeMounts:
         - name: shared-home
           mountPath: /shared-home

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -449,7 +449,7 @@ confluence:
 
   # -- Standard K8s field that holds security configurations that will be applied to a container.
   #
-  containerSecurityContext: { }
+  containerSecurityContext: {}
 
   # -- The umask used by the Confluence process when it creates new files.
   # The default is 0022. This gives the new files:

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -430,21 +430,27 @@ confluence:
     # -- Additional annotations to apply to the Service
     #
     annotations: {}
-  
-  # Enable or disable security context in StatefulSet template spec. Enabled
-  # by default with UID 2002. Disable when deploying to OpenShift, unless anyuid
-  # policy is attached to a service account.
+
+  # Standard K8s field that holds pod-level security attributes and common container settings.
   #
   securityContext:
-  
-    # -- Set to 'true' to enable the security context
-    #
-    enabled: true
-    
+
     # -- The GID used by the Confluence docker image
     #
-    gid: "2002"
-    
+    fsGroup: 2002
+
+#    # -- Set to 'true' to enable the security context (Deprecated)
+#    #
+#    enabled: true
+#
+#    # -- The GID used by the Confluence docker image (Deprecated)
+#    #
+#    gid: "2002"
+
+  # -- Standard K8s field that holds security configurations that will be applied to a container.
+  #
+  containerSecurityContext: { }
+
   # -- The umask used by the Confluence process when it creates new files.
   # The default is 0022. This gives the new files:
     #  - read/write permissions for the Confluence user

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -37,6 +37,7 @@ Kubernetes: `>=1.19.x-0`
 | crowd.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Crowd container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
 | crowd.clustering.enabled | bool | `false` | Set to 'true' if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
 | crowd.clustering.usePodNameAsClusterNodeName | bool | `true` | Set to 'true' if the K8s pod name should be used as the end-user-visible name of the Data Center cluster node. |
+| crowd.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. |
 | crowd.ports.hazelcast | int | `5701` | The port on which the Crowd container listens for Hazelcast traffic |
 | crowd.ports.http | int | `8095` | The port on which the Crowd container listens for HTTP traffic |
 | crowd.readinessProbe.failureThreshold | int | `30` | The number of consecutive failures of the Crowd container readiness probe before the pod fails readiness checks. |
@@ -46,8 +47,7 @@ Kubernetes: `>=1.19.x-0`
 | crowd.resources.container.requests.memory | string | `"1G"` | Initial Memory request by Crowd pod |
 | crowd.resources.jvm.maxHeap | string | `"768m"` | The maximum amount of heap memory that will be used by the Crowd JVM |
 | crowd.resources.jvm.minHeap | string | `"384m"` | The minimum amount of heap memory that will be used by the Crowd JVM |
-| crowd.securityContext.enabled | bool | `true` | Set to 'true' to enable the security context |
-| crowd.securityContext.gid | string | `"2004"` | The GID used by the Crowd docker image |
+| crowd.securityContext.fsGroup | int | `2004` | The GID used by the Crowd docker image |
 | crowd.service.annotations | object | `{}` | Additional annotations to apply to the Service |
 | crowd.service.port | int | `80` | The port on which the Crowd K8s Service will listen |
 | crowd.service.type | string | `"ClusterIP"` | The type of K8s service to use for Crowd |

--- a/src/main/charts/crowd/templates/_helpers.tpl
+++ b/src/main/charts/crowd/templates/_helpers.tpl
@@ -117,7 +117,7 @@ The command that should be run by the nfs-fixer init container to correct the pe
 {{- if .Values.volumes.sharedHome.nfsPermissionFixer.command }}
 {{ .Values.volumes.sharedHome.nfsPermissionFixer.command }}
 {{- else }}
-{{- printf "(chgrp %s %s; chmod g+w %s)" .Values.crowd.securityContext.gid .Values.volumes.sharedHome.nfsPermissionFixer.mountPath .Values.volumes.sharedHome.nfsPermissionFixer.mountPath }}
+{{- printf "(chgrp %v %s; chmod g+w %s)" .Values.crowd.securityContext.fsGroup .Values.volumes.sharedHome.nfsPermissionFixer.mountPath .Values.volumes.sharedHome.nfsPermissionFixer.mountPath }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -21,12 +21,8 @@ spec:
     spec:
       serviceAccountName: {{ include "crowd.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.crowd.shutdown.terminationGracePeriodSeconds }}
-      {{ if .Values.crowd.securityContext.enabled }}
       securityContext:
-        # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Crowd container.
-        # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
-        fsGroup: {{ .Values.crowd.securityContext.gid }}
-      {{ end }}
+        {{ toYaml .Values.crowd.securityContext | nindent 8 }}
       initContainers:
         {{- include "crowd.additionalInitContainers" . | nindent 8 }}
         {{- if .Values.volumes.sharedHome.nfsPermissionFixer.enabled }}
@@ -61,6 +57,10 @@ spec:
             initialDelaySeconds: {{ .Values.crowd.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.crowd.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.crowd.readinessProbe.failureThreshold }}
+          {{- with .Values.crowd.containerSecurityContext}}
+          securityContext:
+          {{- toYaml . | nindent 12}}
+          {{- end}}
           {{- with .Values.crowd.resources.container }}
           resources:
           {{- toYaml . | nindent 12 }}

--- a/src/main/charts/crowd/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/crowd/templates/tests/test-shared-home-permissions.yaml
@@ -17,8 +17,8 @@ spec:
       imagePullPolicy: IfNotPresent
       securityContext:
         # Slightly dodgy; we assume that the UID and GID used by the product images are the same, which in practice they are
-        runAsUser: {{ .Values.crowd.securityContext.gid }}
-        runAsGroup: {{ .Values.crowd.securityContext.gid }}
+        runAsUser: {{ .Values.crowd.securityContext.fsGroup }}
+        runAsGroup: {{ .Values.crowd.securityContext.fsGroup }}
       volumeMounts:
         - name: shared-home
           mountPath: /shared-home

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -122,19 +122,25 @@ crowd:
     #
     annotations: {}
 
-  # Enable or disable security context in StatefulSet template spec. Enabled
-  # by default with UID 2002. Disable when deploying to OpenShift, unless anyuid
-  # policy is attached to a service account.
+  # Standard K8s field that holds pod-level security attributes and common container settings.
   #
   securityContext:
 
-    # -- Set to 'true' to enable the security context
-    #
-    enabled: true
-
     # -- The GID used by the Crowd docker image
     #
-    gid: "2004"
+    fsGroup: 2004
+
+#    # -- Set to 'true' to enable the security context (Deprecated)
+#    #
+#    enabled: true
+#
+#    # -- The GID used by the Crowd docker image (Deprecated)
+#    #
+#    gid: "2004"
+
+  # -- Standard K8s field that holds security configurations that will be applied to a container.
+  #
+  containerSecurityContext: {}
 
   # -- The umask used by the Crowd process when it creates new files.
   # The default is 0022. This gives the new files:

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -61,6 +61,7 @@ Kubernetes: `>=1.19.x-0`
 | jira.additionalLibraries | list | `[]` | Specifies a list of additional Java libraries that should be added to the Jira container. Each item in the list should specify the name of the volume that contains the library, as well as the name of the library file within that volume's root directory. Optionally, a subDirectory field can be included to specify which directory in the volume contains the library file. Additional details: https://atlassian.github.io/data-center-helm-charts/examples/external_libraries/EXTERNAL_LIBS/ |
 | jira.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Jira container. These can refer to existing volumes, or new volumes can be defined via 'volumes.additional'. |
 | jira.clustering.enabled | bool | `false` | Set to 'true' if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
+| jira.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. |
 | jira.license.secretKey | string | `"license-key"` | The key in the K8s Secret that contains the Jira license key |
 | jira.license.secretName | string | `nil` | The name of the K8s Secret that contains the Jira license key. If specified, then the license will be automatically populated during Jira setup. Otherwise, it will need to be provided via the browser after initial startup. An Example of creating a K8s secret for the license below: 'kubectl create secret generic <secret-name> --from-literal=license-key=<license> https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets |
 | jira.ports.ehcache | int | `40001` | Ehcache port |
@@ -74,8 +75,7 @@ Kubernetes: `>=1.19.x-0`
 | jira.resources.jvm.maxHeap | string | `"768m"` | The maximum amount of heap memory that will be used by the Jira JVM |
 | jira.resources.jvm.minHeap | string | `"384m"` | The minimum amount of heap memory that will be used by the Jira JVM |
 | jira.resources.jvm.reservedCodeCache | string | `"512m"` | The memory reserved for the Jira JVM code cache |
-| jira.securityContext.enabled | bool | `true` | Set to 'true' to enable the security context |
-| jira.securityContext.gid | string | `"2001"` | The GID used by the Jira docker image |
+| jira.securityContext.fsGroup | int | `2001` | The GID used by the Jira docker image |
 | jira.service.annotations | object | `{}` | Additional annotations to apply to the Service |
 | jira.service.contextPath | string | `nil` | The Tomcat context path that Jira will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically. |
 | jira.service.port | int | `80` | The port on which the Jira K8s Service will listen |

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -99,7 +99,7 @@ The command that should be run by the nfs-fixer init container to correct the pe
 {{- if .Values.volumes.sharedHome.nfsPermissionFixer.command }}
 {{ .Values.volumes.sharedHome.nfsPermissionFixer.command }}
 {{- else }}
-{{- printf "(chgrp %s %s; chmod g+w %s)" .Values.jira.securityContext.gid .Values.volumes.sharedHome.nfsPermissionFixer.mountPath .Values.volumes.sharedHome.nfsPermissionFixer.mountPath }}
+{{- printf "(chgrp %v %s; chmod g+w %s)" .Values.jira.securityContext.fsGroup .Values.volumes.sharedHome.nfsPermissionFixer.mountPath .Values.volumes.sharedHome.nfsPermissionFixer.mountPath }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -21,12 +21,8 @@ spec:
     spec:
       serviceAccountName: {{ include "jira.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.jira.shutdown.terminationGracePeriodSeconds }}
-      {{ if .Values.jira.securityContext.enabled }}
       securityContext:
-        # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container.
-        # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
-        fsGroup: {{ .Values.jira.securityContext.gid }}
-      {{ end }}
+        {{ toYaml .Values.jira.securityContext | nindent 8 }}
       initContainers:
         {{- include "jira.additionalInitContainers" . | nindent 8 }}
         {{- if .Values.volumes.sharedHome.nfsPermissionFixer.enabled }}
@@ -115,6 +111,10 @@ spec:
             initialDelaySeconds: {{ .Values.jira.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.jira.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.jira.readinessProbe.failureThreshold }}
+          {{- with .Values.jira.containerSecurityContext}}
+          securityContext:
+          {{- toYaml . | nindent 12}}
+          {{- end}}
           {{- with .Values.jira.resources.container }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/src/main/charts/jira/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/jira/templates/tests/test-shared-home-permissions.yaml
@@ -17,8 +17,8 @@ spec:
       imagePullPolicy: IfNotPresent
       securityContext:
         # Slightly dodgy; we assume that the UID and GID used by the product images are the same, which in practice they are
-        runAsUser: {{ .Values.jira.securityContext.gid }}
-        runAsGroup: {{ .Values.jira.securityContext.gid }}
+        runAsUser: {{ .Values.jira.securityContext.fsGroup }}
+        runAsGroup: {{ .Values.jira.securityContext.fsGroup }}
       volumeMounts:
         - name: shared-home
           mountPath: /shared-home

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -366,20 +366,26 @@ jira:
     # -- Additional annotations to apply to the Service
     #
     annotations: {}
-    
-  # Enable or disable security context in StatefulSet template spec. Enabled
-  # by default with UID 2001. Disable when deploying to OpenShift, unless anyuid
-  # policy is attached to a service account.
+
+  # Standard K8s field that holds pod-level security attributes and common container settings.
   #
   securityContext:
-  
-    # -- Set to 'true' to enable the security context
-    #
-    enabled: true
-    
+
     # -- The GID used by the Jira docker image
     #
-    gid: "2001"
+    fsGroup: 2001
+  
+#    # -- Set to 'true' to enable the security context (Deprecated)
+#    #
+#    enabled: true
+#
+#    # -- The GID used by the Jira docker image (Deprecated)
+#    #
+#    gid: "2001"
+
+  # -- Standard K8s field that holds security configurations that will be applied to a container.
+  #
+  containerSecurityContext: {}
 
   # -- Boolean to define whether to set local home directory permissions on startup
   # of Jira container. Set to 'false' to disable this behaviour.

--- a/src/test/java/test/SecurityContextTest.java
+++ b/src/test/java/test/SecurityContextTest.java
@@ -1,0 +1,50 @@
+package test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import test.helm.Helm;
+import test.model.Product;
+
+import java.util.Map;
+
+import static test.jackson.JsonNodeAssert.assertThat;
+
+/**
+ * Tests the various permutations of the "<product>.securityContext" and "<product>.containerSecurityContext" value structure in the Helm charts
+ */
+class SecurityContextTest {
+    private Helm helm;
+
+    @BeforeEach
+    void initHelm(TestInfo testInfo) {
+        helm = new Helm(testInfo);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class)
+    void test_pod_security_context(Product product) throws Exception {
+
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".securityContext.fsGroup", "1000"));
+
+        JsonNode podSpec = resources.getStatefulSet(product.getHelmReleaseName()).getPodSpec();
+        assertThat(podSpec.path("securityContext").path("fsGroup")).hasValueEqualTo(1000);
+
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class)
+    void test_container_security_context(Product product) throws Exception {
+
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".containerSecurityContext.runAsGroup", "2000"));
+
+        JsonNode containerSecurityContext = resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getSecurityContext();
+        assertThat(containerSecurityContext.path("runAsGroup")).hasValueEqualTo(2000);
+    }
+}

--- a/src/test/java/test/model/Container.java
+++ b/src/test/java/test/model/Container.java
@@ -40,4 +40,8 @@ public final class Container {
     public JsonNode getLimits() {
         return getResources().path("limits");
     }
+
+    public JsonNode getSecurityContext() {
+        return get("securityContext");
+    }
 }

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -90,9 +90,7 @@ spec:
       serviceAccountName: unittest-bitbucket
       terminationGracePeriodSeconds: 35
       securityContext:
-        # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Bitbucket container.
-        # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
-        fsGroup: 2003 # Makes sure that the shared-home volume mount is writeable by the bitbucket user's GID
+        fsGroup: 2003
       initContainers:
         - name: nfs-permission-fixer
           image: alpine

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -208,8 +208,6 @@ spec:
       serviceAccountName: unittest-confluence
       terminationGracePeriodSeconds: 25
       securityContext:
-        # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Confluence container.
-        # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
         fsGroup: 2002
       hostAliases:
       initContainers:

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -85,8 +85,6 @@ spec:
       serviceAccountName: unittest-crowd
       terminationGracePeriodSeconds: 30
       securityContext:
-        # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Crowd container.
-        # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
         fsGroup: 2004
       initContainers:
         - name: nfs-permission-fixer

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -80,8 +80,6 @@ spec:
       serviceAccountName: unittest-jira
       terminationGracePeriodSeconds: 30
       securityContext:
-        # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container.
-        # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
         fsGroup: 2001
       initContainers:
         - name: nfs-permission-fixer


### PR DESCRIPTION
`securityContext` had only `fsGroup` configurable by user supplying `gid` in values.yaml file. However, gid is not a K8s standard field, and we have to convert gid to fsGroup within _helpers template. 
Now made securityContext fully configurable by user supplying the whole section in values.yaml file, so that more fields than `fsGroup` are able to be configured. 

Moreover, there are two levels of securityContext in K8s world: pod level and container level. This PR also separated these two levels by defining `securityContext` stanza for pod, and `containerSecurityContext` stanza for container. User now have 100% flexibility to define securityContext on both pod and container level.    

`Values.bitbucket.securityContext.enabled` and `Values.bitbucket.securityContext.gid` will de deprecated. Breaking changes will have to be introduced for existing customers who wants to upgrade Helm chart. 