### PR TITLE
CLIP-1729: Assume IAM role instead to get AWS credentials for tests

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -128,7 +128,8 @@ jobs:
           # Deploy infrastructure, install helm charts, run e2e tests, and cleanup all
           # boto3 ignores AWS creds env vars for some reason
           mkdir -p ~/.aws
-          echo -e "[default]\naws_access_key_id = ${AWS_ACCESS_KEY_ID}\naws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}\naws_session_token = ${AWS_SESSION_TOKEN}" > ~/.aws/credentials          go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
+          echo -e "[default]\naws_access_key_id = ${AWS_ACCESS_KEY_ID}\naws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}\naws_session_token = ${AWS_SESSION_TOKEN}" > ~/.aws/credentials
+          go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 
       - name: Upload test log files
         if: always()

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -20,10 +20,11 @@ jobs:
     if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     name: Deploy Infrastructure and Run E2E Tests
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       AWS_DEFAULT_REGION: us-east-1
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       TF_VAR_bamboo_license: ${{ secrets.TF_VAR_BAMBOO_LICENSE }}
       TF_VAR_confluence_license: ${{ secrets.TF_VAR_CONFLUENCE_LICENSE }}
       TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}
@@ -38,6 +39,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          role-session-name: DCTerraformHelmSession
 
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
@@ -118,8 +126,9 @@ jobs:
           EOF
 
           # Deploy infrastructure, install helm charts, run e2e tests, and cleanup all
-          aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile default && aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" --profile default && aws configure set region "$AWS_DEFAULT_REGION" --profile default
-          go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
+          # boto3 ignores AWS creds env vars for some reason
+          mkdir -p ~/.aws
+          echo -e "[default]\naws_access_key_id = ${AWS_ACCESS_KEY_ID}\naws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}\naws_session_token = ${AWS_SESSION_TOKEN}" > ~/.aws/credentials          go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 
       - name: Upload test log files
         if: always()

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -40,13 +40,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
-          role-session-name: DCTerraformHelmSession
-
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:
@@ -107,6 +100,14 @@ jobs:
         run: |
           echo ${{ secrets.BITBUCKET_E2E_TEST_PUB_SSH_KEY }} > /home/runner/.ssh/bitbucket-e2e.pub
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          role-session-name: DCTerraformHelmSession
+          role-duration-seconds: 7200
+  
       - name: Deploy the infrastructure, install helm charts, run E2E tests, and cleanup
         id: e2e-test
         working-directory: tf/test/


### PR DESCRIPTION
This PR adds an official [AWS action](https://github.com/aws-actions/configure-aws-credentials) to assume a role (saved in actions secrets).

Run from the branch ✅  https://github.com/atlassian/data-center-helm-charts/actions/runs/3723318978/jobs/6314758186

Also, opened https://github.com/atlassian-labs/data-center-terraform/pull/296


## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [x] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
