### PR TITLE
Pin Python version to 3.9.14

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.9.14'
       - run: |
           python -m pip install --upgrade pip
           pip install boto3


### PR DESCRIPTION
See: https://github.com/atlassian-labs/data-center-terraform/pull/270

Pinning python version to make sure pythonpath is correct (required to execute aws_clan.py script)
