### PR TITLE
CLIP-1611: Fix the release problem by pin the docker version of quay.io/helmpack…

### DIFF
--- a/src/main/scripts/generate_chart_repo.sh
+++ b/src/main/scripts/generate_chart_repo.sh
@@ -37,7 +37,7 @@ docker run --user "$(id -u):$(id -g)" \
   -v "$(pwd)/$PACKAGE_DIR:/releases" \
   --entrypoint cr \
   --rm \
-  quay.io/helmpack/chart-releaser \
+  quay.io/helmpack/chart-releaser:v1.2.1 \
   upload \
   --skip-existing \
   --package-path /releases \
@@ -55,7 +55,7 @@ docker run \
   -v "$(pwd)/$PACKAGE_DIR:/packages" \
   --entrypoint cr \
   --rm \
-  quay.io/helmpack/chart-releaser \
+  quay.io/helmpack/chart-releaser:v1.2.1 \
   index \
   --owner atlassian \
   --git-repo data-center-helm-charts \


### PR DESCRIPTION
…/chart-releaser

Release process broken because the latest docker version of the `quay.io/helmpack/chart-releaser` deprecated `--charts-repo` and end up with an error. Pinning to the older version fixes the issue. 

_Provide description for the PR_

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
