### PR TITLE
CLIP-1553: Use custom port for product server

### DIFF
--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## NEXT_VERSION
+
+**Release date:** RELEASE_DATE
+
+![AppVersion: 8.2.3](https://img.shields.io/static/v1?label=AppVersion&message=8.2.3&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Fix: Use the custom ports for Bamboo service
+
 ## 1.4.0
 
 **Release date:** 2022-05-25

--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -66,6 +66,8 @@ spec:
             - name: ATL_TOMCAT_CONTEXTPATH
               value: {{ .Values.bamboo.service.contextPath | quote }}
             {{ end }}
+            - name: ATL_TOMCAT_PORT
+              value: {{ .Values.bamboo.ports.http | quote }}
             {{ if .Values.ingress.host }}
             - name: ATL_PROXY_NAME
               value: {{ .Values.ingress.host | quote }}

--- a/src/main/charts/bitbucket/Changelog.md
+++ b/src/main/charts/bitbucket/Changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## NEXT_VERSION
+
+**Release date:** RELEASE_DATE
+
+![AppVersion: 7.21.1](https://img.shields.io/static/v1?label=AppVersion&message=7.21.1&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Fix: Use the custom ports for Bitbucket service
+
 ## 1.4.0
 
 **Release date:** 2022-05-25

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -139,6 +139,8 @@ spec:
             {{ end }}
             - name: SERVER_CONTEXT_PATH
               value: {{ include "bitbucket.ingressPath" . | quote }}
+            - name: SERVER_PORT
+              value: {{ .Values.bitbucket.ports.http | quote }}
             {{ if .Values.ingress.https }}
             - name: SERVER_SCHEME
               value: "https"

--- a/src/main/charts/confluence/Changelog.md
+++ b/src/main/charts/confluence/Changelog.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## NEXT_VERSION
+
+**Release date:** RELEASE_DATE
+
+![AppVersion: 7.13.7](https://img.shields.io/static/v1?label=AppVersion&message=7.13.7&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Fix [SCALE-68](https://jira.atlassian.com/browse/SCALE-68): Use the custom ports for Confluence service
+* Fix [SCALE-69](https://jira.atlassian.com/browse/SCALE-69): Use the custom ports for Synchrony service
+
 
 ## 1.4.1
 

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -104,6 +104,8 @@ spec:
             - name: ATL_TOMCAT_CONTEXTPATH
               value: {{ .Values.confluence.service.contextPath | quote }}
             {{ end }}
+            - name: ATL_TOMCAT_PORT
+              value: {{ .Values.confluence.ports.http | quote }}
             {{ if .Values.ingress.host }}
             - name: ATL_PROXY_NAME
               value: {{ .Values.ingress.host | quote }}

--- a/src/main/charts/confluence/templates/synchrony-start-script.yaml
+++ b/src/main/charts/confluence/templates/synchrony-start-script.yaml
@@ -13,6 +13,8 @@ data:
     java \
        -Xms{{ .Values.synchrony.resources.jvm.minHeap }} \
        -Xmx{{ .Values.synchrony.resources.jvm.maxHeap }} \
+       -Dsynchrony.port={{ .Values.synchrony.ports.http }} \
+       -Dcluster.listen.port={{ .Values.synchrony.ports.hazelcast }} \
        {{- range .Values.synchrony.additionalJvmArgs }}
        {{ . }} \
        {{- end }}

--- a/src/main/charts/confluence/templates/synchrony-start-script.yaml
+++ b/src/main/charts/confluence/templates/synchrony-start-script.yaml
@@ -13,12 +13,12 @@ data:
     java \
        -Xms{{ .Values.synchrony.resources.jvm.minHeap }} \
        -Xmx{{ .Values.synchrony.resources.jvm.maxHeap }} \
+       -Xss{{ .Values.synchrony.resources.jvm.stackSize }} \
        -Dsynchrony.port={{ .Values.synchrony.ports.http }} \
        -Dcluster.listen.port={{ .Values.synchrony.ports.hazelcast }} \
        {{- range .Values.synchrony.additionalJvmArgs }}
        {{ . }} \
        {{- end }}
-       -Xss{{ .Values.synchrony.resources.jvm.stackSize }} \
        -XX:ActiveProcessorCount={{ .Values.synchrony.resources.container.requests.cpu }} \
        -classpath /opt/atlassian/confluence/confluence/WEB-INF/packages/synchrony-standalone.jar:/opt/atlassian/confluence/confluence/WEB-INF/lib/* \
        synchrony.core \

--- a/src/main/charts/crowd/Changelog.md
+++ b/src/main/charts/crowd/Changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## NEXT_VERSION
+
+**Release date:** RELEASE_DATE
+
+![AppVersion: 5.0.0](https://img.shields.io/static/v1?label=AppVersion&message=5.0.0&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Fix: Use the custom ports for Crowd service
+
 ## 1.4.0
 
 **Release date:** 2022-05-25

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -98,6 +98,8 @@ spec:
             - name: ATL_TOMCAT_SECURE
               value: "true"
             {{ end }}
+            - name: ATL_TOMCAT_PORT
+              value: {{ .Values.crowd.ports.http | quote }}
             {{ if .Values.ingress.host }}
             - name: ATL_PROXY_NAME
               value: {{ .Values.ingress.host | quote }}

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## NEXT_VERSION
+
+**Release date:** RELEASE_DATE
+
+![AppVersion: 8.20.9](https://img.shields.io/static/v1?label=AppVersion&message=8.20.9&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Fix: Use the custom ports for Jira service
+
 ## 1.4.1
 
 **Release date:** 2022-06-09

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -69,6 +69,8 @@ spec:
             - name: ATL_TOMCAT_CONTEXTPATH
               value: {{ .Values.jira.service.contextPath | quote }}
             {{ end }}
+            - name: ATL_TOMCAT_PORT
+              value: {{ .Values.jira.ports.http | quote }}
             {{ if .Values.ingress.host }}
             - name: ATL_PROXY_NAME
               value: {{ .Values.ingress.host | quote }}

--- a/src/test/java/test/CustomPortTest.java
+++ b/src/test/java/test/CustomPortTest.java
@@ -1,0 +1,47 @@
+package test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import test.helm.Helm;
+import test.model.Container;
+import test.model.Product;
+
+import java.util.Map;
+
+import static test.jackson.JsonNodeAssert.assertThat;
+
+class CustomPortTest {
+    private Helm helm;
+
+    @BeforeEach
+    void initHelm(TestInfo testInfo) {
+        helm = new Helm(testInfo);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bitbucket", "bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    void custom_port_tomcat_server(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".ports.http", "1234"));
+
+        Container container = resources.getStatefulSet(product.getHelmReleaseName()).getContainer();
+
+        container.getEnv().assertHasValue("ATL_TOMCAT_PORT", "1234");
+        assertThat(container.getReadinessProbe().get("httpGet").get("port")).hasValueEqualTo(1234);
+    }
+
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bitbucket"}, mode = EnumSource.Mode.INCLUDE)
+    void custom_port_bitbucket(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".ports.http", "1234"));
+
+        Container container = resources.getStatefulSet(product.getHelmReleaseName()).getContainer();
+
+        container.getEnv().assertHasValue("SERVER_PORT", "1234");
+        assertThat(container.getReadinessProbe().get("httpGet").get("port")).hasValueEqualTo(1234);
+    }
+}

--- a/src/test/java/test/model/Container.java
+++ b/src/test/java/test/model/Container.java
@@ -53,4 +53,8 @@ public final class Container {
     public JsonNode getSecurityContext() {
         return get("securityContext");
     }
+
+    public JsonNode getReadinessProbe() {
+        return get("readinessProbe");
+    }
 }

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -101,6 +101,8 @@ spec:
               value: "true"
             - name: ATL_BASE_URL
               value: "http://localhost:8085/"
+            - name: ATL_TOMCAT_PORT
+              value: "8085"
             - name: SET_PERMISSIONS
               value: "true"
             - name: BAMBOO_SHARED_HOME

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -131,6 +131,8 @@ spec:
               value: "-Dcluster.node.name=$(KUBE_POD_NAME)"
             - name: SERVER_CONTEXT_PATH
               value: "/"
+            - name: SERVER_PORT
+              value: "7990"
             - name: SERVER_SCHEME
               value: "https"
             - name: SERVER_SECURE

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -263,6 +263,8 @@ spec:
               value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
+            - name: ATL_TOMCAT_PORT
+              value: "8090"
             - name: ATL_TOMCAT_ACCESS_LOG
               value: "true"
             - name: UMASK

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -49,6 +49,8 @@ data:
        -Xms1g \
        -Xmx2g \
        -Xss2048k \
+       -Dsynchrony.port=8091 \
+       -Dcluster.listen.port=5701 \
        -XX:ActiveProcessorCount=2 \
        -classpath /opt/atlassian/confluence/confluence/WEB-INF/packages/synchrony-standalone.jar:/opt/atlassian/confluence/confluence/WEB-INF/lib/* \
        synchrony.core \

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -132,6 +132,8 @@ spec:
               value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
+            - name: ATL_TOMCAT_PORT
+              value: "8095"
             - name: ATL_TOMCAT_ACCESS_LOG
               value: "true"
             - name: UMASK

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -101,6 +101,8 @@ spec:
               value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
+            - name: ATL_TOMCAT_PORT
+              value: "8080"
             - name: SET_PERMISSIONS
               value: "true"
             - name: JIRA_SHARED_HOME


### PR DESCRIPTION
## Pull request description

* Fix the use of the custom ports for the products
* Add unit tests
* Bitbucket is not using Tomcat, therefore it needs to use a different env. property (`server.port`).

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [x] (Atlassian only) Internal Bamboo CI is passing
