### PR TITLE
Update checkout actions

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -43,8 +43,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v3.0

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -33,8 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v3.0


### PR DESCRIPTION
Use of `${{ github.event.pull_request.head.sha }}` is more appropriate than `repository: ${{ github.event.pull_request.head.repo.full_name }}` with `ref: ${{ github.head_ref }}`.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
