### PR TITLE
Add ATL_PROXY_NAME and ATL_PROXY_PORT to Confluence/Crowd

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -1,5 +1,12 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
+Create default value for ingress port
+*/}}
+{{- define "confluence.ingressPort" -}}
+{{ default (ternary "443" "80" .Values.ingress.https) .Values.ingress.port -}}
+{{- end }}
+
+{{/*
 The name the synchrony app within the chart.
 TODO: This will break if the common.names.name exceeds 63 characters, need to find a more rebust way to do this
 */}}

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -102,6 +102,12 @@ spec:
             - name: ATL_TOMCAT_CONTEXTPATH
               value: {{ .Values.confluence.service.contextPath | quote }}
             {{ end }}
+            {{ if .Values.ingress.host }}
+            - name: ATL_PROXY_NAME
+              value: {{ .Values.ingress.host | quote }}
+            - name: ATL_PROXY_PORT
+              value: {{ include "confluence.ingressPort" . | quote }}
+            {{ end }}
             - name: ATL_TOMCAT_ACCESS_LOG
               value: {{ .Values.confluence.accessLog.enabled | quote }}
             - name: UMASK

--- a/src/main/charts/crowd/templates/_helpers.tpl
+++ b/src/main/charts/crowd/templates/_helpers.tpl
@@ -1,5 +1,12 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
+Create default value for ingress port
+*/}}
+{{- define "crowd.ingressPort" -}}
+{{ default (ternary "443" "80" .Values.ingress.https) .Values.ingress.port -}}
+{{- end }}
+
+{{/*
 The name of the service account to be used.
 If the name is defined in the chart values, then use that,
 else if we're creating a new service account then use the name of the Helm release,

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -96,6 +96,12 @@ spec:
             - name: ATL_TOMCAT_SECURE
               value: "true"
             {{ end }}
+            {{ if .Values.ingress.host }}
+            - name: ATL_PROXY_NAME
+              value: {{ .Values.ingress.host | quote }}
+            - name: ATL_PROXY_PORT
+              value: {{ include "crowd.ingressPort" . | quote }}
+            {{ end }}
             - name: ATL_TOMCAT_ACCESS_LOG
               value: {{ .Values.crowd.accessLog.enabled | quote }}
             - name: UMASK

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -142,7 +142,7 @@ class IngressTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Product.class, names = "jira")
+    @EnumSource(value = Product.class, names = {"jira", "confluence", "bamboo"})
     void jira_ingress_host_port(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "ingress.host", "myhost.mydomain",
@@ -154,7 +154,7 @@ class IngressTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Product.class, names = "jira")
+    @EnumSource(value = Product.class, names = {"jira", "confluence", "bamboo"})
     void jira_ingress_port(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "ingress.host", "myhost.mydomain"));
@@ -165,7 +165,7 @@ class IngressTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Product.class, names = "jira")
+    @EnumSource(value = Product.class, names = {"jira", "confluence", "bamboo"})
     void jira_ingress_port_http(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "ingress.host", "myhost.mydomain",
@@ -252,41 +252,6 @@ class IngressTest {
 
         assertThat(ingresses.head().getNode("spec", "rules").required(0).path("http").path("paths").required(0).path("path"))
                 .hasTextEqualTo("/");
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = Product.class, names = "bamboo")
-    void bamboo_ingress_host_port(Product product) throws Exception {
-        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
-                "ingress.host", "myhost.mydomain",
-                "ingress.port", "666"));
-
-        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
-                .assertHasValue("ATL_PROXY_NAME", "myhost.mydomain")
-                .assertHasValue("ATL_PROXY_PORT", "666");
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = Product.class, names = "bamboo")
-    void bamboo_ingress_port(Product product) throws Exception {
-        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
-                "ingress.host", "myhost.mydomain"));
-
-        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
-                .assertHasValue("ATL_PROXY_NAME", "myhost.mydomain")
-                .assertHasValue("ATL_PROXY_PORT", "443");
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = Product.class, names = "bamboo")
-    void bamboo_ingress_port_http(Product product) throws Exception {
-        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
-                "ingress.host", "myhost.mydomain",
-                "ingress.https", "False"));
-
-        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
-                .assertHasValue("ATL_PROXY_NAME", "myhost.mydomain")
-                .assertHasValue("ATL_PROXY_PORT", "80");
     }
 
     @ParameterizedTest

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -142,7 +142,7 @@ class IngressTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Product.class, names = {"jira", "confluence", "bamboo"})
+    @EnumSource(value = Product.class, names = {"jira", "confluence", "bamboo", "crowd"})
     void jira_ingress_host_port(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "ingress.host", "myhost.mydomain",
@@ -154,7 +154,7 @@ class IngressTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Product.class, names = {"jira", "confluence", "bamboo"})
+    @EnumSource(value = Product.class, names = {"jira", "confluence", "bamboo", "crowd"})
     void jira_ingress_port(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "ingress.host", "myhost.mydomain"));
@@ -165,7 +165,7 @@ class IngressTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Product.class, names = {"jira", "confluence", "bamboo"})
+    @EnumSource(value = Product.class, names = {"jira", "confluence", "bamboo", "crowd"})
     void jira_ingress_port_http(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "ingress.host", "myhost.mydomain",


### PR DESCRIPTION
## Pull request description
Copied logic from previous DCKUBE-474 for Confluence. Consolidated jira, confluence, and bamboo tests for these settings. Separate bamboo tests for these settings were removed as these tests are the same for all 3 products.

_Provide description for the PR_
Noticed server.xml had empty values for these settings when I was troubleshooting a Confluence issue yesterday with latest helm chart.

## Checklist
- [ x ] I have added unit tests
- [ x ] I have applied the change to all applicable products
- [ x ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [x] (Atlassian only) Internal Bamboo CI is passing
