### PR TITLE
BAMBK8S-194: Support for unattended setups

### DIFF
--- a/src/main/charts/bamboo-agent/Chart.yaml
+++ b/src/main/charts/bamboo-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: bamboo-agent
 description: A chart for installing Bamboo Data Center remote agents on Kubernetes
 type: application
 version: 0.0.1
-appVersion: 8.0.4-jdk11
+appVersion: 8.1.1
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Bamboo

--- a/src/main/charts/bamboo-agent/README.md
+++ b/src/main/charts/bamboo-agent/README.md
@@ -1,6 +1,6 @@
 # bamboo-agent
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.0.4-jdk11](https://img.shields.io/badge/AppVersion-8.0.4--jdk11-informational?style=flat-square)
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1](https://img.shields.io/badge/AppVersion-8.1.1-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center remote agents on Kubernetes
 

--- a/src/main/charts/bamboo/Chart.yaml
+++ b/src/main/charts/bamboo/Chart.yaml
@@ -3,7 +3,7 @@ name: bamboo
 description: A chart for installing Bamboo Data Center on Kubernetes
 type: application
 version: 0.0.1
-appVersion: 8.0.4-jdk11
+appVersion: 8.1.1
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Bamboo

--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -1,6 +1,6 @@
 # bamboo
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.0.4-jdk11](https://img.shields.io/badge/AppVersion-8.0.4--jdk11-informational?style=flat-square)
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1](https://img.shields.io/badge/AppVersion-8.1.1-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center on Kubernetes
 
@@ -34,21 +34,19 @@ Kubernetes: `>=1.19.x-0`
 | bamboo.additionalLibraries | list | `[]` | Specifies a list of additional Java libraries that should be added to the Bamboo container. Each item in the list should specify the name of the volume that contains the library, as well as the name of the library file within that volume's root directory. Optionally, a subDirectory field can be included to specify which directory in the volume contains the library file. Additional details: https://atlassian.github.io/data-center-helm-charts/examples/external_libraries/EXTERNAL_LIBS/ |
 | bamboo.additionalPorts | list | `[]` | Defines any additional ports for the Bamboo container. |
 | bamboo.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Bamboo container. These  can refer to existing volumes, or new volumes can be defined via  'volumes.additional'. |
-| bamboo.baseUrl | string | `nil` | Supply the base URL for the installation. |
 | bamboo.brokerUrl | string | `nil` | Override the server/agent broker URL; this is optional. |
 | bamboo.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | bamboo.disableAgentAuth | bool | `false` | Whether to disable agent authentication. Setting this to true skips the agent approval step in the UI. For more information see: https://confluence.atlassian.com/bamboo/agent-authentication-289277196.html The default is false. |
 | bamboo.import | object | `{"path":null,"type":"clean"}` | Bamboo can optionally import an existing exported dataset on first-run. These optional values can configure the import file or skip this stage entirely. For more details on importing and exporting see the documentation: https://confluence.atlassian.com/bamboo/exporting-data-for-backup-289277255.html https://confluence.atlassian.com/bamboo/importing-data-from-backup-289277260.html |
 | bamboo.import.path | string | `nil` | Path to the existing export to import to the new installation. This should be accessible by the cluster node; e.g. via the shared-home or `additionalVolumeMounts` below. |
 | bamboo.import.type | string | `"clean"` | Import type. Valid values are `clean` (for a new install) or `import`, in which case you should provide the file path. The default is `clean`. |
-| bamboo.license | object | `{"secretKey":"license","secretName":null}` | The license to provide to the Bamboo nodes (optional). If you have an existing license it can be provided to the server up-front to skip the configuration screen on first run. |
 | bamboo.license.secretKey | string | `"license"` | The key (default 'licenseKey') in the Secret used to store the license information |
 | bamboo.license.secretName | string | `nil` | The secret that contains the license information |
 | bamboo.ports.http | int | `8085` | The port on which the Bamboo container listens for HTTP traffic |
 | bamboo.ports.jms | int | `54663` | JMS port |
 | bamboo.readinessProbe.failureThreshold | int | `30` | The number of consecutive failures of the Bamboo container readiness probe  before the pod fails readiness checks. |
 | bamboo.readinessProbe.initialDelaySeconds | int | `10` | The initial delay (in seconds) for the Bamboo container readiness probe,  after which the probe will start running. |
-| bamboo.readinessProbe.periodSeconds | int | `5` | How often (in seconds) the Bamboo container readiness probe will run |
+| bamboo.readinessProbe.periodSeconds | int | `10` | How often (in seconds) the Bamboo container readiness probe will run |
 | bamboo.resources.container.requests.cpu | string | `"2"` | Initial CPU request by Bamboo pod |
 | bamboo.resources.container.requests.memory | string | `"2G"` | Initial Memory request by Bamboo pod |
 | bamboo.resources.jvm.maxHeap | string | `"1024m"` | The maximum amount of heap memory that will be used by the Bamboo JVM |
@@ -63,12 +61,12 @@ Kubernetes: `>=1.19.x-0`
 | bamboo.setPermissions | bool | `true` | Boolean to define whether to set local home directory permissions on startup of Bamboo container. Set to 'false' to disable this behaviour. |
 | bamboo.shutdown.command | string | `"/shutdown-wait.sh"` | By default pods will be stopped via a [preStop hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/), using a script supplied by the Docker image. If any other shutdown behaviour is needed it can be achieved by overriding this value. Note that the shutdown command needs to wait for the application shutdown completely before exiting; see [the default command](https://bitbucket.org/atlassian-docker/docker-bamboo-server/src/master/shutdown-wait.sh)  for details. |
 | bamboo.shutdown.terminationGracePeriodSeconds | int | `30` | The termination grace period for pods during shutdown. This should be set to the internal grace period, plus a small buffer to allow the JVM to fully terminate. |
-| bamboo.sysadminCredentials | object | `{"displayNameSecretKey":"displayName","emailAddressSecretKey":"emailAddress","passwordSecretKey":"password","secretName":null,"usernameSecretKey":"username"}` | The admin user configuration and credentials to provide to Bamboo (optional). If provided this will skip the configuration screen on first run. |
 | bamboo.sysadminCredentials.displayNameSecretKey | string | `"displayName"` | The key in the Kubernetes Secret that contains the sysadmin display name |
 | bamboo.sysadminCredentials.emailAddressSecretKey | string | `"emailAddress"` | The key in the Kubernetes Secret that contains the sysadmin email address |
 | bamboo.sysadminCredentials.passwordSecretKey | string | `"password"` | The key in the Kubernetes Secret that contains the sysadmin password |
 | bamboo.sysadminCredentials.secretName | string | `nil` | The secret that contains the admin user information |
 | bamboo.sysadminCredentials.usernameSecretKey | string | `"username"` | The key in the Kubernetes Secret that contains the sysadmin username |
+| bamboo.unattendedSetup | bool | `true` | To skip the setup wizard post deployment set this property to 'true' and ensure values for all 'REQUIRED' and 'UNATTENDED-SETUP' stanzas  (see banner of this file) have been supplied. For release 1.0.0 this value is by default set to 'true' |
 | database.credentials.passwordSecretKey | string | `"password"` | The key ('password') in the Secret used to store the database login password |
 | database.credentials.secretName | string | `nil` | The name of the K8s Secret that contains the database login credentials. If the secret is specified, then the credentials will be automatically utilised on  Bamboo startup. If the secret is not provided, then the credentials will need to be  provided via the browser during manual configuration post deployment.   Example of creating a database credentials K8s secret below: 'kubectl create secret generic <secret-name> --from-literal=username=<username> \ --from-literal=password=<password>' https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets |
 | database.credentials.usernameSecretKey | string | `"username"` | The key ('username') in the Secret used to store the database login username |
@@ -91,7 +89,7 @@ Kubernetes: `>=1.19.x-0`
 | ingress.className | string | `"nginx"` | The class name used by the ingress controller if it's being used. Please follow documenation of your ingress controller. If the cluster  contains multiple ingress controllers, this setting allows you to control which of them is used for Atlassian application traffic. |
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a  pre-provisioned Ingress Controller being available.  |
 | ingress.host | string | `nil` | The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on  this hostname will be routed by the Ingress Resource to the appropriate backend  Service. |
-| ingress.https | bool | `true` | Set to 'true' if browser communication with the application should be TLS  (HTTPS) enforced. |
+| ingress.https | bool | `true` | Set to 'true' if browser communication with the application should be TLS  (HTTPS) enforced. If not using an ingress and you want to reach the service  on localhost using port-forwarding then this value should be set to 'false' |
 | ingress.maxBodySize | string | `"250m"` | The max body size to allow. Requests exceeding this size will result in an HTTP 413 error being returned to the client. |
 | ingress.nginx | bool | `true` | Set to 'true' if the Ingress Resource is to use the K8s 'ingress-nginx'  controller.  https://kubernetes.github.io/ingress-nginx/ This will populate the Ingress Resource with annotations that are specific to  the K8s ingress-nginx controller. Set to 'false' if a different controller is  to be used, in which case the appropriate annotations for that controller must  be specified below under 'ingress.annotations'. |
 | ingress.path | string | `nil` | The base path for the Ingress Resource. For example '/bamboo'. Based on a  'ingress.host' value of 'company.k8s.com' this would result in a URL of  'company.k8s.com/bamboo'. Default value is 'bamboo.service.contextPath' |

--- a/src/main/charts/bamboo/templates/_helpers.tpl
+++ b/src/main/charts/bamboo/templates/_helpers.tpl
@@ -32,6 +32,19 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Deduce the base URL for bamboo.
+*/}}
+{{- define "bamboo.baseUrl" -}}
+{{- if .Values.ingress.host -}}
+{{ ternary "https" "http" .Values.ingress.https -}}
+://
+{{- .Values.ingress.host -}}
+{{- else }}
+{{- print  "http://localhost:8085/" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create default value for ingress port
 */}}
 {{- define "bamboo.ingressPort" -}}

--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -59,10 +59,8 @@ spec:
             - name: ATL_TOMCAT_SECURE
               value: "true"
             {{ end }}
-            {{ if .Values.bamboo.baseUrl }}
             - name: ATL_BASE_URL
-              value: {{ .Values.bamboo.baseUrl | quote }}
-            {{ end }}
+              value: {{ include "bamboo.baseUrl" . | quote }}
             {{ if .Values.bamboo.service.contextPath }}
             - name: ATL_TOMCAT_CONTEXTPATH
               value: {{ .Values.bamboo.service.contextPath | quote }}
@@ -143,6 +141,8 @@ spec:
             - name: ATL_IMPORT_PATH
               value: {{ .Values.bamboo.import.path }}
             {{ end }}
+            - name: ATL_BAMBOO_ENABLE_UNATTENDED_SETUP
+              value: {{ .Values.bamboo.unattendedSetup | quote }}
             {{- include "bamboo.additionalEnvironmentVariables" . | nindent 12 }}
           ports:
             - name: http

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -2,6 +2,14 @@
 # 
 # HEADS UP! 
 #
+# Release 1.0.0 of this chart only support FULL unattended setups. 
+# 
+# All setup data (denoted with 'UNATTENDED-SETUP') required for configuring Bamboo including
+# sections declared as 'REQUIRED' must be supplied up-front as part of this file. 
+# The property 'bamboo.unattendedSetup' is set, by default, to 'true'. 
+#
+# As a result, post helm install of this chart, there is no manual setup required for Bamboo.
+#
 # Data loss will occur if sections declared as 'REQUIRED' are not configured appropriately!
 # These sections are:
 # - database
@@ -322,7 +330,8 @@ ingress:
   annotations: {}
   
   # -- Set to 'true' if browser communication with the application should be TLS 
-  # (HTTPS) enforced.
+  # (HTTPS) enforced. If not using an ingress and you want to reach the service 
+  # on localhost using port-forwarding then this value should be set to 'false'
   #
   https: true
   
@@ -341,9 +350,13 @@ ingress:
 #
 bamboo:
 
-  # -- Supply the base URL for the installation.
+  # -- To skip the setup wizard post deployment set this property to 'true' and
+  # ensure values for all 'REQUIRED' and 'UNATTENDED-SETUP' stanzas 
+  # (see banner of this file) have been supplied.
   #
-  baseUrl:
+  # For release 1.0.0 this value is by default set to 'true'
+  #
+  unattendedSetup: true
 
   # -- Override the server/agent broker URL; this is optional.
   #
@@ -376,24 +389,27 @@ bamboo:
   #
   disableAgentAuth: false
 
-
-  # -- The license to provide to the Bamboo nodes (optional). If you
-  # have an existing license it can be provided to the server up-front
-  # to skip the configuration screen on first run.
+  # UNATTENDED-SETUP
+  #
+  # -- The Bamboo DC license that should be used.
+  # If supplied here the license configuration will be 
+  # skipped in the setup wizard.
   #
   license:
 
     # -- The secret that contains the license information
     #
-    secretName:
+    secretName: 
 
     # -- The key (default 'licenseKey') in the Secret used to store the license information
     #
     secretKey: license
 
-  # -- The admin user configuration and credentials to provide to
-  # Bamboo (optional). If provided this will skip the configuration
-  # screen on first run.
+  # UNATTENDED-SETUP 
+  #
+  # -- The admin user configuration, and credentials 
+  # that Bamboo should use. If supplied here the admin 
+  # configuration will be skipped in the setup wizard.
   #
   sysadminCredentials:
 
@@ -506,7 +522,7 @@ bamboo:
     
     # -- How often (in seconds) the Bamboo container readiness probe will run
     #
-    periodSeconds: 5
+    periodSeconds: 10
     
     # -- The number of consecutive failures of the Bamboo container readiness probe 
     # before the pod fails readiness checks.

--- a/src/test/config/bamboo/values.yaml
+++ b/src/test/config/bamboo/values.yaml
@@ -1,10 +1,8 @@
 # This file contains overrides for the Bamboo Helm chart's values.yaml file
 
 bamboo:
-  baseUrl: https://${helm.release.prefix}.${eks.ingress.domain}/
 
-  clustering:
-    enabled: ${clustering.enabled}
+  unattendedSetup: true
 
   securityToken:
     secretName: bamboo-security-token

--- a/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: bamboo-agent-0.0.1
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
-    app.kubernetes.io/version: "8.0.4-jdk11"
+    app.kubernetes.io/version: "8.1.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: bamboo-agent/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: bamboo-agent-0.0.1
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
-    app.kubernetes.io/version: "8.0.4-jdk11"
+    app.kubernetes.io/version: "8.1.1"
     app.kubernetes.io/managed-by: Helm
 data:
   max_heap: 512m
@@ -35,7 +35,7 @@ metadata:
     helm.sh/chart: bamboo-agent-0.0.1
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
-    app.kubernetes.io/version: "8.0.4-jdk11"
+    app.kubernetes.io/version: "8.1.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -57,7 +57,7 @@ spec:
       initContainers:
       containers:
         - name: bamboo-agent
-          image: "atlassian/bamboo-agent-base:8.0.4-jdk11"
+          image: "atlassian/bamboo-agent-base:8.1.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: BAMBOO_SERVER

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: bamboo-0.0.1
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.0.4-jdk11"
+    app.kubernetes.io/version: "8.1.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: bamboo/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: bamboo-0.0.1
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.0.4-jdk11"
+    app.kubernetes.io/version: "8.1.1"
     app.kubernetes.io/managed-by: Helm
 data:
   additional_jvm_args: >-
@@ -37,7 +37,7 @@ metadata:
     helm.sh/chart: bamboo-0.0.1
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.0.4-jdk11"
+    app.kubernetes.io/version: "8.1.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -60,7 +60,7 @@ metadata:
     helm.sh/chart: bamboo-0.0.1
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.0.4-jdk11"
+    app.kubernetes.io/version: "8.1.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -92,7 +92,7 @@ spec:
           command: ["sh", "-c", "(chgrp 2005 /shared-home; chmod g+w /shared-home)"]
       containers:
         - name: bamboo
-          image: "atlassian/bamboo:8.0.4-jdk11"
+          image: "atlassian/bamboo:8.1.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: ATL_TOMCAT_SCHEME
@@ -100,7 +100,7 @@ spec:
             - name: ATL_TOMCAT_SECURE
               value: "true"
             - name: ATL_BASE_URL
-              value: "https://testUrl/"
+              value: "http://localhost:8085/"
             - name: SET_PERMISSIONS
               value: "true"
             - name: BAMBOO_SHARED_HOME
@@ -156,6 +156,8 @@ spec:
               value: clean
             - name: ATL_IMPORT_PATH
               value: 
+            - name: ATL_BAMBOO_ENABLE_UNATTENDED_SETUP
+              value: "true"
           ports:
             - name: http
               containerPort: 8085
@@ -168,7 +170,7 @@ spec:
               port: 8085
               path: /rest/api/latest/status
             initialDelaySeconds: 10
-            periodSeconds: 5
+            periodSeconds: 10
             failureThreshold: 30
           resources:
             requests:
@@ -204,7 +206,7 @@ metadata:
     helm.sh/chart: bamboo-0.0.1
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.0.4-jdk11"
+    app.kubernetes.io/version: "8.1.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -236,7 +238,7 @@ metadata:
     helm.sh/chart: bamboo-0.0.1
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.0.4-jdk11"
+    app.kubernetes.io/version: "8.1.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:


### PR DESCRIPTION
Bamboo `8.1` has a limitation where partial setups are broken. For the purposes of the first Bamboo helm chart `1.0.0` release, unattended setups are non optional and must be used. A bug has been raised against Bamboo itself to address this limitation: 

https://jira.atlassian.com/browse/BAM-21542

Until this issue is fixed unattended setups will be required when deploying Bamboo server via Helm. 