### PR TITLE
[documentation] Fix the tabbed content to support mkdocs-material v8.x

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -36,7 +36,8 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.details
   - meta
   - admonition


### PR DESCRIPTION
The `mkdocs` container always fetches the latest image (it is up for discussion if this is a good thing). This will fix the tabbed content

This is now rendered in the official docs
![image](https://user-images.githubusercontent.com/416238/144369675-e5f4a379-e648-476e-9cce-ffd0dbd8330a.png)

This is after the fix
![image](https://user-images.githubusercontent.com/416238/144369771-36ff617b-a6d1-4392-ac4d-c188beb1c9aa.png)

Changelog
https://squidfunk.github.io/mkdocs-material/upgrade/#pymdownxtabbed