### PR TITLE
CLIP-1721: Introduce Kubernetes in Docker (KinD) tests

### DIFF
--- a/.github/workflows/dc-tests.yml
+++ b/.github/workflows/dc-tests.yml
@@ -1,0 +1,50 @@
+# This workflow is for testing Helm charts in KinD clusters
+
+name: DC apps tests in KinD
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '**.xml'
+      - '**.yaml'
+      - '**.properties'
+      - 'LICENSE'
+      - 'Makefile'
+      - '.gitignore'
+      - '.java-version'
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+
+  jira:
+    uses: ./.github/workflows/kind.yaml
+    with:
+      dc_app: jira
+    secrets:
+      JIRA_LICENSE: "${{ secrets.JIRA_LICENSE }}"
+
+  confluence:
+    uses: ./.github/workflows/kind.yaml
+    with:
+      dc_app: confluence
+    secrets:
+      CONFLUENCE_LICENSE: "${{ secrets.TF_VAR_CONFLUENCE_LICENSE }}"
+
+  bitbucket:
+    uses: ./.github/workflows/kind.yaml
+    with:
+      dc_app: bitbucket
+    secrets:
+      BITBUCKET_LICENSE: "${{ secrets.TF_VAR_BITBUCKET_LICENSE }}"
+
+  bamboo:
+    uses: ./.github/workflows/kind.yaml
+    with:
+      dc_app: bamboo
+    secrets:
+      BAMBOO_LICENSE: "${{ secrets.TF_VAR_BAMBOO_LICENSE }}"

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -1,0 +1,92 @@
+name: Test DC App in a KinD Cluster
+
+on:
+  workflow_call:
+    inputs:
+      dc_app:
+        required: true
+        type: string
+    secrets:
+      BITBUCKET_LICENSE:
+        description: 'Bitbucket license'
+      CONFLUENCE_LICENSE:
+        description: 'Confluence license'
+      JIRA_LICENSE:
+        description: 'Jira license'
+      BAMBOO_LICENSE:
+        description: 'Bamboo license'
+
+jobs:
+  kind-testing:
+    runs-on: ubuntu-latest
+    env:
+      # See: https://github.com/kubernetes-sigs/kind/tags
+      KIND_VERSION: "v0.17.0"
+      # See: https://hub.docker.com/r/kindest/node/tags
+      K8S_VERSION: "v1.25.3"
+      DC_APP: ${{inputs.dc_app}}
+      LICENSE: ${{ secrets[format('{0}_LICENSE', inputs.dc_app)] }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Pin Kubectl version
+        uses: azure/setup-kubectl@v3.0
+        with:
+          version: 'v1.25.3'
+
+      - name: Pin Helm version
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.9.2
+
+      - name: Create KinD cluster
+        run: |
+          src/test/scripts/kind/create_kind.sh
+
+      - name: Install KinD tooling
+        run: |
+          src/test/scripts/kind/configure_kind.sh
+
+      - name: Deploy postgres database
+        run: |
+          source src/test/scripts/kind/deploy_app.sh
+          deploy_postgres
+
+      - name: Create db, admin and license secrets
+        run: |
+          source src/test/scripts/kind/deploy_app.sh
+          create_secrets
+
+      - name: Deploy ${{inputs.dc_app}}
+        run: |
+          source src/test/scripts/kind/deploy_app.sh
+          deploy_app
+
+      - name: Verify ${{inputs.dc_app}} status
+        run: |
+          source src/test/scripts/kind/deploy_app.sh
+          verify_ingress
+
+      - name: Test scaling ${{inputs.dc_app}}
+        run: |
+          echo "[INFO]: Scaling ${DC_APP} to 2 replicas"
+          kubectl scale sts/${DC_APP} --replicas=2 -n atlassian
+          sleep 10
+          kubectl wait --for=condition=ready pod/${DC_APP}-1 -n atlassian --timeout=360s
+
+      - name: Get debug info
+        if: always()
+        run: |
+          kubectl get pods -n atlassian
+          kubectl describe pvc -n atlassian
+          kubectl describe nodes
+          curl -s https://raw.githubusercontent.com/atlassian-labs/data-center-terraform/main/scripts/collect_k8s_logs.sh | bash -s -- dummy dummy logs/${{inputs.dc_app}}
+
+      - name: Upload test log files
+        if: always()
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: kind-artifacts
+          path: logs/

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -79,9 +79,6 @@ jobs:
       - name: Get debug info
         if: always()
         run: |
-          kubectl get pods -n atlassian
-          kubectl describe pvc -n atlassian
-          kubectl describe nodes
           curl -s https://raw.githubusercontent.com/atlassian-labs/data-center-terraform/main/scripts/collect_k8s_logs.sh | bash -s -- dummy dummy logs/${{inputs.dc_app}}
 
       - name: Upload test log files

--- a/src/test/config/kind/common-values.yaml
+++ b/src/test/config/kind/common-values.yaml
@@ -1,0 +1,47 @@
+DC_APP_REPLACEME:
+  # claim little resources as there are limitations in GitHub actions
+  resources:
+    container:
+      requests:
+        cpu: 20m
+        memory: 1G
+  # we want to test scaling to 2 and making sure nodes have joined the cluster
+  clustering:
+    enabled: true
+
+  sysadminCredentials:
+    secretName: DC_APP_REPLACEME-admin
+  displayName: DC_APP_REPLACEME
+
+  license:
+    secretName: DC_APP_REPLACEME-app-license
+    secretKey: license
+
+  # this applies to Bamboo only and will be ignored in other Helm charts
+  disableAgentAuth: true
+
+database:
+  type: DB_TYPE_REPLACEME
+  url: jdbc:postgresql://postgres:5432/DC_APP_REPLACEME
+  driver: org.postgresql.Driver
+  credentials:
+    secretName: DC_APP_REPLACEME-db-creds
+
+# nfs volume provisioner and nfs server are deployed to KinD cluster
+# thus we can create PVCs and expect them to be bound to PVs that provisioner will create
+volumes:
+  localHome:
+    persistentVolumeClaim:
+      create: true
+  sharedHome:
+    persistentVolumeClaim:
+      create: true
+      # this is the default storageclass name created when deploying the provisioner
+      storageClassName: nfs-client
+
+# KinD is deployed with custom settings, namely extraPortMappings for ports 80 and 443
+# to make sure ingress traffic is available at http://localhost
+ingress:
+  create: true
+  host: localhost
+  https: false

--- a/src/test/config/kind/common-values.yaml
+++ b/src/test/config/kind/common-values.yaml
@@ -9,6 +9,7 @@ DC_APP_REPLACEME:
   clustering:
     enabled: true
 
+  # this works for Bitbucket and Bamboo only which support unattended setup
   sysadminCredentials:
     secretName: DC_APP_REPLACEME-admin
   displayName: DC_APP_REPLACEME

--- a/src/test/config/kind/kind-config.yml
+++ b/src/test/config/kind/kind-config.yml
@@ -1,0 +1,24 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  # this is required due to weird nginx controller behavior where it needs to redirect smth to
+  # /dev/null but can't do it due to permission issues. The workaround is to mount /dev into control plane container
+  extraMounts:
+  - hostPath: /dev
+    containerPath: /dev
+  # the below config is required to properly install and use Nginx ingress
+  # and use localhost to access DC applications
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP

--- a/src/test/config/kind/nfs-values.yaml
+++ b/src/test/config/kind/nfs-values.yaml
@@ -1,0 +1,11 @@
+# this will go to StorageClass spec to make sure RWX volumes are mounted with the correct settings
+nfs:
+  mountOptions:
+  - rw
+  - lookupcache=pos
+  - noatime
+  - intr
+  - _netdev
+  - nfsvers=3
+  - rsize=32768
+  - wsize=32768

--- a/src/test/scripts/kind/configure_kind.sh
+++ b/src/test/scripts/kind/configure_kind.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+kubectl cluster-info
+echo "[INFO]: current-context:" $(kubectl config current-context)
+echo "[INFO]: environment-kubeconfig:" "${KUBECONFIG}"
+
+kubectl create namespace atlassian
+echo "[INFO]: Deploy Nginx ingress controller"
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+kubectl wait --for=condition=ready pod \
+        --selector=app.kubernetes.io/component=controller \
+        --timeout=90s \
+        -n ingress-nginx
+
+echo "[INFO]: Deploy NFS server"
+helm install nfs src/test/infrastructure/nfs-server \
+     -n atlassian \
+     --timeout=360s \
+     --wait
+
+nfs_server_ip=$(kubectl get svc/nfs-nfs-server -n atlassian -o jsonpath='{.spec.clusterIP}')
+
+echo "[INFO]: Deploy NFS volume provisioner. Using ${nfs_server_ip} as NFS server IP"
+helm repo add nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
+helm repo update
+
+helm install nfs-volume-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+     -f src/test/config/kind/nfs-values.yaml \
+     --set nfs.server=${nfs_server_ip} \
+     --set nfs.path=/srv/nfs \
+     -n atlassian \
+     --timeout=360s \
+     --wait

--- a/src/test/scripts/kind/create_kind.sh
+++ b/src/test/scripts/kind/create_kind.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-$(uname)-amd64"
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+
+kind create cluster --name=atl-kind \
+                    --image=kindest/node:${K8S_VERSION} \
+                    --config=src/test/config/kind/kind-config.yml \
+                    --wait=5m

--- a/src/test/scripts/kind/deploy_app.sh
+++ b/src/test/scripts/kind/deploy_app.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+deploy_postgres() {
+  echo "[INFO]: Installing Postgres Helm chart"
+  helm repo add bitnami https://charts.bitnami.com/bitnami --force-update
+  helm install postgres bitnami/postgresql \
+       --set postgresqlDatabase="${DC_APP}" \
+       --set postgresqlUsername="${DC_APP}" \
+       --set postgresqlPassword="${DC_APP}pwd" \
+       --set image.tag="11" \
+       --set fullnameOverride="postgres" \
+       --set persistence.enabled=false \
+       --version="10.16.2" \
+       --wait --timeout=120s \
+       -n atlassian
+}
+
+create_secrets() {
+  echo "[INFO]: Creating db, admin and license secrets"
+
+  kubectl create secret generic ${DC_APP}-db-creds \
+          --from-literal=username="${DC_APP}" \
+          --from-literal=password="${DC_APP}pwd" \
+          -n atlassian
+  kubectl create secret generic ${DC_APP}-admin \
+          --from-literal=username="admin" \
+          --from-literal=password="${DC_APP}pwd" \
+          --from-literal=displayName="${DC_APP}" \
+          --from-literal=emailAddress="${DC_APP}@example.com" \
+          -n atlassian
+  kubectl create secret generic ${DC_APP}-app-license \
+          --from-literal=license=${LICENSE} \
+          -n atlassian
+}
+
+deploy_app() {
+  cd src/main/charts/${DC_APP}
+  helm repo add atlassian-data-center https://atlassian.github.io/data-center-helm-charts
+  helm repo update
+  helm dependency build
+  DB_TYPE="postgresql"
+  if [ ${DC_APP} == "jira" ]; then
+    DB_TYPE="postgres72"
+  fi
+  sed -i "s/DC_APP_REPLACEME/${DC_APP}/g" ../../../test/config/kind/common-values.yaml
+  sed -i "s/DB_TYPE_REPLACEME/${DB_TYPE}/g" ../../../test/config/kind/common-values.yaml
+  helm upgrade --install ${DC_APP} ./ \
+               -f ../../../test/config/kind/common-values.yaml \
+               -n atlassian \
+               --wait --timeout=360s \
+               --debug
+
+  if [ ${DC_APP} == "bamboo" ]; then
+    echo "[INFO]: Deploying Bamboo agent..."
+    cd ../bamboo-agent
+    helm dependency build
+    helm upgrade --install bamboo-agent ./ -n atlassian \
+                 --set agent.server=bamboo.atlassian.svc.cluster.local \
+                 --set agent.resources.container.requests.cpu=20m \
+                 --wait --timeout=360s --debug
+  fi
+}
+
+verify_ingress() {
+  STATUS_ENDPOINT_PATH="status"
+  if [ ${DC_APP} == "bamboo" ]; then
+    STATUS_ENDPOINT_PATH="rest/api/latest/status"
+  fi
+  echo "[INFO]: Checking ${DC_APP} status"
+  # give ingress controller a few seconds before polling
+  sleep 5
+  for i in {1..10}; do
+    STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost/${STATUS_ENDPOINT_PATH})
+    if [ $STATUS -ne 200 ]; then
+      echo "[ERROR]: Status code is not 200. Waiting 10 seconds"
+      sleep 10
+    else
+      echo "[INFO]: Received status ${STATUS}"
+      curl -s http://localhost/${STATUS_ENDPOINT_PATH}
+      echo -e "\n"
+      break
+    fi
+  done
+  if [ $STATUS -ne 200 ]; then
+  curl -v http://localhost/${STATUS_ENDPOINT_PATH}
+   exit 1
+  fi
+}


### PR DESCRIPTION
This PR adds a new reusable workflow (see checks in this PR below) that:

* creates a [KinD cluster](https://github.com/kubernetes-sigs/kind). Both K8S API and KinD versions are configurable.
* deploys Nginx ingress controller, NFS server and NFS client provisioner that automatically creates RWX PVs when a PVC is created
* deploys Postgres DB (Bitnami Helm chart) for each app
* deploys Bitbucket, Confluence, Jira and Bamboo (each in its own job, i.e. in its own cluster) with persistence and ingress enabled in values. The values have a few modifications related to lack of CPU, so requests had to be cut a bit. Apps supporting unattended setup use the corresponding values. Database, admin user and license env vars are added to all Helm releases. When Bamboo is deployed, Bamboo agent chart is also installed, agent is pointed to the server, and auto approval is turned on in server
* waits for the helm chart to be successfully deployed
* verifies endpoint status (sadly, it's not possible to run helm test since apps are available on localhost, and tests are run in a container)
* scales each app to 2 replicas and verifies the second pod is in Ready status (i.e. passes its readiness probe)
* collects k8s logs/events from each job and saves them as artifacts

What this PR is not:

* integration/func tests can be pointed to localhost and kind kube context but this is not in the scope of this PR

Existing limitations:
* for some reason when synchrony is enabled the job just hangs soon after a Synchrony pod is starting, and it's not possible to get any K8s logs/events to troubleshoot. KinD runs in a privileged container in docker, so odds are that either NFS mounts make it sad (when synchrony pod mounts shared home) or there are other issues related to nested virtualization. For now, Synchrony is disabled
* Bundled Elasticsearch for now
* Crowd isn't tested for now

The workflow is triggered when:

* push to main branch
* a PR is opened
* someone starts it manually from a selected branch

It takes <10 mins to run the workflow (Bitbucket is the slowest but we have 2vCPU only, so it's expected)

Next steps/improvements:
* figure out Synchrony issue in KinD
* deploy standalone Elasticsearch and force Bitbucket use it
* use existing test suite in KinD or write a new one with a series of functional tests

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
