### PR TITLE
[confluence]: fix additional volumes in synchrony

### DIFF
--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -88,8 +88,5 @@ spec:
             name: {{ include "synchrony.fullname" . }}-entrypoint
             defaultMode: 0744
         {{ include "synchrony.volumes" . | nindent 8 }}
-        {{ with .Values.volumes.additional }}
-        {{ toYaml . | nindent 8 }}
-        {{ end }}
   {{ include "synchrony.volumeClaimTemplates" . | nindent 2 }}
 {{ end }}


### PR DESCRIPTION
**What this PR does**
Delete redundant "additional volumes" section for the synchrony statefulset.
Additional volumes are already defined in `synchrony.volumes` (https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/confluence/templates/_helpers.tpl#L337)

**Current behaviour**
If you define an additional volume, this section is applied twice in the synchrony pod.
This behaviour causes the deployment of the synchrony pods to fail.

**Exepted behaviour**
The additional volumes are defined only once.

**Tests**
Deploying confluence with following `values.yaml` file:
```yaml
synchrony:
  enabled: true
volumes:
  additional:
    - configMap:
        defaultMode: 420
        name: wiki-jmx
      name: jmx-config
```
The statefulset will fail with following error:
```
  Warning  FailedCreate  1s (x13 over 21s)  statefulset-controller  create Pod confluence-synchrony-0 in StatefulSet confluence-synchrony failed error: Pod "confluence-synchrony-0" is invalid: spec.volumes[4].name: Duplicate value: "jmx-config"
```

**PS**
- a unit test [is already defined](https://github.com/atlassian/data-center-helm-charts/blob/main/src/test/java/test/VolumesTest.java#L122) but cannot detect double values
- in which time window do you plan to release bug fixes?