### PR TITLE
add feature to define loadBalancerIP

### DIFF
--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -56,6 +56,7 @@ Kubernetes: `>=1.19.x-0`
 | bamboo.securityToken.secretName | string | `nil` | The name of the K8s Secret that contains the security token. When specified the token will overrided the generated one. This secret should also be shared with the agent deployment. An Example of creating a K8s secret for the secret below: 'kubectl create secret generic <secret-name> --from-literal=security-token=<security token>' https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets |
 | bamboo.service.annotations | object | `{}` | Additional annotations to apply to the Service |
 | bamboo.service.contextPath | string | `nil` | The Tomcat context path that Bamboo will use. The ATL_TOMCAT_CONTEXTPATH  will be set automatically. |
+| bamboo.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer. |
 | bamboo.service.port | int | `80` | The port on which the Bamboo K8s Service will listen |
 | bamboo.service.type | string | `"ClusterIP"` | The type of K8s service to use for Bamboo |
 | bamboo.setPermissions | bool | `true` | Boolean to define whether to set local home directory permissions on startup of Bamboo container. Set to 'false' to disable this behaviour. |

--- a/src/main/charts/bamboo/templates/service.yaml
+++ b/src/main/charts/bamboo/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.bamboo.service.type }}
+  {{- if and (eq .Values.bamboo.service.type "LoadBalancer") (not (empty .Values.bamboo.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.bamboo.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.bamboo.service.port }}
       targetPort: http

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -466,7 +466,11 @@ bamboo:
     # -- The type of K8s service to use for Bamboo
     #
     type: ClusterIP
-    
+
+    # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
+    #
+    loadBalancerIP:
+
     # -- The Tomcat context path that Bamboo will use. The ATL_TOMCAT_CONTEXTPATH 
     # will be set automatically.
     #

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -57,15 +57,17 @@ Kubernetes: `>=1.19.x-0`
 | bitbucket.securityContext.fsGroup | int | `2003` | The GID used by the Bitbucket docker image If not supplied, will default to 2003. This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Bitbucket container. However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260 |
 | bitbucket.service.annotations | object | `{}` | Additional annotations to apply to the Service |
 | bitbucket.service.contextPath | string | `nil` | The context path that Bitbucket will use. |
+| bitbucket.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer. |
 | bitbucket.service.port | int | `80` | The port on which the Bitbucket K8s Service will listen |
 | bitbucket.service.type | string | `"ClusterIP"` | The type of K8s service to use for Bitbucket |
 | bitbucket.setPermissions | bool | `true` | Boolean to define whether to set local home directory permissions on startup of Bitbucket container. Set to 'false' to disable this behaviour. |
 | bitbucket.shutdown.command | string | `"/shutdown-wait.sh"` | By default pods will be stopped via a [preStop hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/), using a script supplied by the Docker image. If any other shutdown behaviour is needed it can be achieved by overriding this value. Note that the shutdown command needs to wait for the application shutdown completely before exiting; see [the default command](https://bitbucket.org/atlassian-docker/docker-atlassian-bitbucket-server/src/master/shutdown-wait.sh) for details. |
 | bitbucket.shutdown.terminationGracePeriodSeconds | int | `35` | The termination grace period for pods during shutdown. This should be set to the Bitbucket internal grace period (default 30 seconds), plus a small buffer to allow the JVM to fully terminate. |
-| bitbucket.sshService | object | `{"annotations":{},"enabled":false,"host":null,"port":22,"type":"LoadBalancer"}` | Enable or disable an additional service for exposing SSH for external access. Disable when the SSH service is exposed through the ingress controller, or enable if the ingress controller does not support TCP. |
+| bitbucket.sshService | object | `{"annotations":{},"enabled":false,"host":null,"loadBalancerIP":null,"port":22,"type":"LoadBalancer"}` | Enable or disable an additional service for exposing SSH for external access. Disable when the SSH service is exposed through the ingress controller, or enable if the ingress controller does not support TCP. |
 | bitbucket.sshService.annotations | object | `{}` | Annotations for the SSH service. Useful if a load balancer controller needs extra annotations. |
 | bitbucket.sshService.enabled | bool | `false` | Set to 'true' if an additional SSH Service should be created |
 | bitbucket.sshService.host | string | `nil` | The hostname of the SSH service. If set, it'll be used to configure the SSH base URL for the application. |
+| bitbucket.sshService.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer. |
 | bitbucket.sshService.port | int | `22` | Port to expose the SSH service on. |
 | bitbucket.sshService.type | string | `"LoadBalancer"` | SSH Service type |
 | bitbucket.sysadminCredentials.displayNameSecretKey | string | `"displayName"` | The key in the Kubernetes Secret that contains the sysadmin display name |

--- a/src/main/charts/bitbucket/templates/service-ssh.yaml
+++ b/src/main/charts/bitbucket/templates/service-ssh.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.bitbucket.sshService.type }}
+  {{- if and (eq .Values.bitbucket.sshService.type "LoadBalancer") (not (empty .Values.bitbucket.sshService.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.bitbucket.sshService.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.bitbucket.sshService.port }}
       targetPort: ssh

--- a/src/main/charts/bitbucket/templates/service.yaml
+++ b/src/main/charts/bitbucket/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.bitbucket.service.type }}
+  {{- if and (eq .Values.bitbucket.service.type "LoadBalancer") (not (empty .Values.bitbucket.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.bitbucket.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.bitbucket.service.port }}
       targetPort: http

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -431,6 +431,10 @@ bitbucket:
     #
     type: ClusterIP
 
+    # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
+    #
+    loadBalancerIP:
+
     # -- The context path that Bitbucket will use.
     #
     contextPath:
@@ -460,7 +464,11 @@ bitbucket:
     # -- SSH Service type
     #
     type: LoadBalancer
-    
+
+    # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
+    #
+    loadBalancerIP:
+
     # -- Annotations for the SSH service. Useful if a load balancer controller
     # needs extra annotations.
     #

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -55,6 +55,7 @@ Kubernetes: `>=1.19.x-0`
 | confluence.securityContext.fsGroup | int | `2002` | The GID used by the Confluence docker image If not supplied, will default to 2002 This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Confluence container. However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260 |
 | confluence.service.annotations | object | `{}` | Additional annotations to apply to the Service |
 | confluence.service.contextPath | string | `nil` | The Tomcat context path that Confluence will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically. |
+| confluence.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer. |
 | confluence.service.port | int | `80` | The port on which the Confluence K8s Service will listen |
 | confluence.service.type | string | `"ClusterIP"` | The type of K8s service to use for Confluence |
 | confluence.setPermissions | bool | `true` | Boolean to define whether to set local home directory permissions on startup of Confluence container. Set to 'false' to disable this behaviour. |
@@ -115,6 +116,7 @@ Kubernetes: `>=1.19.x-0`
 | synchrony.resources.jvm.maxHeap | string | `"2g"` | The minimum amount of heap memory that will be used by the Synchrony JVM |
 | synchrony.resources.jvm.minHeap | string | `"1g"` | The maximum amount of heap memory that will be used by the Synchrony JVM |
 | synchrony.resources.jvm.stackSize | string | `"2048k"` | The memory allocated for the Synchrony stack |
+| synchrony.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer. |
 | synchrony.service.port | int | `80` | The port on which the Synchrony K8s Service will listen |
 | synchrony.service.type | string | `"ClusterIP"` | The type of K8s service to use for Synchrony |
 | synchrony.setPermissions | bool | `true` | Boolean to define whether to set synchrony home directory permissions on startup of Synchrony container. Set to 'false' to disable this behaviour. |

--- a/src/main/charts/confluence/templates/service-synchrony.yaml
+++ b/src/main/charts/confluence/templates/service-synchrony.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "synchrony.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.synchrony.service.type }}
+  {{- if and (eq .Values.synchrony.service.type "LoadBalancer") (not (empty .Values.synchrony.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.synchrony.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.synchrony.service.port }}
       targetPort: http

--- a/src/main/charts/confluence/templates/service.yaml
+++ b/src/main/charts/confluence/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.confluence.service.type }}
+  {{- if and (eq .Values.confluence.service.type "LoadBalancer") (not (empty .Values.confluence.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.confluence.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.confluence.service.port }}
       targetPort: http

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -429,7 +429,11 @@ confluence:
     # -- The type of K8s service to use for Confluence
     #
     type: ClusterIP
-    
+
+    # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
+    #
+    loadBalancerIP:
+
     # -- The Tomcat context path that Confluence will use. The ATL_TOMCAT_CONTEXTPATH
     # will be set automatically.
     #
@@ -701,6 +705,9 @@ synchrony:
     #
     type: ClusterIP
 
+    # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
+    #
+    loadBalancerIP:
 
   # -- Boolean to define whether to set synchrony home directory permissions on startup
   # of Synchrony container. Set to 'false' to disable this behaviour.

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -50,6 +50,7 @@ Kubernetes: `>=1.19.x-0`
 | crowd.resources.jvm.minHeap | string | `"384m"` | The minimum amount of heap memory that will be used by the Crowd JVM |
 | crowd.securityContext.fsGroup | int | `2004` | The GID used by the Crowd docker image If not supplied, will default to 2004 This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Crowd container. However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260 |
 | crowd.service.annotations | object | `{}` | Additional annotations to apply to the Service |
+| crowd.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer. |
 | crowd.service.port | int | `80` | The port on which the Crowd K8s Service will listen |
 | crowd.service.type | string | `"ClusterIP"` | The type of K8s service to use for Crowd |
 | crowd.setPermissions | bool | `true` | Boolean to define whether to set local home directory permissions on startup of Crowd container. Set to 'false' to disable this behaviour. |

--- a/src/main/charts/crowd/templates/service.yaml
+++ b/src/main/charts/crowd/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.crowd.service.type }}
+  {{- if and (eq .Values.crowd.service.type "LoadBalancer") (not (empty .Values.crowd.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.crowd.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.crowd.service.port }}
       targetPort: http

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -118,6 +118,10 @@ crowd:
     #
     type: ClusterIP
 
+    # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
+    #
+    loadBalancerIP:
+
     # -- Additional annotations to apply to the Service
     #
     annotations: {}

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -80,6 +80,7 @@ Kubernetes: `>=1.19.x-0`
 | jira.securityContext.fsGroup | int | `2001` | The GID used by the Jira docker image If not supplied, will default to 2001 This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container. However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260 |
 | jira.service.annotations | object | `{}` | Additional annotations to apply to the Service |
 | jira.service.contextPath | string | `nil` | The Tomcat context path that Jira will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically. |
+| jira.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer. |
 | jira.service.port | int | `80` | The port on which the Jira K8s Service will listen |
 | jira.service.type | string | `"ClusterIP"` | The type of K8s service to use for Jira |
 | jira.setPermissions | bool | `true` | Boolean to define whether to set local home directory permissions on startup of Jira container. Set to 'false' to disable this behaviour. |

--- a/src/main/charts/jira/templates/service.yaml
+++ b/src/main/charts/jira/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.jira.service.type }}
+  {{- if and (eq .Values.jira.service.type "LoadBalancer") (not (empty .Values.jira.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.jira.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.jira.service.port }}
       targetPort: http

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -361,7 +361,11 @@ jira:
     # -- The type of K8s service to use for Jira
     #
     type: ClusterIP
-    
+
+    # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
+    #
+    loadBalancerIP:
+
     # -- The Tomcat context path that Jira will use. The ATL_TOMCAT_CONTEXTPATH
     # will be set automatically.
     #

--- a/src/test/java/test/ServiceTest.java
+++ b/src/test/java/test/ServiceTest.java
@@ -58,4 +58,19 @@ class ServiceTest {
                 "testAnnotation2", "test2"
         ));
     }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    void service_loadbalancer_type(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".service.type", "LoadBalancer",
+                product + ".service.loadBalancerIP", "1.1.1.1"
+        ));
+
+        final var service = resources.get(Kind.Service, Service.class, product.getHelmReleaseName());
+
+        assertThat(service.getType())
+                .hasTextEqualTo("LoadBalancer");
+        assertThat(service.getLoadBalancerIP()).hasTextEqualTo("1.1.1.1");
+    }
 }

--- a/src/test/java/test/model/Service.java
+++ b/src/test/java/test/model/Service.java
@@ -21,4 +21,8 @@ public class Service extends KubeResource {
     public Option<JsonNode> getPort(String name) {
         return getPorts().find(portNode -> name.equals(portNode.path("name").asText()));
     }
+
+    public JsonNode getLoadBalancerIP() {
+        return getSpec().path("loadBalancerIP");
+    }
 }


### PR DESCRIPTION
**What this PR does:**

New feature which allows to define a specific `loadBalancerIP` for a service type `LoadBalancer`.
This is needed f.e. to request a fix service ip with metallb.


**Reference:**

- https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
- https://metallb.universe.tf/usage/#requesting-specific-ips