### PR TITLE
Prepare release script: Remove Jira keys and wrap strings in double quotes

### DIFF
--- a/src/main/scripts/prepare-release.py
+++ b/src/main/scripts/prepare-release.py
@@ -50,16 +50,17 @@ def gen_changelog(repo_path):
 
     changelog = cli.log(f'{lasttag}..main', graph=True, pretty='format:%s', abbrev_commit=True, date='relative')
     changelog = changelog.split('\n')
-
-    return list(filter(changelog_filter, changelog))
+    filtered_changelog = list(filter(changelog_filter, changelog))
+    sanitized_changelog = map(lambda c: re.sub(r'CLIP-[0-9]{2,4}(?![0-9]): ', '', c), filtered_changelog)
+    return list(sanitized_changelog)
 
 
 def format_changelog_yaml(changelog):
     # The artifacthub annotations are a single string, but formatted
     # like YAML. Replacing the leading '*' with '-' should be
     # sufficient.
-    c2 = map(lambda c: re.sub(r'^\* ', '- ', c), changelog)
-    return '\n'.join(c2)
+    c2 = map(lambda c: re.sub(r'^\* ', '- "', c), changelog)
+    return '\n'.join(c2) + "\""
 
 
 def update_changelog_file(version, changelog, chartversions):


### PR DESCRIPTION
Just two small changes:

* wrap strings in double quotes for artifacthub.io annotations
* get rid of Jira ticket key in changelog and artifacthub.io annotations

Here's example git diff:

```
--- a/src/main/charts/bamboo-agent/Chart.yaml
+++ b/src/main/charts/bamboo-agent/Chart.yaml
-  artifacthub.io/changes: |
-    - kind: changed
-      description: Fix artifact hub annotation yaml
+  artifacthub.io/changes: |-
+    - "Hello World"

+## 1.9.2
+
+**Release date:** 2023-2-16
+
+![AppVersion: 9.2.1](https://img.shields.io/static/v1?label=AppVersion&message=9.2.1&color=success&logo=)
+![Kubernetes: >=1.21.x-0](https://img.shields.io/static/v1?label=Kubernetes&message=>=1.21.x-0&color=informational&logo=kubernetes)
+![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+* Hello World
```

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
