### PR TITLE
Use 2.0 tag of the nfs test image in kind

### DIFF
--- a/src/test/scripts/kind/configure_kind.sh
+++ b/src/test/scripts/kind/configure_kind.sh
@@ -17,6 +17,7 @@ kubectl wait --for=condition=ready pod \
 
 echo "[INFO]: Deploy NFS server"
 helm install nfs src/test/infrastructure/nfs-server \
+    --set image.tag=2.0 \
      -n atlassian \
      --timeout=360s \
      --wait


### PR DESCRIPTION
Bamboo and Bitbucket kind tests are failing because both apps do not proceed with unattended setup and thus can't scale and Bamboo can't register agents. The problem can only be reproduced in kind. Overriding image tag fixes the problem.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
