### PR TITLE
DCD-1454: [Bitbucket] readiness probe failed on contextpath

### DIFF
--- a/src/main/charts/bitbucket/templates/NOTES.txt
+++ b/src/main/charts/bitbucket/templates/NOTES.txt
@@ -14,7 +14,7 @@ To see the custom values you used for this release:
   $ helm get values {{ .Release.Name }} -n {{ .Release.Namespace }}
 
 {{ if .Values.ingress.create -}}
-{{ title .Chart.Name }} service URL: {{ ternary "https" "http" .Values.ingress.https -}}://{{ .Values.ingress.host }}{{ default ( "" ) .Values.ingress.path }}
+{{ title .Chart.Name }} service URL: {{ ternary "https" "http" .Values.ingress.https -}}://{{ .Values.ingress.host }}{{ include "bitbucket.ingressPath" . }}
 {{- else }}
 Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 {{- if contains "NodePort" .Values.bitbucket.service.type }}

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
           readinessProbe:
             httpGet:
               port: {{ .Values.bitbucket.ports.http }}
-              path: "/status"
+              path: {{ .Values.bitbucket.service.contextPath }}/status
             periodSeconds: 5
             failureThreshold: 60
             initialDelaySeconds: 10

--- a/src/test/java/test/ContextPathTest.java
+++ b/src/test/java/test/ContextPathTest.java
@@ -55,4 +55,20 @@ class ContextPathTest {
                     product.getHelmReleaseName()).getContainer().get("readinessProbe").get("httpGet").get("path").asText(),
                     "/" + product.name() + "/rest/api/latest/status");
     }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bitbucket"})
+    void test_context_path_bitbucket(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".service.contextPath", "/" + product.name()));
+
+        resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getEnv()
+                .assertHasValue("SERVER_CONTEXT_PATH", "/" + product.name());
+
+        assertEquals(resources.getStatefulSet(
+                        product.getHelmReleaseName()).getContainer().get("readinessProbe").get("httpGet").get("path").asText(),
+                "/" + product.name() + "/status");
+    }
 }

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -111,7 +111,7 @@ spec:
           readinessProbe:
             httpGet:
               port: 7990
-              path: "/status"
+              path: /status
             periodSeconds: 5
             failureThreshold: 60
             initialDelaySeconds: 10


### PR DESCRIPTION
This PR is for fixing https://github.com/atlassian/data-center-helm-charts/issues/377 where readiness probe failed for Bitbucket when contextPath is populated. 