### PR TITLE
[bitbucket]: fix templating of PLUGIN_SSH_BASEURL with custom port

### DIFF
--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -132,7 +132,7 @@ spec:
             {{- end }}
             {{- if and .Values.bitbucket.sshService.enabled (not (empty .Values.bitbucket.sshService.host)) }}
             - name: PLUGIN_SSH_BASEURL
-              value: ssh://{{ .Values.bitbucket.sshService.host }}{{ if ne (default .Values.bitbucket.sshService.port "22") "22" }}:{{ .Values.bitbucket.sshService.port }}{{ end }}/
+              value: ssh://{{ .Values.bitbucket.sshService.host }}{{ if ne (int .Values.bitbucket.sshService.port) 22 }}:{{ .Values.bitbucket.sshService.port }}{{ end }}/
             {{- end }}
             {{ end }}
             - name: SERVER_CONTEXT_PATH

--- a/src/test/java/test/BitbucketSshServiceTest.java
+++ b/src/test/java/test/BitbucketSshServiceTest.java
@@ -46,9 +46,11 @@ class BitbucketSshServiceTest {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "bitbucket.sshService.enabled", "true",
                 "bitbucket.sshService.port", "7999",
+                "bitbucket.sshService.host", "hostname",
                 "bitbucket.sshService.type", "ClusterIP",
                 "bitbucket.sshService.annotations.test" ,"test",
-                "bitbucket.sshService.annotations.test\\.property", "test"));
+                "bitbucket.sshService.annotations.test\\.property", "test",
+                "ingress.host", "hostname"));
 
         var service = resources.get(Kind.Service, Service.class, product.getHelmReleaseName() + "-ssh");
 
@@ -57,5 +59,8 @@ class BitbucketSshServiceTest {
         assertThat(service.getMetadata().path("annotations")).isObject(Map.of(
                 "test", "test",
                 "test.property", "test"));
+
+        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv().
+                assertHasValue("PLUGIN_SSH_BASEURL", "ssh://hostname:7999/");
     }
 }


### PR DESCRIPTION
**What this PR does:**
Fix templating the environment variable `PLUGIN_SSH_BASEURL` with a custom port other than `22`.

**Current behaviour**
If you use following values, the value of the environment variable `PLUGIN_SSH_BASEURL` is still `ssh://testhost-ssh/` without the custom port number.

_values.yml_
```yaml
ingress:
  host: test
bitbucket:
  sshService:
    enabled: true
    port: 7999
    host: testhost-ssh
```

**Exepted behaviour**
With the updated function, the result is the expected string `ssh://testhost-ssh:7999/`.
I removed the "default" templating section, because a default is already defined in the values file (https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bitbucket/values.yaml#L462)