### PR TITLE
Update Bitbucket ingress testing values

### DIFF
--- a/src/test/config/bitbucket/values-EKS.yaml
+++ b/src/test/config/bitbucket/values-EKS.yaml
@@ -5,10 +5,10 @@ serviceAccount:
 
 ingress:
   create: true
+  className: "alb"
   nginx: false
   annotations:
     external-dns.alpha.kubernetes.io/hostname: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/certificate-arn: ${eks.ingress.certificate}
     alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
     alb.ingress.kubernetes.io/target-type: ip


### PR DESCRIPTION
This is a small fix to Bitbucket ingress testing values. After ingress class migrated from `metadata.annotations` to `spec` changes to testing values for EKS are required.
