### PR TITLE
[crowd]: add missing JVM_SUPPORT_RECOMMENDED_ARGS env

### DIFF
--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -104,6 +104,11 @@ spec:
               value: {{ .Values.crowd.setPermissions | quote }}
             - name: ATL_PRODUCT_HOME_SHARED
               value: {{ .Values.volumes.sharedHome.mountPath | quote }}
+            - name: JVM_SUPPORT_RECOMMENDED_ARGS
+              valueFrom:
+                configMapKeyRef:
+                  key: additional_jvm_args
+                  name: {{ include "common.names.fullname" . }}-jvm-config
             - name: JVM_MINIMUM_MEMORY
               valueFrom:
                 configMapKeyRef:

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -140,6 +140,11 @@ spec:
               value: "true"
             - name: ATL_PRODUCT_HOME_SHARED
               value: "/var/atlassian/application-data/crowd/shared"
+            - name: JVM_SUPPORT_RECOMMENDED_ARGS
+              valueFrom:
+                configMapKeyRef:
+                  key: additional_jvm_args
+                  name: unittest-crowd-jvm-config
             - name: JVM_MINIMUM_MEMORY
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
**What this PR does**
add the missing link from the configmap to the ENV `JVM_SUPPORT_RECOMMENDED_ARGS`

**Current behaviour**
All configurations in the values `crowd.additionalJvmArgs` are written in the configmap, but not applied to the environment

**Exepted behaviour**
the ENV `JVM_SUPPORT_RECOMMENDED_ARGS` is set correctly


**PS**
Can you please make new chart releases for any product?
The current versions are from november/december 2021 and I really need to test all the new features (around 9 PRs) with a stable chart.
thanks!