### PR TITLE
CLIP-1774: Generate release notes for each product individually

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,63 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Prepare Release
+
+on:
+  push:
+    branches:
+      - release/*
+
+jobs:
+  prepare-release:
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PYTHONPATH: /opt/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Test git
+        run: |
+          git --version
+          git log --graph --pretty=format:%s --abbrev-commit --date=relative jira-1.9.1..main -- src/main/charts/bamboo
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.9.4
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9.14'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip gitpython ruamel_yaml
+
+      - name: Generate changelog and Chart annotations
+        run: |
+          echo "[INFO]: Preparing release ${GITHUB_REF_NAME##*/}"
+          python src/main/scripts/prepare_release.py ${GITHUB_REF_NAME##*/}
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Commit changes and raise a PR
+        run: |
+          git status
+          git add -A
+          git commit -m "Prepare release ${GITHUB_REF_NAME##*/}"
+          git push origin ${GITHUB_REF_NAME}
+          gh pr create --title "Release/${GITHUB_REF_NAME##*/}" --body "Prepare to release ${GITHUB_REF_NAME##*/}" --base main --head ${GITHUB_REF_NAME}

--- a/src/main/scripts/prepare-release.py
+++ b/src/main/scripts/prepare-release.py
@@ -1,4 +1,3 @@
-
 import git
 import logging as log
 import os
@@ -13,13 +12,6 @@ from tempfile import mkstemp
 products = ["bamboo", "bamboo-agent",
             "bitbucket", "confluence", "crowd", "jira"]
 prodbase = "src/main/charts"
-
-
-# TODO: As a first pass this currently only filters anything tagged
-# with 'CLIP-nnn'. However there are other options; see
-# https://hello.atlassian.net/wiki/spaces/DCD/pages/2108707663/DACI+Automating+the+Helm+release+process
-def changelog_filter(log_entry):
-    return re.match(r'^\*\s+CLIP-[0-9]+', log_entry) != None
 
 
 def get_chart_versions():
@@ -40,60 +32,78 @@ def get_chart_versions():
 
     return versions
 
-def gen_changelog(repo_path):
-    repo = git.Repo(repo_path)
-    cli = git.Git(repo_path)
+
+def gen_changelog(product):
+    repo = git.Repo(".")
+    cli = git.Git(".")
 
     lasttag = repo.tags[-1]
     tagver = re.sub(r'^[^-]+-', '', lasttag.name)
-    log.info(f'Generating changelog since {tagver}')
+    log.info(f'Generating {product} changelog since {tagver}')
 
-    changelog = cli.log(f'{lasttag}..main', graph=True, pretty='format:%s', abbrev_commit=True, date='relative')
+    # git log will pick up commins in src/main/charts/$product directory only
+    changelog = cli.log(f'{lasttag}..main', prodbase + '/' + product, graph=True, pretty='format:%s',
+                        abbrev_commit=True, date='relative', )
+
+    if not changelog:
+        # It is possible that there are no commits to the Helm chart,
+        # in this case we just write a generic git log
+        log.info(f'No commits to {product} Helm chart found')
+        default_git_log = '* Update Helm chart version'
+        changelog = default_git_log
+
     changelog = changelog.split('\n')
-    filtered_changelog = list(filter(changelog_filter, changelog))
-    sanitized_changelog = map(lambda c: re.sub(r'CLIP-[0-9]{2,4}(?![0-9]): ', '', c), filtered_changelog)
-    return list(sanitized_changelog)
+    filtered_changelog = list(changelog)
+
+    # remove Jira keys from commit messages. This substitution assumes the commit message may have the following format:
+    # CLIP-1234: Here is my message
+    # DCCLIP-1234: Here is my message
+    sanitized_changelog = map(lambda c: re.sub(r'(CLIP|DCCLIP)-[0-9]{4}(?![0-9]): ', '', c), filtered_changelog)
+    return list(dict.fromkeys(sanitized_changelog))
 
 
 def format_changelog_yaml(changelog):
     # The artifacthub annotations are a single string, but formatted
-    # like YAML. Replacing the leading '*' with '-' should be
-    # sufficient.
+    # like YAML. Replacing the leading '*' with '-'  and wrapping
+    # strings in double quotes should be sufficient.
     c2 = map(lambda c: re.sub(r'^\* ', '- "', c), changelog)
     return '\n'.join(c2) + "\""
 
 
-def update_changelog_file(version, changelog, chartversions):
-    for prod in products:
-        log.info(f"Updating {prod} Changelog.md to {version}")
+def update_changelog_file(product, version, changelog, chartversions):
+    log.info(f"Updating {product} Changelog.md to {version}")
+    proddir = f"{prodbase}/{product}"
+    clfile = f"{proddir}/Changelog.md"
+    (tmpfd, tmpname) = mkstemp(dir=proddir, text=True)
 
-        proddir = f"{prodbase}/{prod}"
-        clfile = f"{proddir}/Changelog.md"
-        (tmpfd, tmpname) = mkstemp(dir=proddir, text=True)
+    foundfirst = False
+    with open(clfile, 'r') as clfd:
+        for line in clfd:
+            if not foundfirst and re.match(r'^## [0-9]\.[0-9]\.[0-9]', line) != None:
+                # First version line, inject ours before it
+                foundfirst = True
 
-        foundfirst = False
-        with open(clfile, 'r') as clfd:
-            for line in clfd:
-                if not foundfirst and re.match(r'^## [0-9]\.[0-9]\.[0-9]', line) != None:
-                    # First version line, inject ours before it
-                    foundfirst = True
+                kver = chartversions[product]['kubeVersion']
+                appver = chartversions[product]['appVersion']
+                now = datetime.now()
+                os.write(tmpfd, ("## %s\n\n" % version).encode())
+                os.write(tmpfd, ("**Release date:** %s-%s-%s\n\n" % (now.year, now.month, now.day)).encode())
+                os.write(tmpfd, (
+                        '![AppVersion: %s](https://img.shields.io/static/v1?label=AppVersion&message=%s&color=success&logo=)\n' % (
+                    appver, appver)).encode())
+                os.write(tmpfd, (
+                        '![Kubernetes: %s](https://img.shields.io/static/v1?label=Kubernetes&message=%s&color=informational&logo=kubernetes)\n' % (
+                    kver, kver)).encode())
+                os.write(tmpfd,
+                         '![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)\n\n'.encode())
+                for change in changelog:
+                    os.write(tmpfd, ('%s\n' % change).encode())
+                os.write(tmpfd, '\n'.encode())
 
-                    kver = chartversions[prod]['kubeVersion']
-                    appver = chartversions[prod]['appVersion']
-                    now = datetime.now()
-                    os.write(tmpfd, ("## %s\n\n" % version).encode())
-                    os.write(tmpfd, ("**Release date:** %s-%s-%s\n\n" % (now.year, now.month, now.day)).encode())
-                    os.write(tmpfd, ('![AppVersion: %s](https://img.shields.io/static/v1?label=AppVersion&message=%s&color=success&logo=)\n' % (appver, appver)).encode())
-                    os.write(tmpfd, ('![Kubernetes: %s](https://img.shields.io/static/v1?label=Kubernetes&message=%s&color=informational&logo=kubernetes)\n' % (kver, kver)).encode())
-                    os.write(tmpfd, '![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)\n\n'.encode())
-                    for change in changelog:
-                        os.write(tmpfd, ('%s\n' % change).encode())
-                    os.write(tmpfd, '\n'.encode())
+            os.write(tmpfd, line.encode())
 
-                os.write(tmpfd, line.encode())
-
-        os.close(tmpfd)
-        os.rename(tmpname, clfile)
+    os.close(tmpfd)
+    os.rename(tmpname, clfile)
 
 
 def update_helm_dependencies(product):
@@ -106,32 +116,32 @@ def update_helm_dependencies(product):
         sys.exit(-1)
 
 
-def update_charts_yaml(version, changelog):
-    for prod in products:
-        log.info(f"Updating {prod} Chart.yaml to {version}")
+def update_charts_yaml(product, version, changelog):
+    log.info(f"Updating {product} Chart.yaml to {version}")
+    proddir = f"{prodbase}/{product}"
+    chartfile = f"{proddir}/Chart.yaml"
 
-        proddir = f"{prodbase}/{prod}"
-        chartfile = f"{proddir}/Chart.yaml"
+    with open(chartfile, 'r') as chart:
+        yaml = YAML()
+        yaml.preserve_quotes = True
+        chartyaml = yaml.load(chart)
 
-        with open(chartfile, 'r') as chart:
-            yaml = YAML()
-            yaml.preserve_quotes = True
-            chartyaml = yaml.load(chart)
+    chartyaml['version'] = version
+    chartyaml['annotations']['artifacthub.io/changes'] = format_changelog_yaml(changelog)
 
-        chartyaml['version'] = version
-        chartyaml['annotations']['artifacthub.io/changes'] = format_changelog_yaml(changelog)
+    with open(chartfile, 'w') as chart:
+        yaml.dump(chartyaml, chart)
 
-        with open(chartfile, 'w') as chart:
-            yaml.dump(chartyaml, chart)
-
-        update_helm_dependencies(prod)
+    update_helm_dependencies(product)
 
 
 def update_output_tests():
     log.info("Running Maven to update the unit test output")
 
-    update_o = subprocess.run(['mvn', 'test', '-B', '-Dtest=test.HelmOutputComparisonTest#record_helm_template_output_matches_expectations', '-DrecordOutput=true'],
-                              capture_output=True)
+    update_o = subprocess.run(
+        ['mvn', 'test', '-B', '-Dtest=test.HelmOutputComparisonTest#record_helm_template_output_matches_expectations',
+         '-DrecordOutput=true'],
+        capture_output=True)
     if update_o.returncode != 0:
         log.error("Failed to update the unittest comparison data: \n%s", re.sub(r'\\n', '\n', str(update_o.stdout)))
         sys.exit(-1)
@@ -152,12 +162,11 @@ def main():
     log.info(f"Updating Helm charts to release {args.version}")
 
     chartversions = get_chart_versions()
-    changelog = gen_changelog(".")
-    log.info('Changelog:\n%s' % '\n'.join(changelog))
-
-    update_changelog_file(args.version, changelog, chartversions)
-
-    update_charts_yaml(args.version, changelog)
+    for product in products:
+        changelog = gen_changelog(product)
+        log.info(product + ' changelog:\n%s' % '\n'.join(changelog))
+        update_changelog_file(product, args.version, changelog, chartversions)
+        update_charts_yaml(product, args.version, changelog)
 
     update_output_tests()
 

--- a/src/main/scripts/prepare_release.py
+++ b/src/main/scripts/prepare_release.py
@@ -33,9 +33,9 @@ def get_chart_versions():
     return versions
 
 
-def gen_changelog(product):
-    repo = git.Repo(".")
-    cli = git.Git(".")
+def gen_changelog(product, path):
+    repo = git.Repo(path)
+    cli = git.Git(path)
 
     lasttag = repo.tags[-1]
     tagver = re.sub(r'^[^-]+-', '', lasttag.name)
@@ -163,7 +163,7 @@ def main():
 
     chartversions = get_chart_versions()
     for product in products:
-        changelog = gen_changelog(product)
+        changelog = gen_changelog(product, ".")
         log.info(product + ' changelog:\n%s' % '\n'.join(changelog))
         update_changelog_file(product, args.version, changelog, chartversions)
         update_charts_yaml(product, args.version, changelog)


### PR DESCRIPTION
This PR introduces a few changes to the release script, namely:

* there's no filtering by Jira issue key, so all commits are picked up
* changelog is generated for each product - adding path to chart root to git log command. If there are no changes, the default "Update Helm chart version" is added to changelog
* remove duplicate git log messages (like `Update appVersions for DC apps` which is committed every week by a bot)
* renames the script to be able to all a function to get changelog:

```
python3 -c 'import prepare_release; print (prepare_release.gen_changelog("bamboo", "/Users/user/projects/forks/atlassian/data-center-helm-charts"))'
['* Bamboo readme']
```

Ideally, the changelog should not require any editing or deep review after the release script generates it.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [ ] (Atlassian only) Internal Bamboo CI is passing
