### PR TITLE
Set Hazelcast port env var for Confluence and Synchrony

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -506,6 +506,8 @@ volumeClaimTemplates:
       fieldPath: metadata.namespace
 - name: HAZELCAST_KUBERNETES_SERVICE_NAME
   value: {{ include "common.names.fullname" . | quote }}
+- name: HAZELCAST_KUBERNETES_SERVICE_PORT
+  value: {{ .Values.confluence.ports.hazelcast | quote }}
 - name: ATL_CLUSTER_TYPE
   value: "kubernetes"
 - name: ATL_CLUSTER_NAME
@@ -521,6 +523,8 @@ volumeClaimTemplates:
       fieldPath: metadata.namespace
 - name: HAZELCAST_KUBERNETES_SERVICE_NAME
   value: {{ include "synchrony.fullname" . | quote }}
+- name: HAZELCAST_KUBERNETES_SERVICE_PORT
+  value: {{ .Values.synchrony.ports.hazelcast | quote }}
 - name: CLUSTER_JOIN_TYPE
   value: "kubernetes"
 {{ end }}


### PR DESCRIPTION
See: https://jira.atlassian.com/browse/SCALE-70 and https://jira.atlassian.com/browse/SCALE-71

This PR fixes hazelcast discovery for Confluence and Synchrony by explicitly setting `HAZELCAST_KUBERNETES_SERVICE_PORT ` to the value provided in values.yaml.

_Provide description for the PR_

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [x] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
