### PR TITLE
Ingress Class Name is moved under spec.

### DIFF
--- a/src/main/charts/bamboo/templates/ingress.yaml
+++ b/src/main/charts/bamboo/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
   {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/crowd/templates/ingress.yaml
+++ b/src/main/charts/crowd/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:


### PR DESCRIPTION
After Kubernetes 1.18 version, "ingress.class"'s annotation is
deprecated.
So deleted that annotation and add "ingressClassName" field.

ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

## Pull request description

_Provide description for the PR_

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
