### PR TITLE
TFKUBE-384: `ATL_BASE_URL` should be appropriately set when `ingress.path` is supplied

### DIFF
--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 1.3.0
+
+**Release date:** TBD
+
+![AppVersion: 8.1.2-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.1.1-jdk11&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* TFKUBE-384: ATL_BASE_URL should be appropriately set when ingress.path is supplied
+
 ## 1.2.0
 
 **Release date:** 2022-02-14

--- a/src/main/charts/bamboo/templates/_helpers.tpl
+++ b/src/main/charts/bamboo/templates/_helpers.tpl
@@ -3,13 +3,17 @@
 Deduce the base URL for bamboo.
 */}}
 {{- define "bamboo.baseUrl" -}}
-{{- if .Values.ingress.host -}}
-{{ ternary "https" "http" .Values.ingress.https -}}
-://
-{{- .Values.ingress.host -}}
-{{- else }}
-{{- print  "http://localhost:8085/" }}
-{{- end }}
+    {{- if .Values.ingress.host -}}
+        {{ ternary "https" "http" .Values.ingress.https -}}
+        ://
+        {{- if .Values.ingress.path -}}
+            {{ .Values.ingress.host}}{{.Values.ingress.path }}
+        {{- else -}}
+            {{ .Values.ingress.host}}
+        {{- end }}
+    {{- else -}}
+        {{- print  "http://localhost:8085/" }}
+    {{- end }}
 {{- end }}
 
 {{/*

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -351,6 +351,55 @@ class IngressTest {
     }
 
     @ParameterizedTest
+    @EnumSource(value = Product.class, names = "bamboo")
+    void bamboo_atl_base_path_when_all_ingress_vals(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.create", "true",
+                "ingress.host", "myhost.mydomain",
+                "ingress.https", "true",
+                "ingress.path", "/bamboo"));
+
+        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
+                .assertHasValue("ATL_BASE_URL", "https://myhost.mydomain/bamboo");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "bamboo")
+    void bamboo_atl_base_path_when_no_ingress_path(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.create", "true",
+                "ingress.host", "myhost.mydomain",
+                "ingress.https", "true"));
+        
+        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
+                .assertHasValue("ATL_BASE_URL", "https://myhost.mydomain");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "bamboo")
+    void bamboo_atl_base_path_when_no_ingress_host(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.create", "true",
+                "ingress.https", "true"));
+
+        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
+                .assertHasValue("ATL_BASE_URL", "http://localhost:8085/");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "bamboo")
+    void bamboo_atl_base_path_when_ingress_host_over_http(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.create", "true",
+                "ingress.host", "myhost.mydomain",
+                "ingress.https", "false",
+                "ingress.path", "/bamboo"));
+
+        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
+                .assertHasValue("ATL_BASE_URL", "http://myhost.mydomain/bamboo");
+    }
+
+    @ParameterizedTest
     @EnumSource(value = Product.class, names = "confluence")
     void confluence_ingress_path_contextPath(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(


### PR DESCRIPTION
The `ATL_BASE_URL` should be appropriately set when an ingress path is supplied.

## Pull request description

This fix will set the `ATL_BASE_URL` env that bamboo uses to set its base path. Previously the base path was misconfigured (the path was not considered) if an `ingress.path` was supplied.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [x] [Acceptance tests are passing ](https://server-syd-bamboo.internal.atlassian.com/browse/DCD-K8SHELMTEST58-1)
