### PR TITLE
Update _helpers.tpl

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -128,10 +128,8 @@ Pod labels
 
 {{- define "confluence.sysprop.synchronyServiceUrl" -}}
 {{- if .Values.synchrony.enabled -}}
-    {{- if .Values.ingress.https -}}
-    -Dsynchrony.service.url=https://{{ .Values.ingress.host }}/synchrony/v1
-    {{- else }}
-    -Dsynchrony.service.url=http://{{ .Values.ingress.host }}/synchrony/v1
+    {{- if .Values.ingress.https -}}-Dsynchrony.service.url=https://{{ .Values.ingress.host }}/synchrony/v1
+    {{- else }}-Dsynchrony.service.url=http://{{ .Values.ingress.host }}/synchrony/v1
     {{- end }}
 {{- else -}}
 -Dsynchrony.btf.disabled=true


### PR DESCRIPTION
Confluence Pod fails to start when Synchrony is enabled on Helm Chart 1.5.0

## Pull request description

Fix [SCALE-76](https://jira.atlassian.com/browse/SCALE-76) - Confluence Pod fails to start when Synchrony is enabled on Helm Chart 1.5.0

## Checklist
- [ No] I have added unit tests
-- I tested deployment of NON SSL and SSL and confirmed that "additional_jvm_args" from "kubectl describe configmap confluencelocal-jvm-config" appears all on one line 
- [Yes ] I have applied the change to all applicable products
-- Confluence only
- [No ] I have added the change description to the changelog.md and Chart.yaml files
- [No ] (Atlassian only) I have run the E2E test (if applicable)
- [ No] (Atlassian only) Internal Bamboo CI is passing