### PR TITLE
Add a note regarding internal CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,4 @@ _Provide description for the PR_
 - [ ] I have added unit tests
 - [ ] I have applied the change to all applicable products
 - [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
+- [ ] (Atlassian only) Internal Bamboo CI is passing


### PR DESCRIPTION
Add a note regarding internal Bamboo CI. It is a good habit to check the status of the build.

If/when we will move towards full deployments in Github Actions with Terraform, we can remove this.
