### PR TITLE
DCCLIP-481: Fix shared-home path for jmx

### DIFF
--- a/src/main/charts/common/Chart.yaml
+++ b/src/main/charts/common/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: common
 description: A Library Helm Chart for grouping common logic between Atlassian charts. This chart is not deployable by itself.
 type: library
-version: 1.1.0
+version: 1.2.0
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.1.0
+appVersion: 1.2.0
 keywords:
   - common
   - helper


### PR DESCRIPTION
This PR updates shared home vol mount for jmx init container - it now takes into account a subPath. Also, jmx config has been moved to common

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
