### PR TITLE
AWS cleanup and log colletion from k8s after e2e tests

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -69,6 +69,14 @@ jobs:
         with:
           go-version: '1.18'
 
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - run: |
+          python -m pip install --upgrade pip
+          pip install boto3
+
       - name: Install test dependencies
         id: setup-dependencies
         working-directory: tf/test/
@@ -96,14 +104,15 @@ jobs:
           set -o pipefail
           # Create test output directory
           mkdir e2etest/artifacts
-          
+
           # Add root of helm chart repo to the config template
           cat << EOF >> ./e2etest/test-config.tfvars.tmpl
           # install local helm charts
           local_helm_charts_path="$(dirname $(dirname $(pwd)))/src/main/charts"
           EOF
-          
+
           # Deploy infrastructure, install helm charts, run e2e tests, and cleanup all
+          aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile default && aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" --profile default && aws configure set region "$AWS_DEFAULT_REGION" --profile default
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 
       - name: Upload test log files


### PR DESCRIPTION
To be merged after https://github.com/atlassian-labs/data-center-terraform/pull/265

This PR adds python environment and configures aws for boto3 python client and k8s log collection script. No changes to Helm charts, just a little change to e2e workflow.
