### PR TITLE
Changed deprecated annotation for ingress class name

### DIFF
--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "jira.labels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -19,6 +18,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
 {{ if and (.Values.ingress.tlsSecretName) (.Values.ingress.host) }}
   tls:
     - hosts:


### PR DESCRIPTION
The api for (for default) ingress class is changed since Kubernetes 1.18

See:
https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

This is an issue when using a Kubernetes setup with multiple ingress controllers. While most ingress controllers were supporting the deprecated style using the annotation 'kubernetes.io/ingress.class' for some time; recent implementation for at least Nginx stopped supporting it.

I therefore propose a change to the new notation in favour of the old annotation. The old annotation is not needed anymore for the Helm chart already only supports Kubernetes 1.19+