### PR TITLE
DCD-1529: Add Bitbucket, Jira, and Confluence to E2E tests

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -28,7 +28,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          
+
+      - name: Pin Kubectl version
+        uses: azure/setup-kubectl@v2.0
+        with:
+          version: 'v1.23.6'
+
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -22,6 +22,8 @@ jobs:
       TF_VAR_bamboo_license: ${{ secrets.TF_VAR_BAMBOO_LICENSE }}
       TF_VAR_confluence_license: ${{ secrets.TF_VAR_CONFLUENCE_LICENSE }}
       TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}
+      TF_VAR_bamboo_admin_password: ${{ secrets.TF_VAR_BAMBOO_ADMIN_PASSWORD }}
+      TF_VAR_bitbucket_admin_password: ${{ secrets.TF_VAR_BITBUCKET_ADMIN_PASSWORD }}
 
     steps:
       - name: Checkout Helm charts

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'src/main/charts/bamboo/**'
       - 'src/main/charts/bamboo-agent/**'
+      - 'src/main/charts/bitbucket/**'
+      - 'src/main/charts/confluence/**'
+      - 'src/main/charts/jira/**'
   workflow_dispatch:
 
 jobs:
@@ -17,6 +20,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       TF_VAR_bamboo_license: ${{ secrets.TF_VAR_BAMBOO_LICENSE }}
+      TF_VAR_confluence_license: ${{ secrets.TF_VAR_CONFLUENCE_LICENSE }}
+      TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}
 
     steps:
       - name: Checkout Helm charts
@@ -29,10 +34,13 @@ jobs:
         with:
           version: v3.7.1
 
-      - name: Execute helm dependency update for bamboo chart
-        run: helm dependency update src/main/charts/bamboo
-      - name: Execute helm dependency update for bamboo-agent chart
-        run: helm dependency update src/main/charts/bamboo-agent
+      - name: Execute helm dependency update for Helm charts
+        run: |
+          helm dependency update src/main/charts/bamboo
+          helm dependency update src/main/charts/bamboo-agent
+          helm dependency update src/main/charts/bitbucket
+          helm dependency update src/main/charts/confluence
+          helm dependency update src/main/charts/jira
 
       - name: Checkout Deployment Automation
         run: |
@@ -55,6 +63,18 @@ jobs:
           go get -v -t -d ./... && go mod tidy
           echo ::set-output name=exit_code::$?
 
+      - name: Add private SSH key for Bitbucket tests
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.BITBUCKET_E2E_TEST_PRIV_SSH_KEY }}
+          name: bitbucket-e2e # optional
+          known_hosts: dummy-entry
+          if_key_exists: fail # replace / ignore / fail; optional (defaults to fail)
+
+      - name: Add public SSH key for Bitbucket tests
+        run: |
+          echo ${{ secrets.BITBUCKET_E2E_TEST_PUB_SSH_KEY }} > /home/runner/.ssh/bitbucket-e2e.pub
+
       - name: Deploy the infrastructure, install helm charts, run E2E tests, and cleanup
         id: e2e-test
         working-directory: tf/test/
@@ -70,7 +90,7 @@ jobs:
           EOF
           
           # Deploy infrastructure, install helm charts, run e2e tests, and cleanup all
-          go test ./e2etest -v -timeout 60m -run Installer | tee ./e2etest/artifacts/e2etest.log
+          go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 
       - name: Upload test log files
         if: always()


### PR DESCRIPTION
## Pull request description

E2E test detects the latest release in `Deployment Automation for Atlassian DC on K8s` project to test against the latest `main` branch of the helm chart repo. 
As K8s deployment version 2.0.0 is released, `Confluence`, `Bitbucket`, and `Jira` are included to the project. The E2E test in data center helm chart project has no logic to include any application but Bamboo (is written based on version 1.x). So this PR adjust the E2E test and add needed action secrets to fix the E2E test. 

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) Internal Bamboo CI is passing
