### PR TITLE
CLIP-1782: Improve release script and add unit tests

### DIFF
--- a/.github/workflows/release-unit-tests.yaml
+++ b/.github/workflows/release-unit-tests.yaml
@@ -1,0 +1,30 @@
+name: Release Script Unit Testing
+
+on:
+  push:
+    paths:
+      - 'src/main/scripts/prepare_*'
+  workflow_dispatch:
+
+jobs:
+  run-release-unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9.14'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip gitpython ruamel_yaml
+
+      - name: Run release unit tests
+        run: |
+          python src/main/scripts/prepare_release_test.py

--- a/src/main/scripts/prepare_release_test.py
+++ b/src/main/scripts/prepare_release_test.py
@@ -1,0 +1,75 @@
+import unittest
+import logging
+from prepare_release import gen_changelog, format_changelog_yaml
+
+update_versions_message = "* Update appVersions for DC apps"
+jira_key1 = "CLIP-1234"
+jira_key2 = "DCCLIP-1234"
+
+test_git_log = "* Something got updated\n" \
+               + update_versions_message + " (#589)\n" \
+               + update_versions_message + " (#589)\n" \
+                                           "* Prepare release 1.10.12\n" \
+                                           "* " + jira_key1 + ": Fixing a bug\n" \
+                                           "* " + jira_key2 + ": Developing a feature\n" \
+               + update_versions_message + " (#535)\n" \
+               + update_versions_message + " (#543)"
+
+no_git_log_messages = ""
+
+print('Test git log:\n' + test_git_log)
+git_log = gen_changelog("bamboo", ".", test_git_log, True)
+empty_git_log = gen_changelog("bamboo", ".", no_git_log_messages, True)
+
+print('\nProcessed git log:')
+for message in git_log:
+    print(message)
+print('\n')
+
+
+class TestGitLog(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.INFO)
+        self.logger.info("Running test: {}".format(self._testMethodName))
+
+    def test_remove_messages_with_smaller_pr_numbers(self):
+        # asset that only commit message that starts with '* Update appVersions for DC apps'
+        # and has the most recent commit in brackets is left in git log
+        self.assertNotIn(update_versions_message + " (#533)", git_log)
+        self.assertNotIn(update_versions_message + " (#543)", git_log)
+        self.assertTrue(any(update_versions_message + " (#589)" in element for element in git_log))
+
+    def test_remove_messages_matching_pattern(self):
+        # assert commit messages that match the pattern are dropped
+        self.assertNotIn('* Prepare release', git_log)
+
+    def test_remove_jira_keys_from_messages(self):
+        # assert Jira keys are removed from git log
+        self.assertNotIn(jira_key1, git_log)
+        self.assertNotIn(jira_key2, git_log)
+        # asset the rest of the commit message makes it in the git log
+        self.assertTrue(any('Developing a feature' in element for element in git_log))
+        self.assertTrue(any('Fixing a bug' in element for element in git_log))
+
+    def test_duplicate_messages(self):
+        # set(git_log) will automatically remove duplicates from a list which will fail the assertion if that's the case
+        self.assertCountEqual(git_log, set(git_log))
+
+    def test_empty_git_log(self):
+        # assert that if there are no commits, the default git log is returned
+        self.assertEqual(empty_git_log[0], '* Update Helm chart version')
+
+    def test_formatting(self):
+        formatted_changelog = format_changelog_yaml(git_log)
+        # assert '*' chars are removed and replaced with '-',
+        # as well as string are wrapped in double quotes
+        self.assertNotIn('*', formatted_changelog)
+        self.assertIn('- "Fixing a bug"', formatted_changelog)
+        self.assertIn('- "Developing a feature"', formatted_changelog)
+        self.assertIn('- "Update appVersions for DC apps (#589)"', formatted_changelog)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This PR makes git log filtering in the release script a bit smarter. Once a week, [update-lts-tags workflow](https://github.com/atlassian/data-center-helm-charts/blob/main/.github/workflows/update-lts-tags.yaml) raises PRs to bump LTS appVersions. The bot writes the same commit message - `Update appVersions for DC apps`. However, when a PR is merged, by default PR number enclosed in brackets is appended to the commit message, go in git log we see `Update appVersions for DC apps (#533)`. These commits make it to Git log, and we need just one in the release notes - the latest.

Also, adding a few simple unit tests to make sure the script is doing the right job by:

* removing duplicate commit messages
* removing Update appVersions for DC apps with lower PR number, i.e. only one is left
* removing ira keys from commit messages
* applying the default changelog if git log is empty
* formatting changelog according to artifacthub.io requirements (enclosing in double quotes, replacing * with - etc)

In addition, adding a GH action to run the tests on every push to any branch if any of the release script files are changed. Here's the action: https://github.com/atlassian/data-center-helm-charts/actions/runs/4494167510/jobs/7906310139?pr=538#step:5:1

## Checklist
- [x] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
