### PR TITLE
CLIP-1596: Fixed end to end test by bumping up k8s version

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -24,6 +24,7 @@ jobs:
       TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}
       TF_VAR_bamboo_admin_password: ${{ secrets.TF_VAR_BAMBOO_ADMIN_PASSWORD }}
       TF_VAR_bitbucket_admin_password: ${{ secrets.TF_VAR_BITBUCKET_ADMIN_PASSWORD }}
+      USE_DOMAIN: "true"
 
     steps:
       - name: Checkout Helm charts
@@ -34,7 +35,7 @@ jobs:
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:
-          version: 'v1.23.6'
+          version: 'v1.24.0'
 
       - name: Install Helm
         uses: azure/setup-helm@v1


### PR DESCRIPTION

## Pull request description

This PR bump up the version of Kubernetes to use v1beta1 apiVersion for k8s client authentication. We already fix terraform installer project (v2.02) to use the same apiVersion. 

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [x] (Atlassian only) Internal Bamboo CI is passing
