### PR TITLE
Configurable ingress proxy settings

### DIFF
--- a/src/main/charts/bamboo-agent/Changelog.md
+++ b/src/main/charts/bamboo-agent/Changelog.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 1.4.0
+
+**Release date:** TBD
+
+![AppVersion: 7.13.5](https://img.shields.io/static/v1?label=AppVersion&message=7.13.5&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+
 ## 1.3.0
 
 **Release date:** 2022-23-03

--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -8,7 +8,7 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* Support for configuring ingress proxy settings via values.yaml
+* Support for configuring ingress proxy settings via values.yaml (#402)
 
 ## 1.3.0
 

--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 1.4.0
+
+**Release date:** TBD
+
+![AppVersion: 7.13.5](https://img.shields.io/static/v1?label=AppVersion&message=7.13.5&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Support for configuring ingress proxy settings via values.yaml
+
 ## 1.3.0
 
 **Release date:** 2022-23-03

--- a/src/main/charts/bamboo/templates/ingress.yaml
+++ b/src/main/charts/bamboo/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout|quote }}
     {{- end }}
     {{- with .Values.ingress.annotations }}
   {{- toYaml . | nindent 4 }}

--- a/src/main/charts/bamboo/templates/ingress.yaml
+++ b/src/main/charts/bamboo/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
     {{- end }}
     {{- with .Values.ingress.annotations }}
   {{- toYaml . | nindent 4 }}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -316,6 +316,25 @@ ingress:
   #
   maxBodySize: 250m
   
+  # -- Defines a timeout for establishing a connection with a proxied server. It should
+  # be noted that this timeout cannot usually exceed 75 seconds.
+  #
+  proxyConnectTimeout: 60
+
+  # -- Defines a timeout for reading a response from the proxied server. The timeout is
+  # set only between two successive read operations, not for the transmission of the
+  # whole response. If the proxied server does not transmit anything within this time,
+  # the connection is closed.
+  #
+  proxyReadTimeout: 60
+
+  # -- Sets a timeout for transmitting a request to the proxied server. The timeout is set
+  # only between two successive write operations, not for the transmission of the whole
+  # request. If the proxied server does not receive anything within this time, the
+  # connection is closed.
+  #
+  proxySendTimeout: 60
+
   # -- The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on 
   # this hostname will be routed by the Ingress Resource to the appropriate backend 
   # Service.

--- a/src/main/charts/bitbucket/Changelog.md
+++ b/src/main/charts/bitbucket/Changelog.md
@@ -8,7 +8,7 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* Support for configuring ingress proxy settings via values.yaml
+* Support for configuring ingress proxy settings via values.yaml (#402)
 
 ## 1.3.0
 

--- a/src/main/charts/bitbucket/Changelog.md
+++ b/src/main/charts/bitbucket/Changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 1.4.0
+
+**Release date:** TBD
+
+![AppVersion: 7.13.5](https://img.shields.io/static/v1?label=AppVersion&message=7.13.5&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Support for configuring ingress proxy settings via values.yaml
+
 ## 1.3.0
 
 **Release date:** 2022-03-23

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
   {{- end }}
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout|quote }}
   {{- end }}
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -386,6 +386,25 @@ ingress:
   #
   maxBodySize: 250m
   
+  # -- Defines a timeout for establishing a connection with a proxied server. It should
+  # be noted that this timeout cannot usually exceed 75 seconds.
+  #
+  proxyConnectTimeout: 60
+
+  # -- Defines a timeout for reading a response from the proxied server. The timeout is
+  # set only between two successive read operations, not for the transmission of the
+  # whole response. If the proxied server does not transmit anything within this time,
+  # the connection is closed.
+  #
+  proxyReadTimeout: 60
+
+  # -- Sets a timeout for transmitting a request to the proxied server. The timeout is set
+  # only between two successive write operations, not for the transmission of the whole
+  # request. If the proxied server does not receive anything within this time, the
+  # connection is closed.
+  #
+  proxySendTimeout: 60
+
   # -- The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on
   # this hostname will be routed by the Ingress Resource to the appropriate backend
   # Service.

--- a/src/main/charts/confluence/Changelog.md
+++ b/src/main/charts/confluence/Changelog.md
@@ -9,8 +9,9 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-
 * DCD-1471: Add support for separate Synchrony volumes (#390)
+* Support for configuring ingress proxy settings via values.yaml
+
 
 ## 1.3.0
 

--- a/src/main/charts/confluence/Changelog.md
+++ b/src/main/charts/confluence/Changelog.md
@@ -10,7 +10,7 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 * DCD-1471: Add support for separate Synchrony volumes (#390)
-* Support for configuring ingress proxy settings via values.yaml
+* Support for configuring ingress proxy settings via values.yaml (#402)
 
 
 ## 1.3.0

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout|quote }}
     {{- end }}
     {{- with .Values.ingress.annotations }}
   {{- toYaml . | nindent 4 }}

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
     {{- end }}
     {{- with .Values.ingress.annotations }}
   {{- toYaml . | nindent 4 }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -392,6 +392,25 @@ ingress:
   #
   maxBodySize: 250m
   
+  # -- Defines a timeout for establishing a connection with a proxied server. It should
+  # be noted that this timeout cannot usually exceed 75 seconds.
+  #
+  proxyConnectTimeout: 60
+
+  # -- Defines a timeout for reading a response from the proxied server. The timeout is
+  # set only between two successive read operations, not for the transmission of the
+  # whole response. If the proxied server does not transmit anything within this time,
+  # the connection is closed.
+  #
+  proxyReadTimeout: 60
+
+  # -- Sets a timeout for transmitting a request to the proxied server. The timeout is set
+  # only between two successive write operations, not for the transmission of the whole
+  # request. If the proxied server does not receive anything within this time, the
+  # connection is closed.
+  #
+  proxySendTimeout: 60
+
   # -- The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on
   # this hostname will be routed by the Ingress Resource to the appropriate backend
   # Service.

--- a/src/main/charts/crowd/Changelog.md
+++ b/src/main/charts/crowd/Changelog.md
@@ -8,7 +8,7 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* Support for configuring ingress proxy settings via values.yaml
+* Support for configuring ingress proxy settings via values.yaml (#402)
 
 ## 1.3.0
 

--- a/src/main/charts/crowd/Changelog.md
+++ b/src/main/charts/crowd/Changelog.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 1.4.0
+
+**Release date:** TBD
+
+![AppVersion: 7.13.5](https://img.shields.io/static/v1?label=AppVersion&message=7.13.5&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Support for configuring ingress proxy settings via values.yaml
 
 ## 1.3.0
 

--- a/src/main/charts/crowd/templates/ingress.yaml
+++ b/src/main/charts/crowd/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout|quote }}
     {{- end }}
     {{- with .Values.ingress.annotations }}
   {{- toYaml . | nindent 4 }}

--- a/src/main/charts/crowd/templates/ingress.yaml
+++ b/src/main/charts/crowd/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
     {{- end }}
     {{- with .Values.ingress.annotations }}
   {{- toYaml . | nindent 4 }}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -386,6 +386,25 @@ ingress:
   #
   maxBodySize: 250m
 
+  # -- Defines a timeout for establishing a connection with a proxied server. It should
+  # be noted that this timeout cannot usually exceed 75 seconds.
+  #
+  proxyConnectTimeout: 60
+
+  # -- Defines a timeout for reading a response from the proxied server. The timeout is
+  # set only between two successive read operations, not for the transmission of the
+  # whole response. If the proxied server does not transmit anything within this time,
+  # the connection is closed.
+  #
+  proxyReadTimeout: 60
+
+  # -- Sets a timeout for transmitting a request to the proxied server. The timeout is set
+  # only between two successive write operations, not for the transmission of the whole
+  # request. If the proxied server does not receive anything within this time, the
+  # connection is closed.
+  #
+  proxySendTimeout: 60
+
   # -- The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on
   # this hostname will be routed by the Ingress Resource to the appropriate backend
   # Service.

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -8,7 +8,7 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* Support for configuring ingress proxy settings via values.yaml
+* Support for configuring ingress proxy settings via values.yaml (#402)
 
 ## 1.3.0
 

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 1.4.0
+
+**Release date:** TBD
+
+![AppVersion: 7.13.5](https://img.shields.io/static/v1?label=AppVersion&message=7.13.5&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Support for configuring ingress proxy settings via values.yaml
+
 ## 1.3.0
 
 **Release date:** 2022-03-23

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout|quote }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout|quote }}
     {{- end }}
     {{- with .Values.ingress.annotations }}
   {{- toYaml . | nindent 4 }}

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -11,9 +11,9 @@ metadata:
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": {{ .Values.ingress.proxyConnectTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": {{ .Values.ingress.proxyReadTimeout }}
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": {{ .Values.ingress.proxySendTimeout }}
     {{- end }}
     {{- with .Values.ingress.annotations }}
   {{- toYaml . | nindent 4 }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -318,6 +318,25 @@ ingress:
   #
   maxBodySize: 250m
   
+  # -- Defines a timeout for establishing a connection with a proxied server. It should
+  # be noted that this timeout cannot usually exceed 75 seconds.
+  #
+  proxyConnectTimeout: 60
+
+  # -- Defines a timeout for reading a response from the proxied server. The timeout is
+  # set only between two successive read operations, not for the transmission of the
+  # whole response. If the proxied server does not transmit anything within this time,
+  # the connection is closed.
+  #
+  proxyReadTimeout: 60
+
+  # -- Sets a timeout for transmitting a request to the proxied server. The timeout is set
+  # only between two successive write operations, not for the transmission of the whole
+  # request. If the proxied server does not receive anything within this time, the
+  # connection is closed.
+  #
+  proxySendTimeout: 60
+  
   # -- The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on
   # this hostname will be routed by the Ingress Resource to the appropriate backend
   # Service.

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -370,7 +370,7 @@ class IngressTest {
                 "ingress.create", "true",
                 "ingress.host", "myhost.mydomain",
                 "ingress.https", "true"));
-        
+
         resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
                 .assertHasValue("ATL_BASE_URL", "https://myhost.mydomain");
     }
@@ -557,6 +557,19 @@ class IngressTest {
                 "/",
                 "/setup",
                 "/bootstrap");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bamboo", "bitbucket", "confluence", "crowd", "jira"})
+    void ingress_proxy_settings(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.create", "true"));
+
+        assertThat(ingress.getMetadata().path("annotations"))
+                .isObject(Map.of(
+                        "nginx.ingress.kubernetes.io/proxy-connect-timeout", "60",
+                        "nginx.ingress.kubernetes.io/proxy-read-timeout", "60",
+                        "nginx.ingress.kubernetes.io/proxy-send-timeout", "60"));
     }
 
     private List<String> extractAllPaths(Traversable<KubeResource> ingresses) {

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -565,11 +565,23 @@ class IngressTest {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "ingress.create", "true"));
 
-        assertThat(ingress.getMetadata().path("annotations"))
-                .isObject(Map.of(
-                        "nginx.ingress.kubernetes.io/proxy-connect-timeout", "60",
-                        "nginx.ingress.kubernetes.io/proxy-read-timeout", "60",
-                        "nginx.ingress.kubernetes.io/proxy-send-timeout", "60"));
+        final var ingresses = resources.getAll(Kind.Ingress);
+
+        for (KubeResource ingress : ingresses) {
+                if ( ingress.getMetadata().path("name").asText().contains("-setup") ) {
+                    assertThat(ingress.getMetadata().path("annotations"))
+                        .isObject(Map.of(
+                            "nginx.ingress.kubernetes.io/proxy-connect-timeout", "300",
+                            "nginx.ingress.kubernetes.io/proxy-read-timeout", "300",
+                            "nginx.ingress.kubernetes.io/proxy-send-timeout", "300"));
+                } else {
+                    assertThat(ingress.getMetadata().path("annotations"))
+                        .isObject(Map.of(
+                            "nginx.ingress.kubernetes.io/proxy-connect-timeout", "60",
+                            "nginx.ingress.kubernetes.io/proxy-read-timeout", "60",
+                            "nginx.ingress.kubernetes.io/proxy-send-timeout", "60"));
+                }
+        }
     }
 
     private List<String> extractAllPaths(Traversable<KubeResource> ingresses) {


### PR DESCRIPTION
## Pull request description

The default value doesn't fit if i'am running the IntegrityChecker in a large cluster -> Proxy Timeout

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [x] (Atlassian only) [Internal Bamboo CI is passing](https://server-syd-bamboo.internal.atlassian.com/browse/DCD-K8SHELMTEST71-1)
