### PR TITLE
Use ingress.https to enable https in ingress

### DIFF
--- a/src/main/charts/bamboo/templates/ingress.yaml
+++ b/src/main/charts/bamboo/templates/ingress.yaml
@@ -18,11 +18,13 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{ if and (.Values.ingress.tlsSecretName) (.Values.ingress.host) }}
+{{ if and (.Values.ingress.https) (.Values.ingress.host) }}
   tls:
     - hosts:
         - {{ .Values.ingress.host }}
+      {{ if .Values.ingress.tlsSecretName }}
       secretName: {{ .Values.ingress.tlsSecretName }}
+      {{ end }}
 {{ end }}
   ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -18,11 +18,13 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{ if and (.Values.ingress.tlsSecretName) (.Values.ingress.host) }}
+{{ if and (.Values.ingress.https) (.Values.ingress.host) }}
   tls:
     - hosts:
         - {{ .Values.ingress.host }}
+      {{ if .Values.ingress.tlsSecretName }}
       secretName: {{ .Values.ingress.tlsSecretName }}
+      {{ end }}
 {{ end }}
   ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -18,11 +18,13 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{ if and (.Values.ingress.tlsSecretName) (.Values.ingress.host) }}
+{{ if and (.Values.ingress.https) (.Values.ingress.host) }}
   tls:
     - hosts:
         - {{ .Values.ingress.host }}
+      {{ if .Values.ingress.tlsSecretName }}
       secretName: {{ .Values.ingress.tlsSecretName }}
+      {{ end }}
 {{ end }}
   ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:

--- a/src/main/charts/crowd/templates/ingress.yaml
+++ b/src/main/charts/crowd/templates/ingress.yaml
@@ -18,11 +18,13 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{ if and (.Values.ingress.tlsSecretName) (.Values.ingress.host) }}
+{{ if and (.Values.ingress.https) (.Values.ingress.host) }}
   tls:
     - hosts:
         - {{ .Values.ingress.host }}
+      {{ if .Values.ingress.tlsSecretName }}
       secretName: {{ .Values.ingress.tlsSecretName }}
+      {{ end }}
 {{ end }}
   ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -18,11 +18,13 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{ if and (.Values.ingress.tlsSecretName) (.Values.ingress.host) }}
+{{ if and (.Values.ingress.https) (.Values.ingress.host) }}
   tls:
     - hosts:
         - {{ .Values.ingress.host }}
+      {{ if .Values.ingress.tlsSecretName }}
       secretName: {{ .Values.ingress.tlsSecretName }}
+      {{ end }}
 {{ end }}
   ingressClassName: {{ default "nginx" .Values.ingress.className }}
   rules:


### PR DESCRIPTION
## Pull request description

ingress.tlsSecretName was used to enable https in the ingress. This forces to use a TLS secret, but in some cases the default tls secret for the
 default ingress can be used.
In the case the default TLS secret for the default ingress controller should be used
 it is not possible to leave ingress.tlsSecretName enpty and simply set ingress.https to true.

## Checklist
- [ ] I have added unit tests
- [X] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
