### PR TITLE
CLIP-1784: Multiple fixes to GitHub Actions

### DIFF
--- a/.github/workflows/dc-tests.yml
+++ b/.github/workflows/dc-tests.yml
@@ -3,24 +3,11 @@
 name: DC apps tests in KinD
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - '**.xml'
-      - '**.yaml'
-      - '**.properties'
-      - 'LICENSE'
-      - 'Makefile'
-      - '.gitignore'
-      - '.java-version'
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
+    types: [ labeled ]
 
 jobs:
-
   jira:
     uses: ./.github/workflows/kind.yaml
     with:

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -40,9 +40,11 @@ jobs:
 
     steps:
       - name: Checkout Helm charts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
 
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v3.0

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -17,8 +17,8 @@ on:
         description: 'Bamboo license'
 
 jobs:
-  if: ${{ github.event.label.name == 'kind' || github.event_name == 'workflow_dispatch' }}
   kind-testing:
+    if: ${{ github.event.label.name == 'kind' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     env:
       # See: https://github.com/kubernetes-sigs/kind/tags

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -17,6 +17,7 @@ on:
         description: 'Bamboo license'
 
 jobs:
+  if: ${{ github.event.label.name == 'kind' || github.event_name == 'workflow_dispatch' }}
   kind-testing:
     runs-on: ubuntu-latest
     env:
@@ -29,7 +30,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
 
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v3.0

--- a/src/test/config/kind/common-values.yaml
+++ b/src/test/config/kind/common-values.yaml
@@ -21,23 +21,6 @@ DC_APP_REPLACEME:
   # this applies to Bamboo only and will be ignored in other Helm charts
   disableAgentAuth: true
 
-  # applicable to Bitbucket only
-  mesh:
-    enabled: true
-    nodeAutoRegistration: true
-    setByDefault: true
-    resources:
-      jvm:
-        maxHeap: "1g"
-        minHeap: "512m"
-      container:
-        requests:
-          cpu: "20m"
-          memory: "1G"
-        limits:
-          cpu: "2"
-          memory: "2G"
-
 database:
   type: DB_TYPE_REPLACEME
   url: jdbc:postgresql://postgres:5432/DC_APP_REPLACEME

--- a/src/test/scripts/kind/deploy_app.sh
+++ b/src/test/scripts/kind/deploy_app.sh
@@ -43,10 +43,7 @@ deploy_app() {
   fi
   sed -i "s/DC_APP_REPLACEME/${DC_APP}/g" ../../../test/config/kind/common-values.yaml
   sed -i "s/DB_TYPE_REPLACEME/${DB_TYPE}/g" ../../../test/config/kind/common-values.yaml
-  if [ ${DC_APP} == "bitbucket" ]; then
-    # this is to test mesh
-    IMAGE_OVERRIDE="--set image.tag=8.6.1"
-  fi
+
   helm upgrade --install ${DC_APP} ./ \
                -f ../../../test/config/kind/common-values.yaml \
                -n atlassian \


### PR DESCRIPTION
Current problems:

* KinD tests fail when trigged by PRs created from forks because secrets are not available for actions triggered by `pull_request`.
* e2e tests triggered by labeled PRs checkout code from main branch in this repo rather than a fork

With this PR merged, to run KinD tests, `kind` label needs to be added to PR (or one can manually start this workflow). Also, e2e tests will checkout code from the fork and actually test the changes

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
