### PR TITLE
Skip mesh deployment to KITT

### DIFF
--- a/src/test/config/bitbucket/values-KITT.yaml
+++ b/src/test/config/bitbucket/values-KITT.yaml
@@ -30,10 +30,3 @@ bitbucket:
   mesh:
     podAnnotations:
       "atlassian.com/business_unit": "server_engineering"
-    enabled: true
-    nodeAutoRegistration: true
-    setByDefault: true
-
-image:
-  # test Bitbucket mesh
-  tag: 8.6.1


### PR DESCRIPTION
Just minor cleanup to fix CI. KITT values were hardcoded for testing purposes. Mesh tests run in a different Bamboo plan

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] I have added the change description to the `changelog.md` and `Chart.yaml` files
- [ ] (Atlassian only) I have run the E2E test (if applicable)
- [x] (Atlassian only) Internal Bamboo CI is passing
