### PR TITLE
CLIP-1566: Make it possible to configure images/tags of auxiliary containers

### DIFF
--- a/docs/docs/troubleshooting/LIMITATIONS.md
+++ b/docs/docs/troubleshooting/LIMITATIONS.md
@@ -68,6 +68,3 @@ These configurations are explicitly not supported, and the Helm charts don’t w
 * [Istio infrastructure](https://istio.io/latest/docs/ops/deployment/architecture/){.external}
     * Due to several reasons, Istio is imposing networking rules on every workload in the Kubernetes cluster that doesn't work with our deployments.
     * The current recommendation is to create an exemption for our workloads if Istio is enabled in the cluster by default.
-* Air-tight network (no outgoing requests)
-    * Some of our components are installed from publicly available repositories. When they can't reach the internet, they won’t work.
-

--- a/docs/docs/userguide/INSTALLATION.md
+++ b/docs/docs/userguide/INSTALLATION.md
@@ -165,7 +165,44 @@ license:
       emailAddressSecretKey: emailAddress
     ```
 
-## 8. Install your chosen product
+## 8. Configure container images
+
+By default, container images are pulled from [official Atlassian DockerHub repositories](https://hub.docker.com/u/atlassian). Deployments may also use 2 other official non-Altassian images - [alpine](https://hub.docker.com/_/alpine) and [fluentd](https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset).
+
+In air-gapped environments that cannot directly access DockerHub you will need to pass custom repositories/tags to the Helm installation/upgrade command.
+
+### Product images
+
+For product images (such as Jira, Bitbucket, Confluence, Bamboo), update `values.yaml`:
+
+```
+image:
+  registry: artifactory.mycompany.com
+  repository: jira
+  tag: 7.8.20
+```
+
+### Helper containers
+
+If `volumes.sharedHome.persistentVolumeClaim.sharedHome.nfsPermissionFixer.enabled` is set to `true`, update `values.yaml`:
+
+```
+volumes:
+  sharedHome:
+    nfsPermissionFixer:
+      imageRepo: artifactory.mycompany.com/alpine
+      imageTag: latest
+```
+
+If `fluentd.enabled` is set to `true` (false by default), update `values.yaml`:
+
+```
+fluentd:
+  imageRepo: artifactory.mycompany.com/fluentd-kubernetes-daemonset
+  imageTag: v1.11.5-debian-elasticsearch7-1.2
+```
+
+## 9. Install your chosen product
 
 ```shell
 helm install <release-name> \

--- a/src/main/charts/bamboo/templates/_fluentd_templates.tpl
+++ b/src/main/charts/bamboo/templates/_fluentd_templates.tpl
@@ -1,7 +1,7 @@
 {{- define "fluentd.container" -}}
 {{ if .Values.fluentd.enabled }}
 - name: fluentd
-  image: {{ .Values.fluentd.imageName }}
+  image: {{ .Values.fluentd.imageRepo }}:{{ .Values.fluentd.imageTag }}
   command: ["sh", "-c", {{ include "fluentd.start.command" . | quote }}]
   volumeMounts:
     - name: local-home

--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -37,7 +37,7 @@ spec:
         {{- include "bamboo.additionalInitContainers" . | nindent 8 }}
         {{- if .Values.volumes.sharedHome.nfsPermissionFixer.enabled }}
         - name: nfs-permission-fixer
-          image: alpine
+          image: {{ .Values.volumes.sharedHome.nfsPermissionFixer.imageRepo }}:{{ .Values.volumes.sharedHome.nfsPermissionFixer.imageTag }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0 # make sure we run as root so we get the ability to change the volume permissions

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -265,6 +265,13 @@ volumes:
       #
       mountPath: "/shared-home"
 
+      # -- Image repository for the permission fixer init container. Defaults to alpine
+      #
+      imageRepo: alpine
+      # -- Image tag for the permission fixer init container. Defaults to latest
+      #
+      imageTag: latest
+
       # -- By default, the fixer will change the group ownership of the volume's root directory
       # to match the Bamboo container's GID (2001), and then ensures the directory is
       # group-writeable. If this is not the desired behaviour, command used can be specified
@@ -725,9 +732,12 @@ fluentd:
   #
   enabled: false
 
-  # -- The Fluentd sidecar image
+  # -- The Fluentd sidecar image repository
   #
-  imageName: fluent/fluentd-kubernetes-daemonset:v1.11.5-debian-elasticsearch7-1.2
+  imageRepo: fluent/fluentd-kubernetes-daemonset
+  # -- The Fluentd sidecar image tag
+  #
+  imageTag: v1.11.5-debian-elasticsearch7-1.2
 
   # -- The command used to start Fluentd. If not supplied the default command
   # will be used: "fluentd -c /fluentd/etc/fluent.conf -v"

--- a/src/main/charts/bitbucket/templates/_fluentd_templates.tpl
+++ b/src/main/charts/bitbucket/templates/_fluentd_templates.tpl
@@ -1,7 +1,7 @@
 {{- define "fluentd.container" -}}
 {{ if .Values.fluentd.enabled }}
 - name: fluentd
-  image: {{ .Values.fluentd.imageName }}
+  image: {{ .Values.fluentd.imageRepo }}:{{ .Values.fluentd.imageTag }}
   command: ["sh", "-c", {{ include "fluentd.start.command" . | quote }}]
   volumeMounts:
     - name: local-home

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
         {{- include "bitbucket.additionalInitContainers" . | nindent 8 }}
         {{- if and .Values.volumes.sharedHome.nfsPermissionFixer.enabled (or .Values.volumes.sharedHome.persistentVolumeClaim.create .Values.volumes.sharedHome.customVolume) }}
         - name: nfs-permission-fixer
-          image: alpine
+          image: {{ .Values.volumes.sharedHome.nfsPermissionFixer.imageRepo }}:{{ .Values.volumes.sharedHome.nfsPermissionFixer.imageTag }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0 # make sure we run as root so we get the ability to change the volume permissions

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -334,7 +334,14 @@ volumes:
       # -- The path in the K8s initContainer where the shared-home volume will be mounted
       #
       mountPath: "/shared-home"
-      
+
+      # -- Image repository for the permission fixer init container. Defaults to alpine
+      #
+      imageRepo: alpine
+      # -- Image tag for the permission fixer init container. Defaults to latest
+      #
+      imageTag: latest
+
       # -- By default, the fixer will change the group ownership of the volume's root directory
       # to match the Bitbucket container's GID (2003), and then ensures the directory is
       # group-writeable. If this is not the desired behaviour, command used can be specified
@@ -817,9 +824,12 @@ fluentd:
   #
   enabled: false
   
-  # -- The Fluentd sidecar image
+  # -- The Fluentd sidecar image repository
   #
-  imageName: fluent/fluentd-kubernetes-daemonset:v1.11.5-debian-elasticsearch7-1.2
+  imageRepo: fluent/fluentd-kubernetes-daemonset
+  # -- The Fluentd sidecar image tag
+  #
+  imageTag: v1.11.5-debian-elasticsearch7-1.2
 
   # -- The command used to start Fluentd. If not supplied the default command
   # will be used: "fluentd -c /fluentd/etc/fluent.conf -v"

--- a/src/main/charts/confluence/templates/_fluentd_templates.tpl
+++ b/src/main/charts/confluence/templates/_fluentd_templates.tpl
@@ -1,7 +1,7 @@
 {{- define "fluentd.container" -}}
 {{ if .Values.fluentd.enabled }}
 - name: fluentd
-  image: {{ .Values.fluentd.imageName }}
+  image: {{ .Values.fluentd.imageRepo }}:{{ .Values.fluentd.imageTag }}
   command: ["sh", "-c", {{ include "fluentd.start.command" . | quote }}]
   ports:
     - containerPort: {{ .Values.fluentd.httpPort }}

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         {{- include "confluence.additionalInitContainers" . | nindent 8 }}
         {{- if .Values.volumes.sharedHome.nfsPermissionFixer.enabled }}
         - name: nfs-permission-fixer
-          image: alpine
+          image: {{ .Values.volumes.sharedHome.nfsPermissionFixer.imageRepo }}:{{ .Values.volumes.sharedHome.nfsPermissionFixer.imageTag }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0 # make sure we run as root so we get the ability to change the volume permissions

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -284,7 +284,14 @@ volumes:
       # -- The path in the K8s initContainer where the shared-home volume will be mounted
       #
       mountPath: "/shared-home"
-      
+
+      # -- Image repository for the permission fixer init container. Defaults to alpine
+      #
+      imageRepo: alpine
+      # -- Image tag for the permission fixer init container. Defaults to latest
+      #
+      imageTag: latest
+
       # -- By default, the fixer will change the group ownership of the volume's root directory
       # to match the Confluence container's GID (2002), and then ensures the directory is
       # group-writeable. If this is not the desired behaviour, command used can be specified
@@ -894,9 +901,12 @@ fluentd:
   #
   enabled: false
   
-  # -- The Fluentd sidecar image
+  # -- The Fluentd sidecar image repository
   #
-  imageName: fluent/fluentd-kubernetes-daemonset:v1.11.5-debian-elasticsearch7-1.2
+  imageRepo: fluent/fluentd-kubernetes-daemonset
+  # -- The Fluentd sidecar image tag
+  #
+  imageTag: v1.11.5-debian-elasticsearch7-1.2
 
   # -- The command used to start Fluentd. If not supplied the default command
   # will be used: "fluentd -c /fluentd/etc/fluent.conf -v"

--- a/src/main/charts/crowd/templates/_fluentd_templates.tpl
+++ b/src/main/charts/crowd/templates/_fluentd_templates.tpl
@@ -1,7 +1,7 @@
 {{- define "fluentd.container" -}}
 {{ if .Values.fluentd.enabled }}
 - name: fluentd
-  image: {{ .Values.fluentd.imageName }}
+  image: {{ .Values.fluentd.imageRepo }}:{{ .Values.fluentd.imageTag }}
   command: ["sh", "-c", {{ include "fluentd.start.command" . | quote }}]
   ports:
     - containerPort: {{ .Values.fluentd.httpPort }}

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         {{- include "crowd.additionalInitContainers" . | nindent 8 }}
         {{- if .Values.volumes.sharedHome.nfsPermissionFixer.enabled }}
         - name: nfs-permission-fixer
-          image: alpine
+          image: {{ .Values.volumes.sharedHome.nfsPermissionFixer.imageRepo }}:{{ .Values.volumes.sharedHome.nfsPermissionFixer.imageTag }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0 # make sure we run as root so we get the ability to change the volume permissions

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -456,9 +456,12 @@ fluentd:
   #
   enabled: false
 
-  # -- The Fluentd sidecar image
+  # -- The Fluentd sidecar image repository
   #
-  imageName: fluent/fluentd-kubernetes-daemonset:v1.11.5-debian-elasticsearch7-1.2
+  imageRepo: fluent/fluentd-kubernetes-daemonset
+  # -- The Fluentd sidecar image tag
+  #
+  imageTag: v1.11.5-debian-elasticsearch7-1.2
 
   # -- The command used to start Fluentd. If not supplied the default command
   # will be used: "fluentd -c /fluentd/etc/fluent.conf -v"
@@ -640,6 +643,13 @@ volumes:
       # -- The path in the K8s initContainer where the shared-home volume will be mounted
       #
       mountPath: /shared-home
+
+      # -- Image repository for the permission fixer init container. Defaults to alpine
+      #
+      imageRepo: alpine
+      # -- Image tag for the permission fixer init container. Defaults to latest
+      #
+      imageTag: latest
 
       # -- By default, the fixer will change the group ownership of the volume's root directory
       # to match the Crowd container's GID (2002), and then ensures the directory is

--- a/src/main/charts/jira/templates/_fluentd_templates.tpl
+++ b/src/main/charts/jira/templates/_fluentd_templates.tpl
@@ -1,7 +1,7 @@
 {{- define "fluentd.container" -}}
 {{ if .Values.fluentd.enabled }}
 - name: fluentd
-  image: {{ .Values.fluentd.imageName }}
+  image: {{ .Values.fluentd.imageRepo }}:{{ .Values.fluentd.imageTag }}
   command: ["sh", "-c", {{ include "fluentd.start.command" . | quote }}]
   volumeMounts:
     - name: fluentd-config

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         {{- include "jira.additionalInitContainers" . | nindent 8 }}
         {{- if .Values.volumes.sharedHome.nfsPermissionFixer.enabled }}
         - name: nfs-permission-fixer
-          image: alpine
+          image: {{ .Values.volumes.sharedHome.nfsPermissionFixer.imageRepo }}:{{ .Values.volumes.sharedHome.nfsPermissionFixer.imageTag }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0 # make sure we run as root so we get the ability to change the volume permissions

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -266,6 +266,13 @@ volumes:
       # -- The path in the K8s initContainer where the shared-home volume will be mounted
       #
       mountPath: "/shared-home"
+
+      # -- Image repository for the permission fixer init container. Defaults to alpine
+      #
+      imageRepo: alpine
+      # -- Image tag for the permission fixer init container. Defaults to latest
+      #
+      imageTag: latest
       
       # -- By default, the fixer will change the group ownership of the volume's root directory
       # to match the Jira container's GID (2001), and then ensures the directory is
@@ -638,9 +645,12 @@ fluentd:
   #
   enabled: false
   
-  # -- The Fluentd sidecar image
+  # -- The Fluentd sidecar image repository
   #
-  imageName: fluent/fluentd-kubernetes-daemonset:v1.11.5-debian-elasticsearch7-1.2
+  imageRepo: fluent/fluentd-kubernetes-daemonset
+  # -- The Fluentd sidecar image tag
+  #
+  imageTag: v1.11.5-debian-elasticsearch7-1.2
 
   # -- The command used to start Fluentd. If not supplied the default command
   # will be used: "fluentd -c /fluentd/etc/fluent.conf -v"

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -82,7 +82,7 @@ spec:
         fsGroup: 2005
       initContainers:
         - name: nfs-permission-fixer
-          image: alpine
+          image: alpine:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0 # make sure we run as root so we get the ability to change the volume permissions

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -222,7 +222,7 @@ spec:
           ip: 192.168.1.1
       initContainers:
         - name: nfs-permission-fixer
-          image: alpine
+          image: alpine:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0 # make sure we run as root so we get the ability to change the volume permissions

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -89,7 +89,7 @@ spec:
         fsGroup: 2004
       initContainers:
         - name: nfs-permission-fixer
-          image: alpine
+          image: alpine:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0 # make sure we run as root so we get the ability to change the volume permissions

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -84,7 +84,7 @@ spec:
         fsGroup: 2001
       initContainers:
         - name: nfs-permission-fixer
-          image: alpine
+          image: alpine:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0 # make sure we run as root so we get the ability to change the volume permissions


### PR DESCRIPTION
Fixes https://github.com/atlassian/data-center-helm-charts/issues/411

A small change to values and templates to be able to pass custom image and tag to nfs permission fixes init container and fluentd sidecar (if enabled)

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
