### PR TITLE
Release/1.2.0

### DIFF
--- a/src/main/charts/bamboo-agent/Changelog.md
+++ b/src/main/charts/bamboo-agent/Changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.0.0
+## 1.2.0
 
 **Release date:** 2022-02-10
 

--- a/src/main/charts/bamboo-agent/Changelog.md
+++ b/src/main/charts/bamboo-agent/Changelog.md
@@ -2,6 +2,22 @@
 
 ## 1.0.0
 
+**Release date:** 2022-02-10
+
+![AppVersion: 8.1.2-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.1.1-jdk11&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* DCD-1452: Updated appVersion to the latest product LTS version. (#378)
+* Added end-to-end test for Bamboo Helm chart using Terraform (#375)
+* Improvements on documentation (#370)
+* Updated Atlassian charts to use common definitions (#303)
+* Added service account annotation (#363)
+
+
+## 1.0.0
+
 **Release date:** 2022-01-11
 
 This is the first officially supported version of the Helm chart.

--- a/src/main/charts/bamboo-agent/Changelog.md
+++ b/src/main/charts/bamboo-agent/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0
 
-**Release date:** 2022-02-10
+**Release date:** 2022-02-14
 
 ![AppVersion: 8.1.2-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.1.1-jdk11&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)

--- a/src/main/charts/bamboo-agent/Chart.yaml
+++ b/src/main/charts/bamboo-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bamboo-agent
 description: A chart for installing Bamboo Data Center remote agents on Kubernetes
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: 8.1.2-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:

--- a/src/main/charts/bamboo-agent/Chart.yaml
+++ b/src/main/charts/bamboo-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bamboo-agent
 description: A chart for installing Bamboo Data Center remote agents on Kubernetes
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: 8.1.2-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:
@@ -18,18 +18,33 @@ sources:
   - https://bitbucket.org/atlassian-docker/docker-bamboo-agent-base
 deprecated: false
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
-      description: Support for defining podLabels
+      description: Added service account annotation
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/366
+        url: https://github.com/atlassian/data-center-helm-charts/pull/363
+    - kind: changed
+      description: Updated Atlassian charts to use common definitions
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/303
+    - kind: changed
+      description: Improvements on documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/370
     - kind: added
-      description: Support for defining podAnnotations
+      description: Added end-to-end test for Bamboo Helm chart using Terraform
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/341
+        url: https://github.com/atlassian/data-center-helm-charts/pull/375
+    - kind: changed
+      description: Bamboo Agent DC updated to 8.1.2 version (LTS)
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/378
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/bamboo-agent/README.md
+++ b/src/main/charts/bamboo-agent/README.md
@@ -1,6 +1,6 @@
 # bamboo-agent
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center remote agents on Kubernetes
 

--- a/src/main/charts/bamboo-agent/README.md
+++ b/src/main/charts/bamboo-agent/README.md
@@ -1,6 +1,6 @@
 # bamboo-agent
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center remote agents on Kubernetes
 

--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.1.0
+## 1.2.0
 
 **Release date:** 2022-02-10
 

--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0
 
-**Release date:** 2022-02-10
+**Release date:** 2022-02-14
 
 ![AppVersion: 8.1.2-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.1.1-jdk11&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)

--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## 1.1.0
+
+**Release date:** 2022-02-10
+
+![AppVersion: 8.1.2-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.1.1-jdk11&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* DCD-1452: Updated appVersion to the latest product LTS version. (#378)
+* Added end-to-end test for Bamboo Helm chart using Terraform (#375)
+* Improvements on documentation (#370)
+* Updated Atlassian charts to use common definitions (#303)
+* Added service account annotation (#363)
+* Added new feature additionalVolumeClaimTemplates and provided example in documentation (#334, #368)
+
+
 ## 1.0.0
 
 **Release date:** 2022-01-11

--- a/src/main/charts/bamboo/Chart.yaml
+++ b/src/main/charts/bamboo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bamboo
 description: A chart for installing Bamboo Data Center on Kubernetes
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: 8.1.2-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:

--- a/src/main/charts/bamboo/Chart.yaml
+++ b/src/main/charts/bamboo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bamboo
 description: A chart for installing Bamboo Data Center on Kubernetes
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: 8.1.2-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:
@@ -18,23 +18,40 @@ sources:
   - https://bitbucket.org/atlassian-docker/docker-bamboo-server
 deprecated: false
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
-      description: Support for defining podLabels
+      description: Added new feature additionalVolumeClaimTemplates and provided example in documentation
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/366
+        url: https://github.com/atlassian/data-center-helm-charts/pull/334
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/368
     - kind: added
-      description: Support for defining loadBalancerIP
+      description: Added service account annotation
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/365
+        url: https://github.com/atlassian/data-center-helm-charts/pull/363
+    - kind: changed
+      description: Updated Atlassian charts to use common definitions
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/303
+    - kind: changed
+      description: Improvements on documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/370
     - kind: added
-      description: Support for defining podAnnotations
+      description: Added end-to-end test for Bamboo Helm chart using Terraform
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/341
+        url: https://github.com/atlassian/data-center-helm-charts/pull/375
+    - kind: changed
+      description: Bamboo DC updated to 8.1.2 version (LTS)
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/378
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -1,6 +1,6 @@
 # bamboo
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center on Kubernetes
 

--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -1,6 +1,6 @@
 # bamboo
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center on Kubernetes
 

--- a/src/main/charts/bitbucket/Changelog.md
+++ b/src/main/charts/bitbucket/Changelog.md
@@ -1,5 +1,29 @@
 # Change Log
 
+## 1.2.0
+
+**Release date:** 2022-02-10
+
+![AppVersion: 7.17.5-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=7.17.1-jdk11&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* Use volumeName only if explicitly defined (#372)
+* Fixed templating of PLUGIN_SSH_BASEURL with custom port (#371)
+* DCD-1452: Updated appVersion to the latest product LTS version. (#378)
+* Improvements on documentation (#370, #357)
+* Updated Atlassian charts to use common definitions (#303)
+* Added service account annotation (#363)
+* Added new feature additionalVolumeClaimTemplates and provided example in documentation (#334, #368)
+* Added new feature podLabels (#364)
+* Added new feature to define loadBalancerIP (#365)
+* Define podAnnotations as template to allow overrides (#341)
+* DCKUBE-738: Added topologySpreadConstraints to products (#351)
+* Set ActiveProcessorCount automatically based on Values.<product>.resources.container.requests.cpu (#352)
+* Added new feature additionalPorts (for jmx-monitoring) (#353)
+
+
 ## 1.1.0 
 
 **Release date:** 2021-11-03

--- a/src/main/charts/bitbucket/Changelog.md
+++ b/src/main/charts/bitbucket/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0
 
-**Release date:** 2022-02-10
+**Release date:** 2022-02-14
 
 ![AppVersion: 7.17.5-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=7.17.1-jdk11&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -18,7 +18,7 @@ sources:
   - https://bitbucket.org/atlassian-docker/docker-atlassian-bitbucket-server/
 deprecated: false
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
       description: Add new feature additionalPorts (for jmx-monitoring) 

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bitbucket
 description: A chart for installing Bitbucket Data Center on Kubernetes
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: 7.17.5-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:
@@ -21,40 +21,74 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: added
-      description: Add support for custom schedulerName
+      description: Add new feature additionalPorts (for jmx-monitoring) 
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/301
-    - kind: added
-      description: Enable configuring ingress.class name
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/313
-    - kind: added
-      description: Add support for context path
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/314
+        url: https://github.com/atlassian/data-center-helm-charts/pull/353
     - kind: changed
-      description: Make security context more flexible
+      description: Set ActiveProcessorCount automatically based on Values.<product>.resources.container.requests.cpu
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/321
+        url: https://github.com/atlassian/data-center-helm-charts/pull/352
     - kind: added
-      description: Roll Statefulset Pods if ConfigMap changes
+      description: Added topologySpreadConstraints to products
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/315
-    - kind: added
-      description: Add support for Bitbucket Mirrors
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/265
+        url: https://github.com/atlassian/data-center-helm-charts/pull/351
     - kind: changed
-      description: Bitbucket DC updated to 7.17.1 version (LTS)
+      description: Define podAnnotations as template to allow overrides
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/345
+        url: https://github.com/atlassian/data-center-helm-charts/pull/341
+    - kind: added
+      description: Added new feature to define loadBalancerIP
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/365
+    - kind: added
+      description: Added new feature podLabels
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/364
+    - kind: added
+      description: Added new feature additionalVolumeClaimTemplates and provided example in documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/334
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/368
+    - kind: added
+      description: Added service account annotation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/363
+    - kind: changed
+      description: Updated Atlassian charts to use common definitions
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/303
+    - kind: changed
+      description: Improvements on documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/370
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/357
+    - kind: changed
+      description: Bitbucket DC updated to 7.17.5 version (LTS)
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/378
+    - kind: fixed
+      description: Fix templating of PLUGIN_SSH_BASEURL with custom port
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/371
+    - kind: fixed
+      description: Use volumeName only if explicitly defined
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/372
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -1,6 +1,6 @@
 # bitbucket
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.5-jdk11](https://img.shields.io/badge/AppVersion-7.17.5--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.5-jdk11](https://img.shields.io/badge/AppVersion-7.17.5--jdk11-informational?style=flat-square)
 
 A chart for installing Bitbucket Data Center on Kubernetes
 

--- a/src/main/charts/bitbucket/templates/NOTES.txt
+++ b/src/main/charts/bitbucket/templates/NOTES.txt
@@ -14,7 +14,7 @@ To see the custom values you used for this release:
   $ helm get values {{ .Release.Name }} -n {{ .Release.Namespace }}
 
 {{ if .Values.ingress.create -}}
-{{ title .Chart.Name }} service URL: {{ ternary "https" "http" .Values.ingress.https -}}://{{ .Values.ingress.host }}{{ default ( "" ) .Values.ingress.path }}
+{{ title .Chart.Name }} service URL: {{ ternary "https" "http" .Values.ingress.https -}}://{{ .Values.ingress.host }}{{ include "bitbucket.ingressPath" . }}
 {{- else }}
 Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 {{- if contains "NodePort" .Values.bitbucket.service.type }}

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
           readinessProbe:
             httpGet:
               port: {{ .Values.bitbucket.ports.http }}
-              path: "/status"
+              path: {{ .Values.bitbucket.service.contextPath }}/status
             periodSeconds: 5
             failureThreshold: 60
             initialDelaySeconds: 10

--- a/src/main/charts/confluence/Changelog.md
+++ b/src/main/charts/confluence/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0
 
-**Release date:** 2022-02-10
+**Release date:** 2022-02-14
 
 ![AppVersion: 7.13.4-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=7.13.2-jdk11&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)

--- a/src/main/charts/confluence/Changelog.md
+++ b/src/main/charts/confluence/Changelog.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## 1.2.0
+
+**Release date:** 2022-02-10
+
+![AppVersion: 7.13.4-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=7.13.2-jdk11&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* DCD-1452: Updated appVersion to the latest product LTS version. (#378)
+* Improvements on documentation (#370, #357)
+* Updated Atlassian charts to use common definitions (#303)
+* Added service account annotation (#363)
+* Added new feature additionalVolumeClaimTemplates and provided example in documentation (#334, #368)
+* Added new feature podLabels (#364)
+* Added new feature to define loadBalancerIP (#365)
+* Define podAnnotations as template to allow overrides (#341)
+* DCKUBE-738: Added topologySpreadConstraints to products (#351)
+* Set ActiveProcessorCount automatically based on Values.<product>.resources.container.requests.cpu (#352)
+* Added new feature additionalPorts (for jmx-monitoring) (#353)
+
+
 ## 1.1.0 
 
 **Release date:** 2021-11-03

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: confluence
 description: A chart for installing Confluence Data Center on Kubernetes
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: 7.13.4-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:
@@ -20,36 +20,65 @@ deprecated: false
 annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
-    - kind: changed
-      description: Decrease Confluence failover time
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/299
     - kind: added
-      description: Add support for custom schedulerName
+      description: Add new feature additionalPorts (for jmx-monitoring) 
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/301
-    - kind: added
-      description: Enable configuring ingress.class name
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/313
+        url: https://github.com/atlassian/data-center-helm-charts/pull/353
     - kind: changed
-      description: Make security context more flexible
+      description: Set ActiveProcessorCount automatically based on Values.<product>.resources.container.requests.cpu
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/321
+        url: https://github.com/atlassian/data-center-helm-charts/pull/352
     - kind: added
-      description: Roll Statefulset Pods if ConfigMap changes
+      description: Added topologySpreadConstraints to products
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/315
+        url: https://github.com/atlassian/data-center-helm-charts/pull/351
     - kind: changed
-      description: Confluence DC updated to 7.13.2 version (LTS)
+      description: Define podAnnotations as template to allow overrides
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/345
+        url: https://github.com/atlassian/data-center-helm-charts/pull/341
+    - kind: added
+      description: Added new feature to define loadBalancerIP
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/365
+    - kind: added
+      description: Added new feature podLabels
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/364
+    - kind: added
+      description: Added new feature additionalVolumeClaimTemplates and provided example in documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/334
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/368
+    - kind: added
+      description: Added service account annotation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/363
+    - kind: changed
+      description: Updated Atlassian charts to use common definitions
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/303
+    - kind: changed
+      description: Improvements on documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/370
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/357
+    - kind: changed
+      description: Confluence DC updated to 7.13.4 version (LTS)
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/378
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -18,7 +18,7 @@ sources:
   - https://bitbucket.org/atlassian-docker/docker-atlassian-confluence-server/
 deprecated: false
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
       description: Add new feature additionalPorts (for jmx-monitoring) 

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -1,6 +1,6 @@
 # confluence
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.13.4-jdk11](https://img.shields.io/badge/AppVersion-7.13.4--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.13.4-jdk11](https://img.shields.io/badge/AppVersion-7.13.4--jdk11-informational?style=flat-square)
 
 A chart for installing Confluence Data Center on Kubernetes
 

--- a/src/main/charts/crowd/Changelog.md
+++ b/src/main/charts/crowd/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0
 
-**Release date:** 2022-02-10
+**Release date:** 2022-02-14
 
 ![AppVersion: 4.4.0-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=4.4.0-jdk11&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)

--- a/src/main/charts/crowd/Changelog.md
+++ b/src/main/charts/crowd/Changelog.md
@@ -1,5 +1,28 @@
 # Change Log
 
+## 1.2.0
+
+**Release date:** 2022-02-10
+
+![AppVersion: 4.4.0-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=4.4.0-jdk11&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+Crowd (1.1.0 -> 1.2.0)
+* Added missing JVM_SUPPORT_RECOMMENDED_ARGS env (#376)
+* Improvements on documentation (#370, #357)
+* Updated Atlassian charts to use common definitions (#303)
+* Added service account annotation (#363)
+* Added new feature additionalVolumeClaimTemplates and provided example in documentation (#334, #368)
+* Added new feature podLabels (#364)
+* Added new feature to define loadBalancerIP (#365)
+* Define podAnnotations as template to allow overrides (#341)
+* DCKUBE-738: Added topologySpreadConstraints to products (#351)
+* Set ActiveProcessorCount automatically based on Values.<product>.resources.container.requests.cpu (#352)
+* Added new feature additionalPorts (for jmx-monitoring) (#353)
+
+
 ## 1.1.0 
 
 **Release date:** 2021-11-03

--- a/src/main/charts/crowd/Chart.yaml
+++ b/src/main/charts/crowd/Chart.yaml
@@ -18,7 +18,7 @@ sources:
   - https://bitbucket.org/atlassian-docker/docker-atlassian-crowd/
 deprecated: false
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
       description: Add new feature additionalPorts (for jmx-monitoring) 

--- a/src/main/charts/crowd/Chart.yaml
+++ b/src/main/charts/crowd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: crowd
 description: A chart for installing Crowd Data Center on Kubernetes
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: 4.4.0-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:
@@ -21,30 +21,64 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: added
-      description: Add support for custom schedulerName
+      description: Add new feature additionalPorts (for jmx-monitoring) 
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/301
-    - kind: added
-      description: Enable configuring ingress.class name
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/313
+        url: https://github.com/atlassian/data-center-helm-charts/pull/353
     - kind: changed
-      description: Make security context more flexible
+      description: Set ActiveProcessorCount automatically based on Values.<product>.resources.container.requests.cpu
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/321
+        url: https://github.com/atlassian/data-center-helm-charts/pull/352
     - kind: added
-      description: Roll Statefulset Pods if ConfigMap changes
+      description: Added topologySpreadConstraints to products
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/315
+        url: https://github.com/atlassian/data-center-helm-charts/pull/351
     - kind: changed
-      description: Crowd DC updated to 4.4.0 version
+      description: Define podAnnotations as template to allow overrides
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/345
+        url: https://github.com/atlassian/data-center-helm-charts/pull/341
+    - kind: added
+      description: Added new feature to define loadBalancerIP
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/365
+    - kind: added
+      description: Added new feature podLabels
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/364
+    - kind: added
+      description: Added new feature additionalVolumeClaimTemplates and provided example in documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/334
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/368
+    - kind: added
+      description: Added service account annotation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/363
+    - kind: changed
+      description: Updated Atlassian charts to use common definitions
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/303
+    - kind: changed
+      description: Improvements on documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/370
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/357
+    - kind: added
+      description: Added missing JVM_SUPPORT_RECOMMENDED_ARGS env
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/376
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -1,6 +1,6 @@
 # crowd
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.0-jdk11](https://img.shields.io/badge/AppVersion-4.4.0--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.0-jdk11](https://img.shields.io/badge/AppVersion-4.4.0--jdk11-informational?style=flat-square)
 
 A chart for installing Crowd Data Center on Kubernetes
 

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0
 
-**Release date:** 2022-02-10
+**Release date:** 2022-02-14
 
 ![AppVersion: 8.20.5-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.20.1-jdk11&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## 1.2.0
+
+**Release date:** 2022-02-10
+
+![AppVersion: 8.20.5-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.20.1-jdk11&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* DCD-1452: Updated appVersion to the latest product LTS version. (#378)
+* Improvements on documentation (#370, #357)
+* Updated Atlassian charts to use common definitions (#303)
+* Added service account annotation (#363)
+* Added new feature additionalVolumeClaimTemplates and provided example in documentation (#334, #368)
+* Added new feature podLabels (#364)
+* Added new feature to define loadBalancerIP (#365)
+* Define podAnnotations as template to allow overrides (#341)
+* DCKUBE-738: Added topologySpreadConstraints to products (#351)
+* Set ActiveProcessorCount automatically based on Values.<product>.resources.container.requests.cpu (#352)
+* Added new feature additionalPorts (for jmx-monitoring) (#353)
+
+
 ## 1.1.0 
 
 **Release date:** 2021-11-03

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -19,7 +19,7 @@ sources:
   - https://bitbucket.org/atlassian-docker/docker-atlassian-jira/
 deprecated: false
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
       description: Add new feature additionalPorts (for jmx-monitoring) 

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jira
 description: A chart for installing Jira Data Center on Kubernetes
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: 8.20.5-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:
@@ -22,40 +22,64 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: added
-      description: Add support for custom schedulerName
+      description: Add new feature additionalPorts (for jmx-monitoring) 
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/301
-    - kind: added
-      description: Bind EHCACHE ports as environmental variables
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/308
-    - kind: added
-      description: Enable configuring ingress.class name
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/313
-    - kind: removed
-      description: Cleanup redundant (not-used) jira.terminationGracePeriodSeconds
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/306
+        url: https://github.com/atlassian/data-center-helm-charts/pull/353
     - kind: changed
-      description: Make security context more flexible
+      description: Set ActiveProcessorCount automatically based on Values.<product>.resources.container.requests.cpu
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/321
+        url: https://github.com/atlassian/data-center-helm-charts/pull/352
     - kind: added
-      description: Roll Statefulset Pods if ConfigMap changes
+      description: Added topologySpreadConstraints to products
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/315
+        url: https://github.com/atlassian/data-center-helm-charts/pull/351
     - kind: changed
-      description: Jira DC updated to 8.20.1 version (LTS)
+      description: Define podAnnotations as template to allow overrides
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/345
+        url: https://github.com/atlassian/data-center-helm-charts/pull/341
+    - kind: added
+      description: Added new feature to define loadBalancerIP
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/365
+    - kind: added
+      description: Added new feature podLabels
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/364
+    - kind: added
+      description: Added new feature additionalVolumeClaimTemplates and provided example in documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/334
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/368
+    - kind: added
+      description: Added service account annotation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/363
+    - kind: changed
+      description: Updated Atlassian charts to use common definitions
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/303
+    - kind: changed
+      description: Improvements on documentation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/370
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/357
+    - kind: changed
+      description: Jira DC updated to 8.20.5 version (LTS)
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/378
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -1,6 +1,6 @@
 # jira
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.20.5-jdk11](https://img.shields.io/badge/AppVersion-8.20.5--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.20.5-jdk11](https://img.shields.io/badge/AppVersion-8.20.5--jdk11-informational?style=flat-square)
 
 A chart for installing Jira Data Center on Kubernetes
 

--- a/src/test/java/test/ContextPathTest.java
+++ b/src/test/java/test/ContextPathTest.java
@@ -55,4 +55,20 @@ class ContextPathTest {
                     product.getHelmReleaseName()).getContainer().get("readinessProbe").get("httpGet").get("path").asText(),
                     "/" + product.name() + "/rest/api/latest/status");
     }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bitbucket"})
+    void test_context_path_bitbucket(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".service.contextPath", "/" + product.name()));
+
+        resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getEnv()
+                .assertHasValue("SERVER_CONTEXT_PATH", "/" + product.name());
+
+        assertEquals(resources.getStatefulSet(
+                        product.getHelmReleaseName()).getContainer().get("readinessProbe").get("httpGet").get("path").asText(),
+                "/" + product.name() + "/status");
+    }
 }

--- a/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: unittest-bamboo-agent
   labels:
-    helm.sh/chart: bamboo-agent-1.1.0
+    helm.sh/chart: bamboo-agent-1.2.0
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: unittest-bamboo-agent-jvm-config
   labels:
-    helm.sh/chart: bamboo-agent-1.1.0
+    helm.sh/chart: bamboo-agent-1.2.0
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -32,7 +32,7 @@ kind: Deployment
 metadata:
   name: unittest-bamboo-agent
   labels:
-    helm.sh/chart: bamboo-agent-1.1.0
+    helm.sh/chart: bamboo-agent-1.2.0
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
     app.kubernetes.io/version: "8.1.2-jdk11"

--- a/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: unittest-bamboo-agent
   labels:
-    helm.sh/chart: bamboo-agent-1.0.0
+    helm.sh/chart: bamboo-agent-1.1.0
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: unittest-bamboo-agent-jvm-config
   labels:
-    helm.sh/chart: bamboo-agent-1.0.0
+    helm.sh/chart: bamboo-agent-1.1.0
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -32,7 +32,7 @@ kind: Deployment
 metadata:
   name: unittest-bamboo-agent
   labels:
-    helm.sh/chart: bamboo-agent-1.0.0
+    helm.sh/chart: bamboo-agent-1.1.0
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
     app.kubernetes.io/version: "8.1.2-jdk11"

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: unittest-bamboo
   labels:
-    helm.sh/chart: bamboo-1.0.0
+    helm.sh/chart: bamboo-1.1.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: unittest-bamboo-jvm-config
   labels:
-    helm.sh/chart: bamboo-1.0.0
+    helm.sh/chart: bamboo-1.1.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -34,7 +34,7 @@ kind: Service
 metadata:
   name: unittest-bamboo
   labels:
-    helm.sh/chart: bamboo-1.0.0
+    helm.sh/chart: bamboo-1.1.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -57,7 +57,7 @@ kind: StatefulSet
 metadata:
   name: unittest-bamboo
   labels:
-    helm.sh/chart: bamboo-1.0.0
+    helm.sh/chart: bamboo-1.1.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -203,7 +203,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: bamboo-1.0.0
+    helm.sh/chart: bamboo-1.1.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -247,7 +247,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: bamboo-1.0.0
+    helm.sh/chart: bamboo-1.1.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: unittest-bamboo
   labels:
-    helm.sh/chart: bamboo-1.1.0
+    helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: unittest-bamboo-jvm-config
   labels:
-    helm.sh/chart: bamboo-1.1.0
+    helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -34,7 +34,7 @@ kind: Service
 metadata:
   name: unittest-bamboo
   labels:
-    helm.sh/chart: bamboo-1.1.0
+    helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -57,7 +57,7 @@ kind: StatefulSet
 metadata:
   name: unittest-bamboo
   labels:
-    helm.sh/chart: bamboo-1.1.0
+    helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -203,7 +203,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: bamboo-1.1.0
+    helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"
@@ -247,7 +247,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: bamboo-1.1.0
+    helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
     app.kubernetes.io/version: "8.1.2-jdk11"

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -111,7 +111,7 @@ spec:
           readinessProbe:
             httpGet:
               port: 7990
-              path: "/status"
+              path: /status
             periodSeconds: 5
             failureThreshold: 60
             initialDelaySeconds: 10

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: unittest-bitbucket
   labels:
-    helm.sh/chart: bitbucket-1.1.0
+    helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
     app.kubernetes.io/version: "7.17.5-jdk11"
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: unittest-bitbucket-jvm-config
   labels:
-    helm.sh/chart: bitbucket-1.1.0
+    helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
     app.kubernetes.io/version: "7.17.5-jdk11"
@@ -34,7 +34,7 @@ kind: Service
 metadata:
   name: unittest-bitbucket
   labels:
-    helm.sh/chart: bitbucket-1.1.0
+    helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
     app.kubernetes.io/version: "7.17.5-jdk11"
@@ -65,7 +65,7 @@ kind: StatefulSet
 metadata:
   name: unittest-bitbucket
   labels:
-    helm.sh/chart: bitbucket-1.1.0
+    helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
     app.kubernetes.io/version: "7.17.5-jdk11"
@@ -173,7 +173,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: bitbucket-1.1.0
+    helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
     app.kubernetes.io/version: "7.17.5-jdk11"
@@ -205,7 +205,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: bitbucket-1.1.0
+    helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
     app.kubernetes.io/version: "7.17.5-jdk11"

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: unittest-confluence
   labels:
-    helm.sh/chart: confluence-1.1.0
+    helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.13.4-jdk11"
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: unittest-confluence-jvm-config
   labels:
-    helm.sh/chart: confluence-1.1.0
+    helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.13.4-jdk11"
@@ -60,7 +60,7 @@ kind: Service
 metadata:
   name: unittest-confluence-synchrony
   labels:
-    helm.sh/chart: confluence-1.1.0
+    helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence-synchrony
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.13.4-jdk11"
@@ -86,7 +86,7 @@ kind: Service
 metadata:
   name: unittest-confluence
   labels:
-    helm.sh/chart: confluence-1.1.0
+    helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.13.4-jdk11"
@@ -113,7 +113,7 @@ kind: StatefulSet
 metadata:
   name: unittest-confluence-synchrony
   labels:
-    helm.sh/chart: confluence-1.1.0
+    helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence-synchrony
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.13.4-jdk11"
@@ -188,7 +188,7 @@ kind: StatefulSet
 metadata:
   name: unittest-confluence
   labels:
-    helm.sh/chart: confluence-1.1.0
+    helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.13.4-jdk11"
@@ -304,7 +304,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: confluence-1.1.0
+    helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.13.4-jdk11"
@@ -335,7 +335,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: confluence-1.1.0
+    helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.13.4-jdk11"

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: unittest-crowd
   labels:
-    helm.sh/chart: crowd-1.1.0
+    helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
     app.kubernetes.io/version: "4.4.0-jdk11"
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: unittest-crowd-jvm-config
   labels:
-    helm.sh/chart: crowd-1.1.0
+    helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
     app.kubernetes.io/version: "4.4.0-jdk11"
@@ -37,7 +37,7 @@ kind: Service
 metadata:
   name: unittest-crowd
   labels:
-    helm.sh/chart: crowd-1.1.0
+    helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
     app.kubernetes.io/version: "4.4.0-jdk11"
@@ -64,7 +64,7 @@ kind: StatefulSet
 metadata:
   name: unittest-crowd
   labels:
-    helm.sh/chart: crowd-1.1.0
+    helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
     app.kubernetes.io/version: "4.4.0-jdk11"
@@ -174,7 +174,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: crowd-1.1.0
+    helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
     app.kubernetes.io/version: "4.4.0-jdk11"
@@ -205,7 +205,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: crowd-1.1.0
+    helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
     app.kubernetes.io/version: "4.4.0-jdk11"
@@ -242,7 +242,7 @@ kind: Job
 metadata:
   name: unittest-crowd-nfs-fixer
   labels:
-    helm.sh/chart: crowd-1.1.0
+    helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
     app.kubernetes.io/version: "4.4.0-jdk11"
@@ -255,7 +255,7 @@ spec:
     metadata:
       name: unittest-crowd-nfs-fixer
       labels:
-        helm.sh/chart: crowd-1.1.0
+        helm.sh/chart: crowd-1.2.0
         app.kubernetes.io/name: crowd
         app.kubernetes.io/instance: unittest-crowd
         app.kubernetes.io/version: "4.4.0-jdk11"

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: unittest-jira
   labels:
-    helm.sh/chart: jira-1.1.0
+    helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
     app.kubernetes.io/version: "8.20.5-jdk11"
@@ -17,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: unittest-jira-jvm-config
   labels:
-    helm.sh/chart: jira-1.1.0
+    helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
     app.kubernetes.io/version: "8.20.5-jdk11"
@@ -36,7 +36,7 @@ kind: Service
 metadata:
   name: unittest-jira
   labels:
-    helm.sh/chart: jira-1.1.0
+    helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
     app.kubernetes.io/version: "8.20.5-jdk11"
@@ -59,7 +59,7 @@ kind: StatefulSet
 metadata:
   name: unittest-jira
   labels:
-    helm.sh/chart: jira-1.1.0
+    helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
     app.kubernetes.io/version: "8.20.5-jdk11"
@@ -173,7 +173,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: jira-1.1.0
+    helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
     app.kubernetes.io/version: "8.20.5-jdk11"
@@ -205,7 +205,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: jira-1.1.0
+    helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
     app.kubernetes.io/version: "8.20.5-jdk11"


### PR DESCRIPTION
This PR bumps chart version to 1.2.0 for all products.
For Bamboo and Bamboo agent, 1.1.0 is skipped to keep consistent with the other products. 