### PR TITLE
[bitbucket]: use volumeName only if explicitly defined

### DIFF
--- a/src/main/charts/bitbucket/templates/shared-home-pvc.yaml
+++ b/src/main/charts/bitbucket/templates/shared-home-pvc.yaml
@@ -13,7 +13,7 @@ spec:
   {{- end }}
   {{- if .Values.volumes.sharedHome.persistentVolume.create }}
   volumeName: {{ include "bitbucket.volume.sharedHome.name" . }}
-  {{- else}}
+  {{- else if .Values.volumes.sharedHome.persistentVolumeClaim.volumeName }}
   volumeName: {{ .Values.volumes.sharedHome.persistentVolumeClaim.volumeName | quote }}
   {{- end }}
   {{- with .Values.volumes.sharedHome.persistentVolumeClaim.resources }}


### PR DESCRIPTION
**What this PR does**
Only set `volumeName` for the shared-home `persistentVolumeClaim` if explicitly defined in the values file.

**Current behaviour**
If you want to define only the shared-home `persistentVolumeClaim` without the `persistentVolume`, the field `volumeName` is always set as an empty string.

_values.yml_
```yaml
volumes:
  sharedHome:
    persistentVolume:
      create: false
    persistentVolumeClaim:
      create: true
```

This behaviour can lead to problems, because the volumeName is then set by the CSI (like Longhorn, etc.). The next time you rollout the helm-chart, helm stops the upgrade with the following error:

```bash
Error: UPGRADE FAILED: cannot patch "bitbucket-shared-home" with kind PersistentVolumeClaim: PersistentVolumeClaim "bitbucket-shared-home" is invalid: spec: Forbidden: spec is immutable after creation except resources.requests for bound claims
  core.PersistentVolumeClaimSpec{
  	AccessModes:      {"ReadWriteMany"},
  	Selector:         nil,
  	Resources:        {Requests: {s"storage": {i: {...}, s: "1Gi", Format: "BinarySI"}}},
- 	VolumeName:       "",
+ 	VolumeName:       "pvc-e58b1bd4-600d-4a13-9349-903ef65bf8a0",
  	StorageClassName: &"standard",
  	VolumeMode:       &"Filesystem",
  	DataSource:       nil,
  }

```

**Exepted behaviour**
Only set the field `volumeName` if it is explicitly defined in the values file. Otherwise the value will not be set.