### PR TITLE
Make pod securityContext optional.

### DIFF
--- a/src/main/charts/bamboo-agent/templates/deployment-agent.yaml
+++ b/src/main/charts/bamboo-agent/templates/deployment-agent.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       serviceAccountName: {{ include "agent.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.agent.shutdown.terminationGracePeriodSeconds }}
+      {{- if .Values.agent.securityContextEnabled }}
       {{- with .Values.agent.securityContext }}
       securityContext:
         {{ toYaml . | nindent 8 }}
@@ -27,6 +28,7 @@ spec:
         {{- if not $securityContext.fsGroup }}
         fsGroup: 2005
         {{- end }}
+      {{- end }}
       {{- end }}
       initContainers:
         {{- include "agent.additionalInitContainers" . | nindent 8 }}    

--- a/src/main/charts/bamboo-agent/values.yaml
+++ b/src/main/charts/bamboo-agent/values.yaml
@@ -91,10 +91,15 @@ agent:
   # Standard K8s field that holds pod-level security attributes and common container settings.
   # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   # Do not populate when deploying to OpenShift, unless anyuid policy is attached to a service account.
+
+  # -- Whether to apply security context to pod.
+  #
+  securityContextEnabled: true
+
   securityContext:
 
     # -- The GID used by the Bamboo docker image
-    # If not supplied, will default to 2005.
+    # GID will default to 2005 if not supplied and securityContextEnabled is set to true.
     # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Bamboo container.
     # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
     #

--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -24,12 +24,14 @@ spec:
     spec:
       serviceAccountName: {{ include "bamboo.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.bamboo.shutdown.terminationGracePeriodSeconds }}
+      {{- if .Values.bamboo.securityContextEnabled }}
       {{- with .Values.bamboo.securityContext }}
       securityContext:
         {{ toYaml . | nindent 8 }}
         {{- if not .fsGroup }}
         fsGroup: 2005
         {{- end }}
+      {{- end }}
       {{- end }}
       initContainers:
         {{- include "bamboo.additionalInitContainers" . | nindent 8 }}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -487,10 +487,15 @@ bamboo:
   # Standard K8s field that holds pod-level security attributes and common container settings.
   # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   # Do not populate when deploying to OpenShift, unless anyuid policy is attached to a service account.
+
+  # -- Whether to apply security context to pod.
+  #
+  securityContextEnabled: true
+
   securityContext:
 
     # -- The GID used by the Bamboo docker image
-    # If not supplied, will default to 2005.
+    # GID will default to 2005 if not supplied and securityContextEnabled is set to true.
     # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Bamboo container.
     # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
     #

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       serviceAccountName: {{ include "bitbucket.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.bitbucket.shutdown.terminationGracePeriodSeconds }}
+      {{- if .Values.bitbucket.securityContextEnabled }}
       {{- with .Values.bitbucket.securityContext }}
       securityContext:
         {{/* this condition is to be removed in v2.0.0 */}}
@@ -43,6 +44,7 @@ spec:
         fsGroup: 2003
         {{- end }}
         {{- end }}
+      {{- end }}
       {{- end }}
       initContainers:
         {{- include "bitbucket.additionalInitContainers" . | nindent 8 }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -482,10 +482,15 @@ bitbucket:
   # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   # Do not populate when deploying to OpenShift, unless anyuid policy is attached to a service account.
   #
+
+  # -- Whether to apply security context to pod.
+  #
+  securityContextEnabled: true
+
   securityContext:
 
     # -- The GID used by the Bitbucket docker image
-    # If not supplied, will default to 2003.
+    # GID will default to 2003 if not supplied and securityContextEnabled is set to true.
     # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Bitbucket container.
     # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
     #

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -24,6 +24,7 @@ spec:
     spec:
       serviceAccountName: {{ include "confluence.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.confluence.shutdown.terminationGracePeriodSeconds }}
+      {{- if .Values.confluence.securityContextEnabled }}
       {{- with .Values.confluence.securityContext }}
       securityContext:
         {{/* this condition will be removed in v2.0.0 */}}
@@ -35,6 +36,7 @@ spec:
         fsGroup: 2002
         {{- end }}
         {{- end }}
+      {{- end }}
       {{- end }}
       hostAliases:
         {{- include "confluence.additionalHosts" . | nindent 8 }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -451,10 +451,15 @@ confluence:
   # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   # Do not populate when deploying to OpenShift, unless anyuid policy is attached to a service account.
   #
+
+  # -- Whether to apply security context to pod.
+  #
+  securityContextEnabled: true
+
   securityContext:
 
     # -- The GID used by the Confluence docker image
-    # If not supplied, will default to 2002
+    # GID will default to 2002 if not supplied and securityContextEnabled is set to true.
     # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Confluence container.
     # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
     fsGroup: 2002

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -24,6 +24,7 @@ spec:
     spec:
       serviceAccountName: {{ include "crowd.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.crowd.shutdown.terminationGracePeriodSeconds }}
+      {{- if .Values.crowd.securityContextEnabled }}
       {{- with .Values.crowd.securityContext }}
       securityContext:
         {{/* this condition is to be removed in v2.0.0 */}}
@@ -35,6 +36,7 @@ spec:
         fsGroup: 2004
         {{- end }}
         {{- end }}
+      {{- end }}
       {{- end }}
       initContainers:
         {{- include "crowd.additionalInitContainers" . | nindent 8 }}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -133,10 +133,16 @@ crowd:
   # Standard K8s field that holds pod-level security attributes and common container settings.
   # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   # Do not populate when deploying to OpenShift, unless anyuid policy is attached to a service account.
+  #
+
+  # -- Whether to apply security context to pod.
+  #
+  securityContextEnabled: true
+
   securityContext:
 
     # -- The GID used by the Crowd docker image
-    # If not supplied, will default to 2004
+    # GID will default to 2004 if not supplied and securityContextEnabled is set to true.
     # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Crowd container.
     # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
     #

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -24,6 +24,7 @@ spec:
     spec:
       serviceAccountName: {{ include "jira.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.jira.shutdown.terminationGracePeriodSeconds }}
+      {{- if .Values.jira.securityContextEnabled }}
       {{- with .Values.jira.securityContext }}
       securityContext:
         {{/* this condition is to be removed in v2.0.0 */}}
@@ -35,6 +36,7 @@ spec:
         fsGroup: 2001
         {{- end }}
         {{- end }}
+      {{- end }}
       {{- end }}
       initContainers:
         {{- include "jira.additionalInitContainers" . | nindent 8 }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -392,7 +392,7 @@ jira:
   securityContext:
 
     # -- The GID used by the Jira docker image
-    # If not supplied, will default to 2001 if securityContextEnables is set to true.
+    # GID will default to 2001 if not supplied and securityContextEnables is set to true.
     # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container.
     # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
     #

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -385,14 +385,14 @@ jira:
   # Do not populate when deploying to OpenShift, unless anyuid policy is attached to a service account.
   #
 
-  # -- Wether to apply security context to pod.
+  # -- Whether to apply security context to pod.
   #
   securityContextEnabled: true
 
   securityContext:
 
     # -- The GID used by the Jira docker image
-    # GID will default to 2001 if not supplied and securityContextEnables is set to true.
+    # GID will default to 2001 if not supplied and securityContextEnabled is set to true.
     # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container.
     # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
     #

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -384,10 +384,15 @@ jira:
   # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   # Do not populate when deploying to OpenShift, unless anyuid policy is attached to a service account.
   #
+
+  # -- Wether to apply security context to pod.
+  #
+  securityContextEnabled: true
+
   securityContext:
 
     # -- The GID used by the Jira docker image
-    # If not supplied, will default to 2001
+    # If not supplied, will default to 2001 if securityContextEnables is set to true.
     # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container.
     # However, this doesn't appear to work for NFS volumes due to a K8s bug: https://github.com/kubernetes/examples/issues/260
     #

--- a/src/test/java/test/SecurityContextTest.java
+++ b/src/test/java/test/SecurityContextTest.java
@@ -39,6 +39,17 @@ class SecurityContextTest {
     }
 
     @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    void test_no_pod_security_context(Product product) throws Exception {
+
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".securityContextEnabled", "false"));
+
+        JsonNode podSpec = resources.getStatefulSet(product.getHelmReleaseName()).getPodSpec();
+        assertThat(podSpec.path("securityContext")).isEmpty();
+    }
+
+    @ParameterizedTest
     @CsvSource({
             "jira,2001",
             "confluence,2002",


### PR DESCRIPTION
Currently, helm charts enforce securityContext, most notably fsGroup is set to 2001. For instances with lots of files this is problematic due to bug https://github.com/kubernetes/kubernetes/issues/69699 (issue is fixed, but will reach GA in 1.23).

Furthermore, as you already found out, setting fsGroup doesn't work for NFS, so this step can also be skipped for that kind of storage. From my personal research I also noticed fsGroup doesn't work well with samba shares, but this needs more through testing.

This PR makes setting whole securityContext optional for Jira and main goal here is to workaround the K8s issue. By default it will still apply securityContext.

If you like it then I can apply the change for the rest of applications.

I'll appreciate if you approve it quickly, as we want to migrate Jira & Confluence to K8s, but in current state mounting shared disk can take 40 minutes for us. I can imagine instances with more files taking even more time to mount a disk.