### PR TITLE
Update product latest LTS versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 
 target
+__pycache__
 *.iml
 \#*\#
 docs/site

--- a/src/main/charts/bamboo-agent/Changelog.md
+++ b/src/main/charts/bamboo-agent/Changelog.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 1.3.0
+
+**Release date:** 2022-23-03
+
+![AppVersion: 8.1.3](https://img.shields.io/static/v1?label=AppVersion&message=8.1.3&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Update Bamboo version to 8.1.3 (#396)
+
+
 ## 1.2.0
 
 **Release date:** 2022-02-14

--- a/src/main/charts/bamboo-agent/Chart.yaml
+++ b/src/main/charts/bamboo-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: bamboo-agent
 description: A chart for installing Bamboo Data Center remote agents on Kubernetes
 type: application
 version: 1.2.0
-appVersion: 8.1.2-jdk11
+appVersion: 8.1.3
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Bamboo

--- a/src/main/charts/bamboo-agent/README.md
+++ b/src/main/charts/bamboo-agent/README.md
@@ -1,6 +1,6 @@
 # bamboo-agent
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.3](https://img.shields.io/badge/AppVersion-8.1.3-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center remote agents on Kubernetes
 

--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -2,13 +2,14 @@
 
 ## 1.3.0
 
-**Release date:** TBD
+**Release date:** 2022-23-03
 
-![AppVersion: 8.1.2-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.1.1-jdk11&color=success&logo=)
+![AppVersion: 8.1.3](https://img.shields.io/static/v1?label=AppVersion&message=8.1.3&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* TFKUBE-384: ATL_BASE_URL should be appropriately set when ingress.path is supplied
+* TFKUBE-384: ATL_BASE_URL should be appropriately set when ingress.path is supplied (#391)
+* Update Bamboo version to 8.1.3 (#396)
 
 ## 1.2.0
 

--- a/src/main/charts/bamboo/Chart.yaml
+++ b/src/main/charts/bamboo/Chart.yaml
@@ -3,7 +3,7 @@ name: bamboo
 description: A chart for installing Bamboo Data Center on Kubernetes
 type: application
 version: 1.2.0
-appVersion: 8.1.2-jdk11
+appVersion: 8.1.3
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Bamboo

--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -1,6 +1,6 @@
 # bamboo
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2-jdk11](https://img.shields.io/badge/AppVersion-8.1.2--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.3](https://img.shields.io/badge/AppVersion-8.1.3-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center on Kubernetes
 

--- a/src/main/charts/bitbucket/Changelog.md
+++ b/src/main/charts/bitbucket/Changelog.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 1.3.0
+
+**Release date:** 2022-03-23
+
+![AppVersion: 7.21.0](https://img.shields.io/static/v1?label=AppVersion&message=7.21.0&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* Update Bitbucket version to 7.21.0
+
 ## 1.2.0
 
 **Release date:** 2022-02-14

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -3,7 +3,7 @@ name: bitbucket
 description: A chart for installing Bitbucket Data Center on Kubernetes
 type: application
 version: 1.2.0
-appVersion: 7.21.0-jdk11
+appVersion: 7.21.0
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Bitbucket

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -3,7 +3,7 @@ name: bitbucket
 description: A chart for installing Bitbucket Data Center on Kubernetes
 type: application
 version: 1.2.0
-appVersion: 7.17.5-jdk11
+appVersion: 7.21.0-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Bitbucket

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -1,6 +1,6 @@
 # bitbucket
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.17.5-jdk11](https://img.shields.io/badge/AppVersion-7.17.5--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.21.0-jdk11](https://img.shields.io/badge/AppVersion-7.21.0--jdk11-informational?style=flat-square)
 
 A chart for installing Bitbucket Data Center on Kubernetes
 

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -1,6 +1,6 @@
 # bitbucket
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.21.0-jdk11](https://img.shields.io/badge/AppVersion-7.21.0--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.21.0](https://img.shields.io/badge/AppVersion-7.21.0-informational?style=flat-square)
 
 A chart for installing Bitbucket Data Center on Kubernetes
 

--- a/src/main/charts/confluence/Changelog.md
+++ b/src/main/charts/confluence/Changelog.md
@@ -2,14 +2,17 @@
 
 ## 1.3.0
 
-**Release date:** TBD
+**Release date:** 2022-23-03
 
-![AppVersion: 7.13.4-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=7.13.2-jdk11&color=success&logo=)
+![AppVersion: 7.13.5](https://img.shields.io/static/v1?label=AppVersion&message=7.13.5&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
 * DCD-1471: Add support for separate Synchrony volumes (#390)
+* Update Confluence version to 7.13.5 (#396)
+
+## 1.2.0
 
 **Release date:** 2022-02-14
 

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -3,7 +3,7 @@ name: confluence
 description: A chart for installing Confluence Data Center on Kubernetes
 type: application
 version: 1.2.0
-appVersion: 7.13.5-jdk11
+appVersion: 7.13.5
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Confluence

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -3,7 +3,7 @@ name: confluence
 description: A chart for installing Confluence Data Center on Kubernetes
 type: application
 version: 1.2.0
-appVersion: 7.13.4-jdk11
+appVersion: 7.13.5-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Confluence

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -1,6 +1,6 @@
 # confluence
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.13.4-jdk11](https://img.shields.io/badge/AppVersion-7.13.4--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.13.5-jdk11](https://img.shields.io/badge/AppVersion-7.13.5--jdk11-informational?style=flat-square)
 
 A chart for installing Confluence Data Center on Kubernetes
 

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -1,6 +1,6 @@
 # confluence
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.13.5-jdk11](https://img.shields.io/badge/AppVersion-7.13.5--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.13.5](https://img.shields.io/badge/AppVersion-7.13.5-informational?style=flat-square)
 
 A chart for installing Confluence Data Center on Kubernetes
 

--- a/src/main/charts/crowd/Changelog.md
+++ b/src/main/charts/crowd/Changelog.md
@@ -1,5 +1,18 @@
 # Change Log
 
+
+## 1.3.0
+
+**Release date:** 2022-03-23
+
+![AppVersion: 4.4.1](https://img.shields.io/static/v1?label=AppVersion&message=4.4.1&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
+* Update Crowd version to 4.4.1 (#396)
+
+
 ## 1.2.0
 
 **Release date:** 2022-02-14

--- a/src/main/charts/crowd/Chart.yaml
+++ b/src/main/charts/crowd/Chart.yaml
@@ -3,7 +3,7 @@ name: crowd
 description: A chart for installing Crowd Data Center on Kubernetes
 type: application
 version: 1.2.0
-appVersion: 4.4.0-jdk11
+appVersion: 4.4.1
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Crowd

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -1,6 +1,6 @@
 # crowd
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.0-jdk11](https://img.shields.io/badge/AppVersion-4.4.0--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.1](https://img.shields.io/badge/AppVersion-4.4.1-informational?style=flat-square)
 
 A chart for installing Crowd Data Center on Kubernetes
 

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -2,14 +2,16 @@
 
 ## 1.3.0
 
-**Release date:** TBD
+**Release date:** 2022-03-23
 
-![AppVersion: 8.20.5-jdk11](https://img.shields.io/static/v1?label=AppVersion&message=8.20.1-jdk11&color=success&logo=)
+![AppVersion: 8.20.5](https://img.shields.io/static/v1?label=AppVersion&message=8.20.5&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
 * DCD-1455: Remove the unused Jira license value
+* Update Jira version to 8.20.5 (#396)
+
 
 ## 1.2.0
 

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -4,13 +4,13 @@
 
 **Release date:** 2022-03-23
 
-![AppVersion: 8.20.5](https://img.shields.io/static/v1?label=AppVersion&message=8.20.5&color=success&logo=)
+![AppVersion: 8.20.7](https://img.shields.io/static/v1?label=AppVersion&message=8.20.7&color=success&logo=)
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 
 * DCD-1455: Remove the unused Jira license value
-* Update Jira version to 8.20.5 (#396)
+* Update Jira version to 8.20.7 (#396)
 
 
 ## 1.2.0

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -3,7 +3,7 @@ name: jira
 description: A chart for installing Jira Data Center on Kubernetes
 type: application
 version: 1.2.0
-appVersion: 8.20.5-jdk11
+appVersion: 8.20.7-jdk11
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Jira

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -3,7 +3,7 @@ name: jira
 description: A chart for installing Jira Data Center on Kubernetes
 type: application
 version: 1.2.0
-appVersion: 8.20.7-jdk11
+appVersion: 8.20.7
 kubeVersion: ">=1.19.x-0"
 keywords:
   - Jira

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -1,6 +1,6 @@
 # jira
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.20.7-jdk11](https://img.shields.io/badge/AppVersion-8.20.7--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.20.7](https://img.shields.io/badge/AppVersion-8.20.7-informational?style=flat-square)
 
 A chart for installing Jira Data Center on Kubernetes
 

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -1,6 +1,6 @@
 # jira
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.20.5-jdk11](https://img.shields.io/badge/AppVersion-8.20.5--jdk11-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.20.7-jdk11](https://img.shields.io/badge/AppVersion-8.20.7--jdk11-informational?style=flat-square)
 
 A chart for installing Jira Data Center on Kubernetes
 

--- a/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: bamboo-agent-1.2.0
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
-    app.kubernetes.io/version: "8.1.2-jdk11"
+    app.kubernetes.io/version: "8.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: bamboo-agent/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: bamboo-agent-1.2.0
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
-    app.kubernetes.io/version: "8.1.2-jdk11"
+    app.kubernetes.io/version: "8.1.3"
     app.kubernetes.io/managed-by: Helm
 data:
   max_heap: 512m
@@ -35,7 +35,7 @@ metadata:
     helm.sh/chart: bamboo-agent-1.2.0
     app.kubernetes.io/name: bamboo-agent
     app.kubernetes.io/instance: unittest-bamboo-agent
-    app.kubernetes.io/version: "8.1.2-jdk11"
+    app.kubernetes.io/version: "8.1.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -57,7 +57,7 @@ spec:
       initContainers:
       containers:
         - name: bamboo-agent
-          image: "atlassian/bamboo-agent-base:8.1.2-jdk11"
+          image: "atlassian/bamboo-agent-base:8.1.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: BAMBOO_SERVER

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.1.2-jdk11"
+    app.kubernetes.io/version: "8.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: bamboo/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.1.2-jdk11"
+    app.kubernetes.io/version: "8.1.3"
     app.kubernetes.io/managed-by: Helm
 data:
   additional_jvm_args: >-
@@ -37,7 +37,7 @@ metadata:
     helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.1.2-jdk11"
+    app.kubernetes.io/version: "8.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -60,7 +60,7 @@ metadata:
     helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.1.2-jdk11"
+    app.kubernetes.io/version: "8.1.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -92,7 +92,7 @@ spec:
           command: ["sh", "-c", "(chgrp 2005 /shared-home; chmod g+w /shared-home)"]
       containers:
         - name: bamboo
-          image: "atlassian/bamboo:8.1.2-jdk11"
+          image: "atlassian/bamboo:8.1.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: ATL_TOMCAT_SCHEME
@@ -206,7 +206,7 @@ metadata:
     helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.1.2-jdk11"
+    app.kubernetes.io/version: "8.1.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -250,7 +250,7 @@ metadata:
     helm.sh/chart: bamboo-1.2.0
     app.kubernetes.io/name: bamboo
     app.kubernetes.io/instance: unittest-bamboo
-    app.kubernetes.io/version: "8.1.2-jdk11"
+    app.kubernetes.io/version: "8.1.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.21.0-jdk11"
+    app.kubernetes.io/version: "7.21.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: bitbucket/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.21.0-jdk11"
+    app.kubernetes.io/version: "7.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   additional_jvm_args: >-
@@ -37,7 +37,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.21.0-jdk11"
+    app.kubernetes.io/version: "7.21.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -68,7 +68,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.21.0-jdk11"
+    app.kubernetes.io/version: "7.21.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -96,7 +96,7 @@ spec:
       initContainers:
       containers:
         - name: bitbucket
-          image: "atlassian/bitbucket:7.21.0-jdk11"
+          image: "atlassian/bitbucket:7.21.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -176,7 +176,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.21.0-jdk11"
+    app.kubernetes.io/version: "7.21.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -208,7 +208,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.21.0-jdk11"
+    app.kubernetes.io/version: "7.21.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.17.5-jdk11"
+    app.kubernetes.io/version: "7.21.0-jdk11"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: bitbucket/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.17.5-jdk11"
+    app.kubernetes.io/version: "7.21.0-jdk11"
     app.kubernetes.io/managed-by: Helm
 data:
   additional_jvm_args: >-
@@ -37,7 +37,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.17.5-jdk11"
+    app.kubernetes.io/version: "7.21.0-jdk11"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -68,7 +68,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.17.5-jdk11"
+    app.kubernetes.io/version: "7.21.0-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -96,7 +96,7 @@ spec:
       initContainers:
       containers:
         - name: bitbucket
-          image: "atlassian/bitbucket:7.17.5-jdk11"
+          image: "atlassian/bitbucket:7.21.0-jdk11"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -176,7 +176,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.17.5-jdk11"
+    app.kubernetes.io/version: "7.21.0-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -208,7 +208,7 @@ metadata:
     helm.sh/chart: bitbucket-1.2.0
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
-    app.kubernetes.io/version: "7.17.5-jdk11"
+    app.kubernetes.io/version: "7.21.0-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.4-jdk11"
+    app.kubernetes.io/version: "7.13.5-jdk11"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: confluence/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.4-jdk11"
+    app.kubernetes.io/version: "7.13.5-jdk11"
     app.kubernetes.io/managed-by: Helm
 data:
   additional_jvm_args: >-
@@ -63,7 +63,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence-synchrony
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.4-jdk11"
+    app.kubernetes.io/version: "7.13.5-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -89,7 +89,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.4-jdk11"
+    app.kubernetes.io/version: "7.13.5-jdk11"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -116,7 +116,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence-synchrony
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.4-jdk11"
+    app.kubernetes.io/version: "7.13.5-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -137,7 +137,7 @@ spec:
       hostAliases:
       containers:
         - name: synchrony
-          image: "atlassian/confluence:7.13.4-jdk11"
+          image: "atlassian/confluence:7.13.5-jdk11"
           imagePullPolicy: IfNotPresent
           command: ["/scripts/start-synchrony.sh"]
           volumeMounts:
@@ -191,7 +191,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.4-jdk11"
+    app.kubernetes.io/version: "7.13.5-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -224,7 +224,7 @@ spec:
           command: ["sh", "-c", "(chgrp 2002 /shared-home; chmod g+w /shared-home)"]
       containers:
         - name: confluence
-          image: "atlassian/confluence:7.13.4-jdk11"
+          image: "atlassian/confluence:7.13.5-jdk11"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -307,7 +307,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.4-jdk11"
+    app.kubernetes.io/version: "7.13.5-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -338,7 +338,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.4-jdk11"
+    app.kubernetes.io/version: "7.13.5-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.5-jdk11"
+    app.kubernetes.io/version: "7.13.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: confluence/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.5-jdk11"
+    app.kubernetes.io/version: "7.13.5"
     app.kubernetes.io/managed-by: Helm
 data:
   additional_jvm_args: >-
@@ -63,7 +63,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence-synchrony
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.5-jdk11"
+    app.kubernetes.io/version: "7.13.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -89,7 +89,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.5-jdk11"
+    app.kubernetes.io/version: "7.13.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -116,7 +116,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence-synchrony
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.5-jdk11"
+    app.kubernetes.io/version: "7.13.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -137,7 +137,7 @@ spec:
       hostAliases:
       containers:
         - name: synchrony
-          image: "atlassian/confluence:7.13.5-jdk11"
+          image: "atlassian/confluence:7.13.5"
           imagePullPolicy: IfNotPresent
           command: ["/scripts/start-synchrony.sh"]
           volumeMounts:
@@ -191,7 +191,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.5-jdk11"
+    app.kubernetes.io/version: "7.13.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -224,7 +224,7 @@ spec:
           command: ["sh", "-c", "(chgrp 2002 /shared-home; chmod g+w /shared-home)"]
       containers:
         - name: confluence
-          image: "atlassian/confluence:7.13.5-jdk11"
+          image: "atlassian/confluence:7.13.5"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -307,7 +307,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.5-jdk11"
+    app.kubernetes.io/version: "7.13.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -338,7 +338,7 @@ metadata:
     helm.sh/chart: confluence-1.2.0
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
-    app.kubernetes.io/version: "7.13.5-jdk11"
+    app.kubernetes.io/version: "7.13.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
-    app.kubernetes.io/version: "4.4.0-jdk11"
+    app.kubernetes.io/version: "4.4.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: crowd/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
-    app.kubernetes.io/version: "4.4.0-jdk11"
+    app.kubernetes.io/version: "4.4.1"
     app.kubernetes.io/managed-by: Helm
 data:
   additional_jvm_args: >-
@@ -40,7 +40,7 @@ metadata:
     helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
-    app.kubernetes.io/version: "4.4.0-jdk11"
+    app.kubernetes.io/version: "4.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -67,7 +67,7 @@ metadata:
     helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
-    app.kubernetes.io/version: "4.4.0-jdk11"
+    app.kubernetes.io/version: "4.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -177,7 +177,7 @@ metadata:
     helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
-    app.kubernetes.io/version: "4.4.0-jdk11"
+    app.kubernetes.io/version: "4.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -208,7 +208,7 @@ metadata:
     helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
-    app.kubernetes.io/version: "4.4.0-jdk11"
+    app.kubernetes.io/version: "4.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -245,7 +245,7 @@ metadata:
     helm.sh/chart: crowd-1.2.0
     app.kubernetes.io/name: crowd
     app.kubernetes.io/instance: unittest-crowd
-    app.kubernetes.io/version: "4.4.0-jdk11"
+    app.kubernetes.io/version: "4.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
@@ -258,7 +258,7 @@ spec:
         helm.sh/chart: crowd-1.2.0
         app.kubernetes.io/name: crowd
         app.kubernetes.io/instance: unittest-crowd
-        app.kubernetes.io/version: "4.4.0-jdk11"
+        app.kubernetes.io/version: "4.4.1"
         app.kubernetes.io/managed-by: Helm
     spec:
       restartPolicy: Never

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.7-jdk11"
+    app.kubernetes.io/version: "8.20.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: jira/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.7-jdk11"
+    app.kubernetes.io/version: "8.20.7"
     app.kubernetes.io/managed-by: Helm
 data:
   additional_jvm_args: >-
@@ -39,7 +39,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.7-jdk11"
+    app.kubernetes.io/version: "8.20.7"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -62,7 +62,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.7-jdk11"
+    app.kubernetes.io/version: "8.20.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -94,7 +94,7 @@ spec:
           command: ["sh", "-c", "(chgrp 2001 /shared-home; chmod g+w /shared-home)"]
       containers:
         - name: jira
-          image: "atlassian/jira-software:8.20.7-jdk11"
+          image: "atlassian/jira-software:8.20.7"
           imagePullPolicy: IfNotPresent
           env:
             - name: ATL_TOMCAT_SCHEME
@@ -176,7 +176,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.7-jdk11"
+    app.kubernetes.io/version: "8.20.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -208,7 +208,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.7-jdk11"
+    app.kubernetes.io/version: "8.20.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.5-jdk11"
+    app.kubernetes.io/version: "8.20.7-jdk11"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: jira/templates/config-jvm.yaml
@@ -20,7 +20,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.5-jdk11"
+    app.kubernetes.io/version: "8.20.7-jdk11"
     app.kubernetes.io/managed-by: Helm
 data:
   additional_jvm_args: >-
@@ -39,7 +39,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.5-jdk11"
+    app.kubernetes.io/version: "8.20.7-jdk11"
     app.kubernetes.io/managed-by: Helm
   annotations:
 spec:
@@ -62,7 +62,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.5-jdk11"
+    app.kubernetes.io/version: "8.20.7-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -94,7 +94,7 @@ spec:
           command: ["sh", "-c", "(chgrp 2001 /shared-home; chmod g+w /shared-home)"]
       containers:
         - name: jira
-          image: "atlassian/jira-software:8.20.5-jdk11"
+          image: "atlassian/jira-software:8.20.7-jdk11"
           imagePullPolicy: IfNotPresent
           env:
             - name: ATL_TOMCAT_SCHEME
@@ -176,7 +176,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.5-jdk11"
+    app.kubernetes.io/version: "8.20.7-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:
@@ -208,7 +208,7 @@ metadata:
     helm.sh/chart: jira-1.2.0
     app.kubernetes.io/name: jira
     app.kubernetes.io/instance: unittest-jira
-    app.kubernetes.io/version: "8.20.5-jdk11"
+    app.kubernetes.io/version: "8.20.7-jdk11"
     app.kubernetes.io/managed-by: Helm
 spec:
   containers:

--- a/src/test/scripts/product_versions.py
+++ b/src/test/scripts/product_versions.py
@@ -4,12 +4,15 @@ import json
 import re
 
 known_supported_version = {
+	'bitbucket': '7.21.0',
 	'jira-software': '8.13.8',
 	'confluence': '7.12.2',
 	'stash': '7.12.1',
 	'bamboo': '8.1.1' # Bamboo has not LTS versions.
 }
 
+# If tag suffix is desired - e.g. 7.8.0-jdk11 -> tag_suffix = "-jdk11"
+tag_suffix = "-jdk11"
 
 def get_lts_version(argv):
 	product = argv[0].lower()
@@ -47,7 +50,7 @@ def get_lts_version(argv):
 		except:
 			lts_version = known_supported_version[product]
 
-		lts_version = f"{lts_version}-jdk11"
+		lts_version = f"{lts_version}{tag_suffix}"
 	else:
 		lts_version = 'unknown'
 

--- a/src/test/scripts/product_versions.py
+++ b/src/test/scripts/product_versions.py
@@ -1,18 +1,19 @@
-import sys
-import urllib.request
 import json
 import re
+import sys
+import urllib.request
 
 known_supported_version = {
 	'bitbucket': '7.21.0',
 	'jira-software': '8.13.8',
 	'confluence': '7.12.2',
 	'stash': '7.12.1',
-	'bamboo': '8.1.1' # Bamboo has not LTS versions.
+	'bamboo': '8.1.1'  # Bamboo has not LTS versions.
 }
 
 # If tag suffix is desired - e.g. 7.8.0-jdk11 -> tag_suffix = "-jdk11"
-tag_suffix = "-jdk11"
+tag_suffix = ""
+
 
 def get_lts_version(argv):
 	product = argv[0].lower()
@@ -43,7 +44,7 @@ def get_lts_version(argv):
 			else:
 				lts_version = known_supported_version[product]
 
-			# Currently latest lts version of Bitbucket and Confluence don't support K8s
+			# Currently, latest lts version of Bitbucket and Confluence don't support K8s
 			# We use non-lts version of those products in the test
 			if cversion(lts_version) < cversion(known_supported_version[product]):
 				lts_version = known_supported_version[product]

--- a/src/test/scripts/update_versions.py
+++ b/src/test/scripts/update_versions.py
@@ -16,7 +16,7 @@ Script is currently executed manually and is in a fairly rough shape.
 logging.basicConfig(level=logging.INFO, format="%(levelname).1s %(message)s")
 
 products = ["bitbucket", "jira", "bamboo", "confluence", "crowd"]
-suffix = ""
+tag_suffix = ""
 lts_products = ["bitbucket", "jira", "confluence"]
 
 
@@ -94,13 +94,15 @@ for product in products:
     logging.info("Product: %s", product)
 
     if product in lts_products:
-        version = product_versions.get_lts_version([product]).replace(suffix, "")
+        version = product_versions.get_lts_version([product]).replace(tag_suffix, "")
         logging.info("Latest LTS version: %s", version)
     else:
         logging.info("Non-LTS product")
         r = requests.get(f'https://marketplace.atlassian.com/rest/2/products/key/{product}/versions/latest')
         version = r.json()['name']
 
-    new_version_tag = f"{version}{suffix}"
-    logging.info(f"Latest version: %s, tagname: {version}{suffix}", version)
+    new_version_tag = f"{version}{tag_suffix}"
+    logging.info(f"Latest version: %s, tagname: {version}{tag_suffix}", version)
     update_versions(product, new_version_tag)
+
+logging.info(">>>> ATTENTION - Don't forget to update the product Changelogs.md - ATTENTION <<<<")

--- a/src/test/scripts/update_versions.py
+++ b/src/test/scripts/update_versions.py
@@ -16,7 +16,7 @@ Script is currently executed manually and is in a fairly rough shape.
 logging.basicConfig(level=logging.INFO, format="%(levelname).1s %(message)s")
 
 products = ["bitbucket", "jira", "bamboo", "confluence", "crowd"]
-suffix = "-jdk11"
+suffix = ""
 lts_products = ["bitbucket", "jira", "confluence"]
 
 


### PR DESCRIPTION
## Pull request description

* Updated all products to the latest LTS versions. The major bump is for Bitbucket to jump to 7.21.0 (which is the latest LTS).
* Added changelogs
* Removed the `jdk-11` suffix, I don't think it serves us or customers any purpose

## Checklist
- [x] ~~I have added unit tests~~ not applicable
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files

The internal CI build is running https://server-syd-bamboo.internal.atlassian.com/browse/DCD-K8SHELMTEST62-2