### PR TITLE
Confluence: Fix additionalHosts

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -255,7 +255,8 @@ Define additional init containers here to allow template overrides when used as 
 Define additional hosts here to allow template overrides when used as a sub chart
 */}}
 {{- define "confluence.additionalHosts" -}}
-{{- range .Values.additionalHosts }}
+{{- with .Values.additionalHosts }}
+{{- toYaml . }}
 {{- end }}
 {{- end }}
 

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -135,6 +135,9 @@ spec:
       serviceAccountName: unittest-confluence
       terminationGracePeriodSeconds: 25
       hostAliases:
+        - hostnames:
+          - test.example.com
+          ip: 192.168.1.1
       containers:
         - name: synchrony
           image: "atlassian/confluence:7.13.4-jdk11"

--- a/src/test/resources/expected_helm_output/confluence/values.yaml
+++ b/src/test/resources/expected_helm_output/confluence/values.yaml
@@ -6,3 +6,8 @@ volumes:
 
 synchrony:
   enabled: true
+
+additionalHosts:
+- ip: "192.168.1.1"
+  hostnames:
+    - "test.example.com"


### PR DESCRIPTION
Previously the additionalHosts were not rendered in the range loop.

## Pull request description

Allows the user to set hostAliases with the additionalHosts value. This did not work previously and now works.

## Checklist
- [ x ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
