### PR TITLE
feat: Added support for configuring healthcheckPath to Synchrony readinessProbe

### DIFF
--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -54,7 +54,7 @@ spec:
           readinessProbe:
             httpGet:
               port: {{ .Values.synchrony.ports.http }}
-              path: /heartbeat
+              path: {{ .Values.synchrony.readinessProbe.healthcheckPath }}
             initialDelaySeconds: {{ .Values.synchrony.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.synchrony.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.synchrony.readinessProbe.failureThreshold }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -829,6 +829,12 @@ synchrony:
   #
   readinessProbe:
 
+    # -- The healthcheck path to check against for the Synchrony container 
+    # useful when configuring behind a reverse-proxy or loadbalancer such as "/synchrony/heartbeat"
+    # https://confluence.atlassian.com/confkb/cannot-enable-collaborative-editing-on-synchrony-cluster-962962742.html
+    #
+    healthcheckPath: "/heartbeat"
+
     # -- The initial delay (in seconds) for the Synchrony container readiness probe,
     # after which the probe will start running.
     #

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -830,10 +830,10 @@ synchrony:
   readinessProbe:
 
     # -- The healthcheck path to check against for the Synchrony container 
-    # useful when configuring behind a reverse-proxy or loadbalancer such as "/synchrony/heartbeat"
+    # useful when configuring behind a reverse-proxy or loadbalancer
     # https://confluence.atlassian.com/confkb/cannot-enable-collaborative-editing-on-synchrony-cluster-962962742.html
     #
-    healthcheckPath: "/heartbeat"
+    healthcheckPath: "/synchrony/heartbeat"
 
     # -- The initial delay (in seconds) for the Synchrony container readiness probe,
     # after which the probe will start running.

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -164,7 +164,7 @@ spec:
           readinessProbe:
             httpGet:
               port: 8091
-              path: /heartbeat
+              path: /synchrony/heartbeat
             initialDelaySeconds: 5
             periodSeconds: 1
             failureThreshold: 10


### PR DESCRIPTION
## Pull request description

When setting up my external Google Cloud Ingress (not using Nginx Ingress), we need the ability to configure the healthcheck path. As documented, Synchrony expects the path to include "/synchrony" to be included in all requests. If not, we were seeing healthchecks returning back a `204 No Content`.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
