### PR TITLE
BAMBK8S-172: Remove 'under active development' references

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -5,7 +5,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://github.com/atlassian/data-center-helm-charts/blob/main/CONTRIBUTING.md) 
 [![Maven unit tests](https://github.com/atlassian/data-center-helm-charts/actions/workflows/maven.yml/badge.svg)](https://github.com/atlassian/data-center-helm-charts/actions/workflows/maven.yml)
 
-This project contains [Helm charts](https://helm.sh/){.external} for installing Atlassian's [Jira Data Center](https://www.atlassian.com/enterprise/data-center/jira){.external}, [Confluence Data Center](https://www.atlassian.com/enterprise/data-center/confluence){.external}, [Bitbucket Data Center](https://www.atlassian.com/enterprise/data-center/bitbucket){.external} and [Bamboo Data Center](https://www.atlassian.com/software/bamboo){.external}(Bamboo Helm charts are currently under active development) on Kubernetes. 
+This project contains [Helm charts](https://helm.sh/){.external} for installing Atlassian's [Jira Data Center](https://www.atlassian.com/enterprise/data-center/jira){.external}, [Confluence Data Center](https://www.atlassian.com/enterprise/data-center/confluence){.external}, [Bitbucket Data Center](https://www.atlassian.com/enterprise/data-center/bitbucket){.external} and [Bamboo Data Center](https://www.atlassian.com/software/bamboo){.external} on Kubernetes. 
 
 Use the charts to install and operate Data Center products within a Kubernetes cluster of your choice. It can be a managed environment, such as [Amazon EKS](https://aws.amazon.com/eks/){.external}, [Azure Kubernetes Service](https://azure.microsoft.com/en-au/services/kubernetes-service/){.external}, [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine){.external}, or a custom on-premise system.
 
@@ -19,7 +19,7 @@ Use the charts to install and operate Data Center products within a Kubernetes c
     **Certain product limitations listed below:**
 
     * **Jira** currently has [limitations with scaling](troubleshooting/LIMITATIONS.md#jira-and-horizontal-scaling).
-    * **Bamboo** is currently under active development. [Please see current deployment limitations](troubleshooting/LIMITATIONS/#deployment)
+    * **Bamboo** has a number of limitations, [particularly with deployment and clustering](troubleshooting/LIMITATIONS/#deployment).
     * **Crowd** is not officially supported.
     
     Read more about these [product and platform limitations](troubleshooting/LIMITATIONS.md).
@@ -50,7 +50,7 @@ The minimum versions that we support for each product are:
 
 | Jira DC                                                                                                            | Confluence DC                                                                                         | Bitbucket DC                                                                                                                           | Bamboo DC                                                                                        |
 |--------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| [8.19](https://confluence.atlassian.com/jirasoftware/jira-software-8-19-x-release-notes-1082526044.html){.external} | [7.13](https://confluence.atlassian.com/doc/confluence-7-13-release-notes-1044114085.html){.external}  | [7.12](https://confluence.atlassian.com/bitbucketserver/bitbucket-data-center-and-server-7-12-release-notes-1044112744.html){.external} | [8.1](https://confluence.atlassian.com/bamboo/bamboo-8-1-release-notes-1077903836.html){.external} (Under active development)|
+| [8.19](https://confluence.atlassian.com/jirasoftware/jira-software-8-19-x-release-notes-1082526044.html){.external} | [7.13](https://confluence.atlassian.com/doc/confluence-7-13-release-notes-1044114085.html){.external}  | [7.12](https://confluence.atlassian.com/bitbucketserver/bitbucket-data-center-and-server-7-12-release-notes-1044112744.html){.external} | [8.1](https://confluence.atlassian.com/bamboo/bamboo-8-1-release-notes-1103070461.html){.external}|
       
 
 ## Feedback

--- a/docs/docs/troubleshooting/LIMITATIONS.md
+++ b/docs/docs/troubleshooting/LIMITATIONS.md
@@ -20,12 +20,6 @@ At present there are issues relating to index replication with Jira when immedia
 Although these issues are Jira specific, they are exasperated on account of the significantly reduced startup times for Jira when running in a Kubernetes cluster. As such these issues can have an impact on horizontal scaling if [you don't take the correct approach](../../userguide/resource_management/RESOURCE_SCALING/#scaling-jira-safely).
 
 ## Bamboo
-
-!!!warning "Under active development"
-    
-    Bamboo is currently under active development and should not be used for production based deployments.
-
-
 There are a number of known limitations relating to Bamboo Data Center, these are documented below.
 
 ### Deployment


### PR DESCRIPTION
⚠️ Only to be merged after version `1.0.0` of the Bamboo Helm charts has been cut! ⚠️ 