### PR TITLE
Update fluentd configmap template for Crowd

### DIFF
--- a/src/main/charts/crowd/templates/configmap-fluentd.yaml
+++ b/src/main/charts/crowd/templates/configmap-fluentd.yaml
@@ -6,13 +6,18 @@ metadata:
   labels:
   {{- include "common.labels.commonLabels" . | nindent 4 }}
 data:
+  {{ if .Values.fluentd.customConfigFile }}
+{{- range $key, $value := .Values.fluentd.fluentdCustomConfig }}
+  {{ $key }}: |
+{{ $value | indent 4 }}
+  {{- end }}
+  {{ else }}
   fluent.conf: |
     <source>
       @type http
       port {{ .Values.fluentd.httpPort }}
       bind 0.0.0.0
     </source>
-
     <filter **>
       @type record_transformer
       <record>
@@ -35,4 +40,5 @@ data:
       logstash_prefix {{ .Values.fluentd.elasticsearch.indexNamePrefix }}
     </match>
     {{ end }}
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
Adding missing custom fluentd config to configmap template

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
