### PR TITLE
CLIP-1644: Stop supporting 1.19-1.20 k8s

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,9 +23,9 @@ jobs:
           java-version: 11
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.7.1
+          version: v3.9.4
 
       - name: Execute helm dependency update for bamboo chart
         run: helm dependency update src/main/charts/bamboo

--- a/docs/docs/userguide/PREREQUISITES.md
+++ b/docs/docs/userguide/PREREQUISITES.md
@@ -1,13 +1,13 @@
-# Prerequisites 
-## Requirements 
+# Prerequisites
+## Requirements
 
 In order to deploy Atlassian’s Data Center products, the following is required:
 
 1. An understanding of [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/){.external} and [Helm](https://helm.sh/){.external} concepts.
-2. [`kubectl` `v1.19` or later](https://kubernetes.io/docs/tasks/tools/), must be compatible with your cluster.
+2. [`kubectl` `v1.21` or later](https://kubernetes.io/docs/tasks/tools/), must be compatible with your cluster.
 3. [`helm` `v3.3` or later.](https://helm.sh/docs/intro/install/)
 
-## Environment setup 
+## Environment setup
 
 Before installing the Data Center Helm charts you need to set up your environment:
 
@@ -18,13 +18,13 @@ Before installing the Data Center Helm charts you need to set up your environmen
 5. [Configure a local-home volume](#configure-local-home-volume)
 
 !!!info "Elasticsearch for Bitbucket"
-    We highly recommend you use an external Elasticsearch installation for Bitbucket. When you run more than one node you need to have a separate Elasticsearch cluster to enable code search. See [Bitbucket Elasticsearch recommendations](../examples/bitbucket/BITBUCKET_ELASTICSEARCH.md). 
-    
+    We highly recommend you use an external Elasticsearch installation for Bitbucket. When you run more than one node you need to have a separate Elasticsearch cluster to enable code search. See [Bitbucket Elasticsearch recommendations](../examples/bitbucket/BITBUCKET_ELASTICSEARCH.md).
+
 ---
 
 ### :material-kubernetes: Create and connect to the Kubernetes cluster
 
-* In order to install the charts to your Kubernetes cluster (version 1.19+), your Kubernetes client config must be configured appropriately, and you must have the necessary permissions.
+* In order to install the charts to your Kubernetes cluster (version 1.21+), your Kubernetes client config must be configured appropriately, and you must have the necessary permissions.
 * It is up to you to set up security policies.
 
 !!!example ""
@@ -32,7 +32,7 @@ Before installing the Data Center Helm charts you need to set up your environmen
 
 ### :material-directions-fork: Provision an Ingress Controller
 
-* This step is necessary in order to make your Atlassian product available from outside of the Kubernetes cluster after deployment. 
+* This step is necessary in order to make your Atlassian product available from outside of the Kubernetes cluster after deployment.
 * The Kubernetes project supports and maintains ingress controllers for the major cloud providers including; [AWS](https://github.com/kubernetes-sigs/aws-load-balancer-controller#readme){.external}, [GCE](https://github.com/kubernetes/ingress-gce/blob/master/README.md#readme){.external} and [nginx](https://github.com/kubernetes/ingress-nginx/blob/master/README.md#readme){.external}. There are also a number of open-source [third-party projects available](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/){.external}.
 * Because different Kubernetes clusters use different ingress configurations/controllers, the Helm charts provide [Ingress Object](https://kubernetes.io/docs/concepts/services-networking/ingress/){.external} templates only.
 * The Ingress resource provided as part of the Helm charts is geared toward the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/){.external} and can be configured via the `ingress` stanza in the appropriate `values.yaml` (an alternative controller can be used).
@@ -44,7 +44,7 @@ Before installing the Data Center Helm charts you need to set up your environmen
 ### :material-database: Provision a database
 
 * Must be of a type and version supported by the Data Center product you wish to install:
-  
+
 === "Jira"
       [Supported databases](https://confluence.atlassian.com/adminjiraserver/supported-platforms-938846830.html#Supportedplatforms-Databases){.external}
 === "Confluence"
@@ -56,11 +56,11 @@ Before installing the Data Center Helm charts you need to set up your environmen
 === "Crowd"
       [Supported databases](https://confluence.atlassian.com/crowd/supported-platforms-191851.html#SupportedPlatforms-Databases){.external}
 
-* Must be reachable from the product deployed within your Kubernetes cluster. 
+* Must be reachable from the product deployed within your Kubernetes cluster.
 * The database service may be deployed within the same Kubernetes cluster as the Data Center product or elsewhere.
 * The products need to be provided with the information they need to connect to the database service. Configuration for each product is mostly the same, with some small differences. For more information go to the [Database connectivity section of the configuration guide](CONFIGURATION.md#database-connectivity).
 
-!!!info "Reducing pod to database latency" 
+!!!info "Reducing pod to database latency"
 
       For better performance consider co-locating your database in the same Availability Zone (AZ) as your product nodes. Database-heavy operations, such as full re-index, become significantly faster when the database is collocated with the Data Center node in the same AZ. However we don't recommend this if you're running critical workloads.
 
@@ -72,14 +72,14 @@ Before installing the Data Center Helm charts you need to set up your environmen
 * All of the Data Center products require a shared network filesystem if they are to be operated in multi-node clusters. If no shared filesystem is available, the products can only be operated in single-node configuration.
 * Some cloud based options for a shared filesystem include [AWS EFS](https://aws.amazon.com/efs/){.external} and [Azure Files](https://docs.microsoft.com/en-us/azure/storage/files/storage-files-introduction){.external}. You can also stand up your own NFS
 * The logical representation of the chosen storage type within Kubernetes can be defined as `PersistentVolumes` with an associated `PersistentVolumeClaims` in a `ReadWriteMany (RWX)` access mode.
-* For more information about volumes see the [Volumes section of the configuration guide](CONFIGURATION.md#volumes). 
+* For more information about volumes see the [Volumes section of the configuration guide](CONFIGURATION.md#volumes).
 
 !!!example ""
       See examples of [creating shared storage](../examples/storage/STORAGE.md).
 
 ### :material-folder-home: Configure local-home volume
-* As with the [shared-home](#configure-a-shared-home-volume), each pod requires its own volume for `local-home`. Each product needs this for defining operational data. 
-* If not defined, an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir){.external} will be utilised. 
+* As with the [shared-home](#configure-a-shared-home-volume), each pod requires its own volume for `local-home`. Each product needs this for defining operational data.
+* If not defined, an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir){.external} will be utilised.
 * Although an `emptyDir` may be acceptable for evaluation purposes, we recommend that each pod is allocated its own volume.
 * A `local-home` volume could be logically represented within the cluster using a `StorageClass`. This will dynamically provision an [AWS EBS](https://aws.amazon.com/ebs/?ebs-whats-new.sort-by=item.additionalFields.postDateTime&ebs-whats-new.sort-order=desc){.external} volume to each pod.
 

--- a/src/main/charts/bamboo-agent/Chart.yaml
+++ b/src/main/charts/bamboo-agent/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart for installing Bamboo Data Center remote agents on Kubernet
 type: application
 version: 1.7.1
 appVersion: 9.0.1
-kubeVersion: ">=1.19.x-0"
+kubeVersion: ">=1.21.x-0"
 keywords:
   - Bamboo
   - Bamboo Agent

--- a/src/main/charts/bamboo/Chart.yaml
+++ b/src/main/charts/bamboo/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart for installing Bamboo Data Center on Kubernetes
 type: application
 version: 1.7.1
 appVersion: 9.0.1
-kubeVersion: ">=1.19.x-0"
+kubeVersion: ">=1.21.x-0"
 keywords:
   - Bamboo
   - Bamboo Server

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart for installing Bitbucket Data Center on Kubernetes
 type: application
 version: 1.7.1
 appVersion: 7.21.7
-kubeVersion: ">=1.19.x-0"
+kubeVersion: ">=1.21.x-0"
 keywords:
   - Bitbucket
   - Bitbucket Server

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart for installing Confluence Data Center on Kubernetes
 type: application
 version: 1.7.1
 appVersion: 7.19.3
-kubeVersion: ">=1.19.x-0"
+kubeVersion: ">=1.21.x-0"
 keywords:
   - Confluence
   - Confluence Server

--- a/src/main/charts/crowd/Chart.yaml
+++ b/src/main/charts/crowd/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart for installing Crowd Data Center on Kubernetes
 type: application
 version: 1.7.1
 appVersion: 5.0.3
-kubeVersion: ">=1.19.x-0"
+kubeVersion: ">=1.21.x-0"
 keywords:
   - Crowd
   - Crowd Server

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -4,7 +4,7 @@ description: A chart for installing Jira Data Center on Kubernetes
 type: application
 version: 1.7.1
 appVersion: 9.4.0
-kubeVersion: ">=1.19.x-0"
+kubeVersion: ">=1.21.x-0"
 keywords:
   - Jira
   - Jira Software


### PR DESCRIPTION
Bump version of minimal supported K8s API version

## Checklist
- [ ] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
