### PR TITLE
Fix additionalJvmArgs parameter for Synchrony

### DIFF
--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -883,7 +883,7 @@ synchrony:
   # -- Specifies a list of additional arguments that can be passed to the Synchrony JVM, e.g.
   # system properties.
   #
-  additionalJvmArgs: {}
+  additionalJvmArgs: []
     #- -Dsynchrony.example.system.property=46
 
   shutdown:


### PR DESCRIPTION
## Pull request description

Currently a dict is used in the default values for additionalJvmArgs, but the helm charts expects a list. Essentially this is a typo of {} instead of [].

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
