### PR TITLE
CLIP-1597: Change trigger event from pull_request to pull_request_targe

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,5 @@ _Provide description for the PR_
 - [ ] I have added unit tests
 - [ ] I have applied the change to all applicable products
 - [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
-- [ ] (Atlassian only) If changes were made to `src/main/charts`, I have run the E2E test
+- [ ] (Atlassian only) I have run the E2E test (if applicable)
 - [ ] (Atlassian only) Internal Bamboo CI is passing

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,5 @@ _Provide description for the PR_
 - [ ] I have added unit tests
 - [ ] I have applied the change to all applicable products
 - [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
+- [ ] (Atlassian only) If changes were made to `src/main/charts`, I have run the E2E test
 - [ ] (Atlassian only) Internal Bamboo CI is passing

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   test:
-    if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     name: Deploy Infrastructure and Run E2E Tests
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -9,7 +9,7 @@ on:
       - 'src/main/charts/bitbucket/**'
       - 'src/main/charts/confluence/**'
       - 'src/main/charts/jira/**'
-  pull_request:
+  pull_request_target:
     types: [ labeled ]
   workflow_dispatch:
 

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -24,6 +24,7 @@ jobs:
       TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}
       TF_VAR_bamboo_admin_password: ${{ secrets.TF_VAR_BAMBOO_ADMIN_PASSWORD }}
       TF_VAR_bitbucket_admin_password: ${{ secrets.TF_VAR_BITBUCKET_ADMIN_PASSWORD }}
+      USE_DOMAIN: "true"
 
     steps:
       - name: Checkout Helm charts
@@ -34,7 +35,7 @@ jobs:
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:
-          version: 'v1.23.6'
+          version: 'v1.24.0'
 
       - name: Install Helm
         uses: azure/setup-helm@v1

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -9,10 +9,13 @@ on:
       - 'src/main/charts/bitbucket/**'
       - 'src/main/charts/confluence/**'
       - 'src/main/charts/jira/**'
+  pull_request:
+    types: [ labeled ]
   workflow_dispatch:
 
 jobs:
   test:
+    if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     name: Deploy Infrastructure and Run E2E Tests
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Pull request description

As part of the experiment, this PR will change workflow event trigger from `pull_request` to `pull_request_target`.

Given information https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
We can grant main repo's secret access to forked branch PR but still not sure which code the workflow will run on. It is worth test this.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) If changes were made to `src/main/charts`, I have run the E2E test
- [ ] (Atlassian only) Internal Bamboo CI is passing
