### PR TITLE
CLIP-1588: Schedule to run end to end test on every second day at 3:00am

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -1,7 +1,7 @@
 name: Helm Charts E2E Testing
 on:
   schedule:
-    - cron: '0 3 * * 1' # schedule the test to run every Monday at 3:00am
+    - cron: '0 3 */2 * *' # schedule the test to run every second day at 3:00am
   push:
     branches:
       - main

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -1,5 +1,7 @@
 name: Helm Charts E2E Testing
 on:
+  schedule:
+    - cron: '0 3 * * 1' # schedule the test to run every Monday at 3:00am
   push:
     branches:
       - main


### PR DESCRIPTION
## Pull request description

We didn't have scheduled the end to end test run and in no active development periods, we never find out about test failures. To give more visibility on the health of the repo we should run e2e tests in a logical period of time. 

As there is no frequent change in this repo, and e2e test is an expensive test, testing in every second day basis would be sufficient to keep an eye on the repo health and in the same time not spend much on heavy test process. 

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [] (Atlassian only) Internal Bamboo CI is passing
