### PR TITLE
Ingress Class Name is moved under spec field.

### DIFF
--- a/src/main/charts/bamboo/Changelog.md
+++ b/src/main/charts/bamboo/Changelog.md
@@ -9,6 +9,8 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 * Update Bamboo version to 9.0.0 (#455)
+* Ingress is using `spec.ingressClassName` field instead of deprecated annotation
+
 
 ## 1.5.0
 

--- a/src/main/charts/bamboo/Chart.yaml
+++ b/src/main/charts/bamboo/Chart.yaml
@@ -25,6 +25,11 @@ annotations:
       links:
       - name: Github PR
         url: https://github.com/atlassian/data-center-helm-charts/pull/455
+    - kind: changed
+      description: Ingress is using `spec.ingressClassName` field instead of deprecated annotation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/451
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/bamboo/templates/ingress.yaml
+++ b/src/main/charts/bamboo/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/bitbucket/Changelog.md
+++ b/src/main/charts/bitbucket/Changelog.md
@@ -9,6 +9,8 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 * Update Bitbucket version to 7.21.5 (#455)
+* Ingress is using `spec.ingressClassName` field instead of deprecated annotation
+
 
 ## 1.5.0
 

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -25,6 +25,11 @@ annotations:
       links:
       - name: Github PR
         url: https://github.com/atlassian/data-center-helm-charts/pull/455
+    - kind: changed
+      description: Ingress is using `spec.ingressClassName` field instead of deprecated annotation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/451
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
   {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/confluence/Changelog.md
+++ b/src/main/charts/confluence/Changelog.md
@@ -9,7 +9,9 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 * Update the default Confluence version to 7.19.2 (#455)
-* 
+* Ingress is using `spec.ingressClassName` field instead of deprecated annotation
+ 
+ 
 ## 1.5.1
 
 **Release date:** 2022-08-24

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -25,6 +25,11 @@ annotations:
       links:
       - name: Github PR
         url: https://github.com/atlassian/data-center-helm-charts/pull/455
+    - kind: changed
+      description: Ingress is using `spec.ingressClassName` field instead of deprecated annotation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/451
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -20,7 +20,7 @@ deprecated: false
 annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
-     - kind: changed
+    - kind: changed
       description: Confluence updated to 7.19.2 version
       links:
       - name: Github PR

--- a/src/main/charts/confluence/templates/ingress-setup.yaml
+++ b/src/main/charts/confluence/templates/ingress-setup.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/crowd/Changelog.md
+++ b/src/main/charts/crowd/Changelog.md
@@ -9,6 +9,8 @@
 ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 * Update Crowd version to 5.0.2 (#455)
+* Ingress is using `spec.ingressClassName` field instead of deprecated annotation
+
 
 ## 1.5.0
 

--- a/src/main/charts/crowd/Chart.yaml
+++ b/src/main/charts/crowd/Chart.yaml
@@ -25,6 +25,11 @@ annotations:
       links:
       - name: Github PR
         url: https://github.com/atlassian/data-center-helm-charts/pull/455
+    - kind: changed
+      description: Ingress is using `spec.ingressClassName` field instead of deprecated annotation
+      links:
+      - name: Github PR
+        url: https://github.com/atlassian/data-center-helm-charts/pull/451
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/crowd/templates/ingress.yaml
+++ b/src/main/charts/crowd/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/jira/Changelog.md
+++ b/src/main/charts/jira/Changelog.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 1.6.0
+
+**Release date:** TBD
+
+![AppVersion: 8.20.10](https://img.shields.io/static/v1?label=AppVersion&message=8.20.10&color=success&logo=)
+![Kubernetes: >=1.19.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.19.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Ingress is using `spec.ingressClassName` field instead of deprecated annotation
+
+
 ## 1.5.0
 
 **Release date:** 2022-07-14
@@ -10,6 +21,7 @@
 
 * Fix: Use the custom ports for Jira service (#419)
 * Update the default Jira version to 8.20.10 (#430)
+
 
 ## 1.4.1
 
@@ -33,6 +45,7 @@
 * Make pod securityContext optional (#389)
 * Support for configuring ingress proxy settings via values.yaml (#402)
 * Update Jira version to 8.20.8 (#412)
+
 
 ## 1.3.0
 

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -21,16 +21,11 @@ deprecated: false
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: added
-      description: Use the custom ports for Jira service
-      links:
-      - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/419
     - kind: changed
-      description: Jira updated to 8.20.10 version
+      description: Ingress is using `spec.ingressClassName` field instead of deprecated annotation
       links:
       - name: Github PR
-        url: https://github.com/atlassian/data-center-helm-charts/pull/430
+        url: https://github.com/atlassian/data-center-helm-charts/pull/451
 dependencies:
   - name: common
     version: 1.0.0

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-    "kubernetes.io/ingress.class": {{ default "nginx" .Values.ingress.className }}
     {{ if .Values.ingress.nginx }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
@@ -25,6 +24,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.ingress.tlsSecretName }}
 {{ end }}
+  ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -41,9 +41,6 @@ class IngressTest {
 
             assertThat(ingress.getNode("spec", "rules").required(0).path("http").path("paths").required(0).path("path"))
                     .hasTextContaining("/mypath");
-
-            assertThat(ingress.getMetadata().path("annotations"))
-                    .isObject(Map.of("kubernetes.io/ingress.class", "nginx"));
         }
     }
 
@@ -57,8 +54,8 @@ class IngressTest {
         final var ingresses = resources.getAll(Kind.Ingress);
 
         for (KubeResource ingress : ingresses) {
-            assertThat(ingress.getMetadata().path("annotations"))
-                    .isObject(Map.of("kubernetes.io/ingress.class", "my-custom-nginx"));
+            assertThat(ingress.getNode("spec").path("ingressClassName"))
+                    .hasTextContaining("my-custom-nginx");
         }
     }
 


### PR DESCRIPTION
After Kubernetes 1.18 version, "ingress.class"'s annotation is deprecated.
So deleted that annotation and add "ingressClassName" field.

ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

## Pull request description

_Provide description for the PR_

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
