### PR TITLE
Bug Fix: Crowd install common.label error.  clusterrolebinding.yaml

### DIFF
--- a/src/main/charts/crowd/templates/clusterrolebinding.yaml
+++ b/src/main/charts/crowd/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "crowd.clusterRoleBindingName" . }}
   labels:
-  {{- include "common.labels" . | nindent 4 }}
+  {{- include "common.labels.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Fix for the following error which occurred during install of Crowd.
`Error: template: crowd/templates/clusterrolebinding.yaml:7:6: executing "crowd/templates/clusterrolebinding.yaml" at <include "common.labels" .>: error calling include: template: no template "common.labels" associated with template "gotpl"`

Change from `common.labels` to `common.labels.commonLabels` reflecting setup for [Confluence template cluterrolebinding.yaml ](https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/confluence/templates/clusterrolebinding.yaml)

## Pull request description

The error `error calling include: template: no template "common.labels" associated with template` occurred during the installation of the Crowd chart. Identified to be the result of incorrect mapping in the common library chart. Fixed to match [Confluence template cluterrolebinding.yaml ](https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/confluence/templates/clusterrolebinding.yaml)

## Checklist
- [ ] I have added unit tests
- [X] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) Internal Bamboo CI is passing
