### PR TITLE
CLIP-1715: Use local helm charts in e2e tests

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -111,6 +111,10 @@ jobs:
           cat << EOF >> ./e2etest/test-config.tfvars.tmpl
           # install local helm charts
           local_helm_charts_path="$(dirname $(dirname $(pwd)))/src/main/charts"
+          confluence_install_local_chart = true
+          jira_install_local_chart = true
+          bitbucket_install_local_chart = true
+          bamboo_install_local_chart = true
           EOF
 
           # Deploy infrastructure, install helm charts, run e2e tests, and cleanup all


### PR DESCRIPTION
Currently, when e2e tests are kicked off, local helm charts aren't used, even though `local_helm_charts_path` [is defined](https://github.com/atlassian/data-center-helm-charts/blob/main/.github/workflows/e2e-tf-deployment.yaml#L113).

However, in [locals.tf](https://github.com/atlassian-labs/data-center-terraform/blob/main/locals.tf#L13) there's a double condition. By default, `_*install_local_chart` [is false](https://github.com/atlassian-labs/data-center-terraform/blob/6074f403035f419f842f2800cb042d572ba944bd/variables.tf#L358).

Taking a look at [Terraform logs](https://github.com/atlassian/data-center-helm-charts/actions/runs/3458274209/jobs/5786932502#step:13:756), we can see that local charts aren't used, moreover, a pretty old version is deployed (this is fixed by https://github.com/atlassian-labs/data-center-terraform/pull/284)

To use local charts, `local_helm_charts_path` needs to be defined and `$app_install_local_chart` needs to be set to true.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
