### PR TITLE
DCD-1455: Remove jira license

### DIFF
--- a/src/main/charts/confluence/Changelog.md
+++ b/src/main/charts/confluence/Changelog.md
@@ -1,6 +1,15 @@
 # Change Log
 
-## 1.2.0
+## 1.3.0
+
+**Release date:** TBD
+
+![AppVersion: 7.13.4-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=7.13.2-jdk11&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* DCD-1471: Add support for separate Synchrony volumes (#390)
 
 **Release date:** 2022-02-14
 

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 1.3.0
+
+**Release date:** TBD
+
+![AppVersion: 8.20.5-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.20.1-jdk11&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* DCD-1455: Remove the unused Jira license value
+
 ## 1.2.0
 
 **Release date:** 2022-02-14

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -69,8 +69,6 @@ Kubernetes: `>=1.19.x-0`
 | jira.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Jira container. These can refer to existing volumes, or new volumes can be defined via 'volumes.additional'. |
 | jira.clustering.enabled | bool | `false` | Set to 'true' if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
 | jira.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
-| jira.license.secretKey | string | `"license-key"` | The key in the K8s Secret that contains the Jira license key |
-| jira.license.secretName | string | `nil` | The name of the K8s Secret that contains the Jira license key. If specified, then the license will be automatically populated during Jira setup. Otherwise, it will need to be provided via the browser after initial startup. An Example of creating a K8s secret for the license below: 'kubectl create secret generic <secret-name> --from-literal=license-key=<license> https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets |
 | jira.ports.ehcache | int | `40001` | Ehcache port |
 | jira.ports.ehcacheobject | int | `40011` | Ehcache object port |
 | jira.ports.http | int | `8080` | The port on which the Jira container listens for HTTP traffic |

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -75,13 +75,6 @@ spec:
             {{ end }}
             {{- include "jira.databaseEnvVars" . | nindent 12 }}
             {{- include "jira.clusteringEnvVars" . | nindent 12 }}
-            {{ with .Values.jira.license.secretName }}
-            - name: JIRA_SETUP_LICENSE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ . }}
-                  key: {{ $.Values.jira.license.secretKey }}
-            {{ end }}
             - name: SET_PERMISSIONS
               value: {{ .Values.jira.setPermissions | quote }}
             - name: JIRA_SHARED_HOME

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -461,23 +461,6 @@ jira:
     #
     enabled: false
 
-  # Jira licensing details
-  #
-  license:
-  
-    # -- The name of the K8s Secret that contains the Jira license key. If specified, then
-    # the license will be automatically populated during Jira setup. Otherwise, it will
-    # need to be provided via the browser after initial startup. An Example of creating
-    # a K8s secret for the license below:
-    # 'kubectl create secret generic <secret-name> --from-literal=license-key=<license>
-    # https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
-    #
-    secretName:
-    
-    # -- The key in the K8s Secret that contains the Jira license key
-    #
-    secretKey: license-key
-
   shutdown:
 
     # -- The termination grace period for pods during shutdown. This

--- a/src/test/java/test/LicenseTest.java
+++ b/src/test/java/test/LicenseTest.java
@@ -45,4 +45,17 @@ class LicenseTest {
                 .getEnv()
                 .assertHasSecretRef("SETUP_LICENSE", "license_secret", "mykey");
     }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "bamboo")
+    void bamboo_license_secret_name(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "bamboo.license.secretName", "license_secret",
+                "bamboo.license.secretKey", "mykey"));
+
+        resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getEnv()
+                .assertHasSecretRef("ATL_LICENSE", "license_secret", "mykey");
+    }
 }


### PR DESCRIPTION
## Pull request description

Remove unused `jira.license` values. Jira application doesn't support pre-seeding license and therefore can cause confusion.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
