### PR TITLE
CLIP-1554: Automatically set ATL_DB_VALIDATIONQUERY for oracle db type

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -477,9 +477,11 @@ volumeClaimTemplates:
       name: {{ . }}
       key: {{ $.Values.database.credentials.passwordSecretKey }}
 {{ end }}
-{{- if and (.Values.database.type) (contains "oracle" .Values.database.type ) }}
+{{- if .Values.database.type }}
+{{- if contains "oracle" .Values.database.type }}
 - name: ATL_DB_VALIDATIONQUERY
   value: "select 1 from dual"
+{{- end }}
 {{- end }}
 {{ end }}
 

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -477,6 +477,10 @@ volumeClaimTemplates:
       name: {{ . }}
       key: {{ $.Values.database.credentials.passwordSecretKey }}
 {{ end }}
+{{- if and (.Values.database.type) (contains "oracle" .Values.database.type ) }}
+- name: ATL_DB_VALIDATIONQUERY
+  value: "select 1 from dual"
+{{- end }}
 {{ end }}
 
 {{- define "synchrony.databaseEnvVars" -}}

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -281,9 +281,11 @@ volumeClaimTemplates:
       name: {{ . }}
       key: {{ $.Values.database.credentials.passwordSecretKey }}
 {{ end }}
-{{- if and (.Values.database.type) (contains "oracle" .Values.database.type ) }}
+{{- if .Values.database.type }}
+{{- if contains "oracle" .Values.database.type }}
 - name: ATL_DB_VALIDATIONQUERY
   value: "select 1 from dual"
+{{- end }}
 {{- end }}
 {{ end }}
 

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -281,6 +281,10 @@ volumeClaimTemplates:
       name: {{ . }}
       key: {{ $.Values.database.credentials.passwordSecretKey }}
 {{ end }}
+{{- if and (.Values.database.type) (contains "oracle" .Values.database.type ) }}
+- name: ATL_DB_VALIDATIONQUERY
+  value: "select 1 from dual"
+{{- end }}
 {{ end }}
 
 {{- define "jira.clusteringEnvVars" -}}

--- a/src/test/java/test/DatabaseTest.java
+++ b/src/test/java/test/DatabaseTest.java
@@ -99,4 +99,16 @@ class DatabaseTest {
                 .assertHasSecretRef("ATL_JDBC_USER", "mysecret", "myusername")
                 .assertHasSecretRef("ATL_JDBC_PASSWORD", "mysecret", "mypassword");
     }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"jira", "confluence"})
+    void atl_db_validation_query_test(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "database.type", "oracle10g"));
+
+        resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getEnv()
+                .assertHasValue("ATL_DB_VALIDATIONQUERY", "select 1 from dual");
+    }
 }


### PR DESCRIPTION
Just a nice little improvement - setting `ATL_DB_VALIDATIONQUERY="select 1 from dual"` if `database.type` is oracle (Confluence) or `oracle10g` (Jira). 

Fixes https://github.com/atlassian/data-center-helm-charts/issues/447

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
