### PR TITLE
CLIP-1413: Fix synchrony ingress path

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:
-          version: 'v1.23.6'
+          version: 'v1.24.0'
 
       - name: Install Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -24,6 +24,7 @@ jobs:
       TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}
       TF_VAR_bamboo_admin_password: ${{ secrets.TF_VAR_BAMBOO_ADMIN_PASSWORD }}
       TF_VAR_bitbucket_admin_password: ${{ secrets.TF_VAR_BITBUCKET_ADMIN_PASSWORD }}
+      USE_DOMAIN: "true"
 
     steps:
       - name: Checkout Helm charts

--- a/docs/docs/assets/stylesheets/extra.css
+++ b/docs/docs/assets/stylesheets/extra.css
@@ -1,4 +1,4 @@
-:root {
+:root > * {
 
     --md-primary-fg-color: #0052CC;
     --md-primary-fg-color--light: #FFFFFF;

--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -8,7 +8,7 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* Fix: Use the custom ports for Bamboo service
+* Fix: Use the custom ports for Bamboo service (#419)
 
 ## 1.4.0
 

--- a/src/main/charts/bamboo/Chart.yaml
+++ b/src/main/charts/bamboo/Chart.yaml
@@ -21,20 +21,10 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
-      description: Make pod securityContext optional
+      description: Use the custom ports for Bamboo service
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/389
-    - kind: added
-      description: Support for configuring ingress proxy settings via values.yaml
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/402
-    - kind: changed
-      description: Bamboo DC updated to 8.2.3 version
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/412
+        url: https://github.com/atlassian/data-center-helm-charts/pull/419
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/bitbucket/Changelog.md
+++ b/src/main/charts/bitbucket/Changelog.md
@@ -8,7 +8,7 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* Fix: Use the custom ports for Bitbucket service
+* Fix: Use the custom ports for Bitbucket service (#419)
 
 ## 1.4.0
 

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -20,26 +20,11 @@ deprecated: false
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: changed
-      description: Remove emptyDir from Bitbucket shared home volume options
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/386
     - kind: added
-      description: Make pod securityContext optional
+      description: Use the custom ports for Bitbucket service
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/389
-    - kind: added
-      description: Support for configuring ingress proxy settings via values.yaml
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/402
-    - kind: changed
-      description: Update Bitbucket version to 7.21.0
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/412
+        url: https://github.com/atlassian/data-center-helm-charts/pull/419
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/confluence/Changelog.md
+++ b/src/main/charts/confluence/Changelog.md
@@ -8,9 +8,9 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* Fix [SCALE-68](https://jira.atlassian.com/browse/SCALE-68): Use the custom ports for Confluence service
-* Fix [SCALE-69](https://jira.atlassian.com/browse/SCALE-69): Use the custom ports for Synchrony service
-
+* Fix [SCALE-68](https://jira.atlassian.com/browse/SCALE-68): Use the custom ports for Confluence service (#419)
+* Fix [SCALE-69](https://jira.atlassian.com/browse/SCALE-69): Use the custom ports for Synchrony service (#419)
+* Fix [ISSUE-225](https://github.com/atlassian/data-center-helm-charts/issues/225): Fixed Synchrony ingress path (#429)
 
 ## 1.4.1
 

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -20,13 +20,21 @@ deprecated: false
 annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update Confluence version to 7.13.7
+    - kind: added
+      description: Use the custom ports for Confluence service
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/417
-      - name: Confluence Security Advisory 2022-06-02
-        url: https://confluence.atlassian.com/doc/confluence-security-advisory-2022-06-02-1130377146.html
+        url: https://github.com/atlassian/data-center-helm-charts/pull/419
+    - kind: added
+      description: Use the custom ports for Synchrony service
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/419
+    - kind: changed
+      description: Fixed Synchrony ingress path
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/429
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -128,11 +128,15 @@ Pod labels
 
 {{- define "confluence.sysprop.synchronyServiceUrl" -}}
 {{- if .Values.synchrony.enabled -}}
--Dsynchrony.service.url={{ .Values.synchrony.ingressUrl }}/v1
+    {{- if .Values.ingress.https -}}
+    -Dsynchrony.service.url=https://{{ .Values.ingress.host }}/synchrony/v1
+    {{- else }}
+    -Dsynchrony.service.url=http://{{ .Values.ingress.host }}/synchrony/v1
+    {{- end }}
 {{- else -}}
 -Dsynchrony.btf.disabled=true
 {{- end -}}
-{{- end }}
+{{- end -}}
 
 {{/*
 Create default value for ingress path

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
                 port:
                   number: {{ $.Values.confluence.service.port }}
           {{ if .Values.synchrony.enabled }}
-          - path: {{ trimSuffix "/" (include "confluence.ingressPath" .) }}/synchrony
+          - path: /synchrony
             pathType: Prefix
             backend:
               service:

--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -62,7 +62,11 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: SYNCHRONY_SERVICE_URL
-              value: {{ .Values.synchrony.ingressUrl | quote }}
+            {{ if .Values.ingress.https }}
+              value: "https://{{ .Values.ingress.host }}/synchrony"
+            {{ else }}
+              value: "http://{{ .Values.ingress.host }}/synchrony"
+            {{- end }}
             {{- include "synchrony.databaseEnvVars" . | nindent 12 }}
             {{- include "synchrony.clusteringEnvVars" . | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -838,12 +838,6 @@ synchrony:
     # should be set to the Synchrony internal grace period (default 20
     # seconds), plus a small buffer to allow the JVM to fully terminate.
     terminationGracePeriodSeconds: 25
-        
-  # -- The base URL of the Synchrony service. This will be the URL that users' browsers will
-  # be given to communicate with Synchrony, as well as the URL that the Confluence service
-  # will use to communicate directly with Synchrony, so the URL must be resolvable both from
-  # inside and outside the Kubernetes cluster.
-  ingressUrl:
   
   # -- Specifies a list of additional Java libraries that should be added to the
   # Synchrony container. Each item in the list should specify the name of the volume

--- a/src/main/charts/crowd/Changelog.md
+++ b/src/main/charts/crowd/Changelog.md
@@ -8,7 +8,7 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* Fix: Use the custom ports for Crowd service
+* Fix: Use the custom ports for Crowd service (#419)
 
 ## 1.4.0
 

--- a/src/main/charts/crowd/Chart.yaml
+++ b/src/main/charts/crowd/Chart.yaml
@@ -21,30 +21,10 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
-      description: Make pod securityContext optional
+      description: Use the custom ports for Crowd service
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/389
-    - kind: added
-      description: Support for configuring ingress proxy settings via values.yaml
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/402
-    - kind: fixed
-      description: Fixed common.label error 
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/403
-    - kind: added
-      description: Add ATL_PROXY_NAME and ATL_PROXY_PORT to Crowd
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/407
-    - kind: changed
-      description: Update Crowd version to 5.0.0
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/412
+        url: https://github.com/atlassian/data-center-helm-charts/pull/419
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -8,7 +8,7 @@
 ![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-* Fix: Use the custom ports for Jira service
+* Fix: Use the custom ports for Jira service (#419)
 
 ## 1.4.1
 

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -21,11 +21,11 @@ deprecated: false
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: changed
-      description: Update Jira version to 8.20.9
+    - kind: added
+      description: Use the custom ports for Jira service
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/417
+        url: https://github.com/atlassian/data-center-helm-charts/pull/419
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -380,7 +380,7 @@ class IngressTest {
 
         org.assertj.core.api.Assertions.assertThat(ingressPaths).containsExactlyInAnyOrder(
                 "/confluence-tmp",
-                "/confluence-tmp/synchrony",
+                "/synchrony",
                 "/confluence-tmp/setup",
                 "/confluence-tmp/bootstrap");
     }
@@ -420,7 +420,7 @@ class IngressTest {
 
         org.assertj.core.api.Assertions.assertThat(ingressPaths).containsExactlyInAnyOrder(
                 "/ingress",
-                "/ingress/synchrony",
+                "/synchrony",
                 "/ingress/setup",
                 "/ingress/bootstrap");
     }
@@ -460,7 +460,7 @@ class IngressTest {
 
         org.assertj.core.api.Assertions.assertThat(ingressPaths).containsExactlyInAnyOrder(
                 "/ingress",
-                "/ingress/synchrony",
+                "/synchrony",
                 "/ingress/setup",
                 "/ingress/bootstrap");
     }

--- a/src/test/java/test/SynchronyTest.java
+++ b/src/test/java/test/SynchronyTest.java
@@ -29,7 +29,9 @@ class SynchronyTest {
     void synchrony_enable(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "synchrony.enabled", "true",
-                "synchrony.ingressUrl", "https://mysynchrony"
+                "ingress.host", "atlassian.net",
+                "ingress.path", "confluence",
+                "ingress.https", "true"
         ));
 
         resources.assertContains(Kind.StatefulSet, product.getHelmReleaseName() + "-synchrony");
@@ -39,7 +41,7 @@ class SynchronyTest {
                 .getNode("data", "additional_jvm_args");
 
         assertThat(sysProps)
-                .hasTextContaining("-Dsynchrony.service.url=https://mysynchrony/v1")
+                .hasTextContaining("-Dsynchrony.service.url=https://atlassian.net/synchrony/v1")
                 .hasTextNotContaining("synchrony.btf.disabled");
     }
 

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -25,7 +25,7 @@ metadata:
 data:
   additional_jvm_args: >-
     -Dconfluence.cluster.hazelcast.listenPort=5701
-    -Dsynchrony.service.url=/v1
+    -Dsynchrony.service.url=https:///synchrony/v1
     -Dsynchrony.by.default.enable.collab.editing.if.manually.managed=true
     -Dconfluence.clusterNodeName.useHostname=true
     -Datlassian.logging.cloud.enabled=false
@@ -176,7 +176,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: SYNCHRONY_SERVICE_URL
-              value: 
+              value: "https:///synchrony"
       volumes:
         - name: entrypoint-script
           configMap:


### PR DESCRIPTION
* synchrony path fix
* This PR is a contribution from community (https://github.com/atlassian/data-center-helm-charts/pull/420)
Merging to CLIP-1413-fix-synchrony-ingress-path branch to run e2e tests

## Pull request description

Allows synchrony to work with or without context path that is driven from the ingress.host used for the confluence application. The context path for synchrony would always be /synchrony and that context path would be reserved for synchrony. I think it removes some of the confusion in the values.yaml around the ingress hosts and context paths and also a lot of the cross-walking of the configuration. There doesn't appear to be much benefit to have the ingress host for synchrony to be configurable as it is only for collaborative editing. A user does not necessarily route to this url directly to use collaborative editing. It just happens in the background. In most cases if the network/web server path to ingress.host is open, then the network path to synchrony will also be open. Currently, the synchrony url does not work with a context path due to incorrect value being placed in the ingress for the synchrony context path.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [x] (Atlassian only) Internal Bamboo CI is passing
