### PR TITLE
CLIP-1709: Fix 1 exit code when fetching PRs

### DIFF
--- a/.github/workflows/update-lts-tags.yaml
+++ b/.github/workflows/update-lts-tags.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * SUN' # At 00:00 on every Sunday
 
 jobs:
-  tls_check:
+  lts_check:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,12 +39,12 @@ jobs:
         run: |
           CHANGES=$(git status --porcelain=v1 2>/dev/null | wc -l)
           if [ ${CHANGES} -ne 0 ]; then
-            gh pr list --state open | grep "Update appVersions for DC apps"
-            if [ $? -ne 0 ]; then
+            OPEN_PRS=$(gh pr list --state open | grep "Update appVersions for DC apps" || true)
+            if [[ ${OPEN_PRS} ]]; then
               echo "Not raising PR because there are open PRs to upgrade versions. Merge or close them to let the workflow raise new PRs"
             else
               git checkout -b lts-tag-update-${GITHUB_RUN_ID}
-              git add -A
+              git add src
               git commit -m "Update appVersions for DC apps"
               git push origin lts-tag-update-${GITHUB_RUN_ID}
               gh pr create --label "e2e" --title "Update appVersions for DC apps" --body "Update appVersions for DC apps" --base main --head lts-tag-update-${GITHUB_RUN_ID}

--- a/.github/workflows/update-lts-tags.yaml
+++ b/.github/workflows/update-lts-tags.yaml
@@ -44,7 +44,7 @@ jobs:
               echo "Not raising PR because there are open PRs to upgrade versions. Merge or close them to let the workflow raise new PRs"
             else
               git checkout -b lts-tag-update-${GITHUB_RUN_ID}
-              git add src
+              git add -A
               git commit -m "Update appVersions for DC apps"
               git push origin lts-tag-update-${GITHUB_RUN_ID}
               gh pr create --label "e2e" --title "Update appVersions for DC apps" --body "Update appVersions for DC apps" --base main --head lts-tag-update-${GITHUB_RUN_ID}


### PR DESCRIPTION
Just a small fixup to handle 1 exit code from grep (if there are no open PRs with a pre-defined title). The workflow was failing when grep returned 1 (i.e. there are no open PRs)

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
