### PR TITLE
CLIP-1709: Raise PRs with the latest app versions

### DIFF
--- a/.github/workflows/update-lts-tags.yaml
+++ b/.github/workflows/update-lts-tags.yaml
@@ -2,7 +2,7 @@ name: Update LTS Tags
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5' # At 00:00 on every day-of-week from Monday through Friday
+    - cron: '0 0 * * SUN' # At 00:00 on every Sunday
 
 jobs:
   tls_check:

--- a/.github/workflows/update-lts-tags.yaml
+++ b/.github/workflows/update-lts-tags.yaml
@@ -1,0 +1,54 @@
+name: Update LTS Tags
+
+on:
+  schedule:
+    - cron: '0 0 * * 1-5' # At 00:00 on every day-of-week from Monday through Friday
+
+jobs:
+  tls_check:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9.14'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml requests
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Update LTS tags in Helm charts
+        run: |
+          cd src/test/scripts
+          python update_versions.py
+
+      - name: Commit changes and raise a PR
+        run: |
+          CHANGES=$(git status --porcelain=v1 2>/dev/null | wc -l)
+          if [ ${CHANGES} -ne 0 ]; then
+            gh pr list --state open | grep "Update appVersions for DC apps"
+            if [ $? -ne 0 ]; then
+              echo "Not raising PR because there are open PRs to upgrade versions. Merge or close them to let the workflow raise new PRs"
+            else
+              git checkout -b lts-tag-update-${GITHUB_RUN_ID}
+              git add -A
+              git commit -m "Update appVersions for DC apps"
+              git push origin lts-tag-update-${GITHUB_RUN_ID}
+              gh pr create --label "e2e" --title "Update appVersions for DC apps" --body "Update appVersions for DC apps" --base main --head lts-tag-update-${GITHUB_RUN_ID}
+            fi
+          else
+            echo "All Helm charts have the latest LTS appVersion"
+          fi


### PR DESCRIPTION
This PR adds a new workflow to be run raily. It will reuse existing script that checks the latest LTS app versions and modifies Chart.yaml and well expected output yaml (for unit tests) with new versions. If there are no changes, it'll do nothing.  If there's an **open** PR with the name "Update appVersions for DC apps", the script won't create a new one.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
