### PR TITLE
CLIP-1783: Added documentation on how to verify Hem charts.

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -37,6 +37,7 @@ The diagram below provides a high level overview of what a typical deployment mi
 ## Installing the Helm charts
 
 * [Prerequisites and setup](userguide/PREREQUISITES.md) - everything you need to do before installing the Helm charts
+* [Verification](userguide/VERIFICATION.md) - verify the integrity of the Helm charts
 * [Installation](userguide/INSTALLATION.md) - the steps to install the Helm charts
 * [Migration](userguide/MIGRATION.md) - what you have to do if you're migrating an existing deployment to Kubernetes
 

--- a/docs/docs/userguide/.pages
+++ b/docs/docs/userguide/.pages
@@ -1,5 +1,6 @@
 nav:
     - PREREQUISITES.md
+    - VERIFICATION.md
     - INSTALLATION.md
     - CONFIGURATION.md
     - MIGRATION.md

--- a/docs/docs/userguide/VERIFICATION.md
+++ b/docs/docs/userguide/VERIFICATION.md
@@ -1,0 +1,30 @@
+# Verification
+
+From release 1.11.0, all the Helm charts are signed with GPG key, following the instruction by official [Helm documentation](https://helm.sh/docs/topics/provenance/). 
+
+To verify the integrity of the charts, 
+1. download chart `.tgz` file, `.prov` file and `helm_key.pub` from [release assets](https://github.com/atlassian/data-center-helm-charts/releases), 
+
+2. and then import the public key into your GPG keyring. (Install GnuPG tool if you haven't done so already.) 
+    
+    ```shell
+    gpg --import helm_key.pub 
+    ```
+   
+3. because Helm currently only supports the legacy gpg format, export the keyring to the legacy format:
+    ```
+    gpg --export >~/.gnupg/pubring.gpg
+    ```
+   
+4. verify the chart.
+    ```
+    helm verify /path/to/product.tgz 
+    ```
+   
+If the verification is successful, the output would be something like: 
+```shell
+helm verify ~/Downloads/jira-1.11.0.tgz                                                                         
+Signed by: Atlassian DC Deployments <dc-deployments@atlassian.com>
+Using Key With Fingerprint: DD1A5B2F7A599129274FB10AD38C66448E19B403
+Chart Hash Verified: sha256:ca102cbf416a5c87998d06ba4527b5afc99e1d7d1776317ddd07720251715fde
+```

--- a/docs/docs/userguide/VERIFICATION.md
+++ b/docs/docs/userguide/VERIFICATION.md
@@ -1,22 +1,22 @@
 # Verification
 
-From release 1.11.0, all the Helm charts are signed with GPG key, following the instruction by official [Helm documentation](https://helm.sh/docs/topics/provenance/). 
+From release 1.11.0, all the Helm charts are signed with a GPG key, following the instructions on the official [Helm documentation](https://helm.sh/docs/topics/provenance/). 
 
 To verify the integrity of the charts, 
-1. download chart `.tgz` file, `.prov` file and `helm_key.pub` from [release assets](https://github.com/atlassian/data-center-helm-charts/releases), 
+1. Download chart `.tgz` file, `.prov` file and `helm_key.pub` from [release assets](https://github.com/atlassian/data-center-helm-charts/releases), 
 
-2. and then import the public key into your GPG keyring. (Install GnuPG tool if you haven't done so already.) 
+2. Import the public key into your local GPG keyring. (Install GnuPG tool if you haven't done so already.) 
     
     ```shell
     gpg --import helm_key.pub 
     ```
    
-3. because Helm currently only supports the legacy gpg format, export the keyring to the legacy format:
+3. At present, Helm only supports the legacy gpg format so export the keyring into the legacy format:
     ```
     gpg --export >~/.gnupg/pubring.gpg
     ```
    
-4. verify the chart.
+4. Verify the chart.
     ```
     helm verify /path/to/product.tgz 
     ```


### PR DESCRIPTION
## Pull request description

This PR added documentation on how to verify Hem charts.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
