### PR TITLE
synchrony path fix

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -128,11 +128,15 @@ Pod labels
 
 {{- define "confluence.sysprop.synchronyServiceUrl" -}}
 {{- if .Values.synchrony.enabled -}}
--Dsynchrony.service.url={{ .Values.synchrony.ingressUrl }}/v1
+    {{- if .Values.ingress.https -}}
+    -Dsynchrony.service.url=https://{{ .Values.ingress.host }}/synchrony/v1
+    {{- else }}
+    -Dsynchrony.service.url=http://{{ .Values.ingress.host }}/synchrony/v1
+    {{- end }}
 {{- else -}}
 -Dsynchrony.btf.disabled=true
 {{- end -}}
-{{- end }}
+{{- end -}}
 
 {{/*
 Create default value for ingress path

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
                 port:
                   number: {{ $.Values.confluence.service.port }}
           {{ if .Values.synchrony.enabled }}
-          - path: {{ trimSuffix "/" (include "confluence.ingressPath" .) }}/synchrony
+          - path: /synchrony
             pathType: Prefix
             backend:
               service:

--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -62,7 +62,11 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: SYNCHRONY_SERVICE_URL
-              value: {{ .Values.synchrony.ingressUrl | quote }}
+            {{ if .Values.ingress.https }}
+              value: "https://{{ .Values.ingress.host }}/synchrony"
+            {{ else }}
+              value: "http://{{ .Values.ingress.host }}/synchrony"
+            {{- end }}
             {{- include "synchrony.databaseEnvVars" . | nindent 12 }}
             {{- include "synchrony.clusteringEnvVars" . | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -838,12 +838,6 @@ synchrony:
     # should be set to the Synchrony internal grace period (default 20
     # seconds), plus a small buffer to allow the JVM to fully terminate.
     terminationGracePeriodSeconds: 25
-        
-  # -- The base URL of the Synchrony service. This will be the URL that users' browsers will
-  # be given to communicate with Synchrony, as well as the URL that the Confluence service
-  # will use to communicate directly with Synchrony, so the URL must be resolvable both from
-  # inside and outside the Kubernetes cluster.
-  ingressUrl:
   
   # -- Specifies a list of additional Java libraries that should be added to the
   # Synchrony container. Each item in the list should specify the name of the volume

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -380,7 +380,7 @@ class IngressTest {
 
         org.assertj.core.api.Assertions.assertThat(ingressPaths).containsExactlyInAnyOrder(
                 "/confluence-tmp",
-                "/confluence-tmp/synchrony",
+                "/synchrony",
                 "/confluence-tmp/setup",
                 "/confluence-tmp/bootstrap");
     }
@@ -420,7 +420,7 @@ class IngressTest {
 
         org.assertj.core.api.Assertions.assertThat(ingressPaths).containsExactlyInAnyOrder(
                 "/ingress",
-                "/ingress/synchrony",
+                "/synchrony",
                 "/ingress/setup",
                 "/ingress/bootstrap");
     }
@@ -460,7 +460,7 @@ class IngressTest {
 
         org.assertj.core.api.Assertions.assertThat(ingressPaths).containsExactlyInAnyOrder(
                 "/ingress",
-                "/ingress/synchrony",
+                "/synchrony",
                 "/ingress/setup",
                 "/ingress/bootstrap");
     }

--- a/src/test/java/test/SynchronyTest.java
+++ b/src/test/java/test/SynchronyTest.java
@@ -29,7 +29,9 @@ class SynchronyTest {
     void synchrony_enable(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "synchrony.enabled", "true",
-                "synchrony.ingressUrl", "https://mysynchrony"
+                "ingress.host", "atlassian.net",
+                "ingress.path", "confluence",
+                "ingress.https", "true"
         ));
 
         resources.assertContains(Kind.StatefulSet, product.getHelmReleaseName() + "-synchrony");
@@ -39,7 +41,7 @@ class SynchronyTest {
                 .getNode("data", "additional_jvm_args");
 
         assertThat(sysProps)
-                .hasTextContaining("-Dsynchrony.service.url=https://mysynchrony/v1")
+                .hasTextContaining("-Dsynchrony.service.url=https://atlassian.net/synchrony/v1")
                 .hasTextNotContaining("synchrony.btf.disabled");
     }
 

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -25,7 +25,7 @@ metadata:
 data:
   additional_jvm_args: >-
     -Dconfluence.cluster.hazelcast.listenPort=5701
-    -Dsynchrony.service.url=/v1
+    -Dsynchrony.service.url=https:///synchrony/v1
     -Dsynchrony.by.default.enable.collab.editing.if.manually.managed=true
     -Dconfluence.clusterNodeName.useHostname=true
     -Datlassian.logging.cloud.enabled=false
@@ -176,7 +176,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: SYNCHRONY_SERVICE_URL
-              value: 
+              value: "https:///synchrony"
       volumes:
         - name: entrypoint-script
           configMap:


### PR DESCRIPTION
## Pull request description
Closes #225 
_Provide description for the PR_
Allows synchrony to work with or without context path that is driven from the ingress.host used for the confluence application. The context path for synchrony would always be /synchrony and that context path would be reserved for synchrony. I think it removes some of the confusion in the values.yaml around the ingress hosts and context paths and also a lot of the cross-walking of the configuration. There doesn't appear to be much benefit to have the ingress host for synchrony to be configurable as it is only for collaborative editing. A user does not necessarily route to this url directly to use collaborative editing. It just happens in the background. In most cases if the network/web server path to ingress.host is open, then the network path to synchrony will also be open. Currently, the synchrony url does not work with a context path due to incorrect value being placed in the ingress for the synchrony context path.

## Checklist
- [ x ] I have added unit tests
- [ x ] I have applied the change to all applicable products
- [ x ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) Internal Bamboo CI is passing
