### PR TITLE
CLIP-1597: Update workflow to run e2e test when PR is labeled as 'e2e'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,5 @@ _Provide description for the PR_
 - [ ] I have added unit tests
 - [ ] I have applied the change to all applicable products
 - [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
+- [ ] (Atlassian only) If changes were made to `src/main/charts`, I have run the E2E test
 - [ ] (Atlassian only) Internal Bamboo CI is passing

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test:
-    if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     name: Deploy Infrastructure and Run E2E Tests
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -9,10 +9,13 @@ on:
       - 'src/main/charts/bitbucket/**'
       - 'src/main/charts/confluence/**'
       - 'src/main/charts/jira/**'
+  pull_request:
+    types: [ labeled ]
   workflow_dispatch:
 
 jobs:
   test:
+    if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     name: Deploy Infrastructure and Run E2E Tests
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Update workflow to run e2e test when PR is labeled as 'e2e'

## Pull request description

This is a PR to test manual trigger for e2e test.
When external contributors raised PR. If required, reviewers can add 'e2e' label on the PR and this will trigger e2e test.

The condition to run e2e test after this PR is going to be:
- Push to main branch
- Labeled PR as 'e2e'
- Manual workflow dispatch
- On Schedule (https://github.com/atlassian/data-center-helm-charts/pull/424)

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) Internal Bamboo CI is passing
