### PR TITLE
Enable Bamboo JMS traffic via Kubernetes Service

### DIFF
--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -44,6 +44,11 @@ Kubernetes: `>=1.21.x-0`
 | bamboo.import | object | `{"path":null,"type":"clean"}` | Bamboo can optionally import an existing exported dataset on first-run. These optional values can configure the import file or skip this stage entirely. For more details on importing and exporting see the documentation:  https://confluence.atlassian.com/bamboo/exporting-data-for-backup-289277255.html https://confluence.atlassian.com/bamboo/importing-data-from-backup-289277260.html  |
 | bamboo.import.path | string | `nil` | Path to the existing export to import to the new installation. This should be accessible by the cluster node; e.g. via the shared-home or `additionalVolumeMounts` below.  |
 | bamboo.import.type | string | `"clean"` | Import type. Valid values are `clean` (for a new install) or `import`, in which case you should provide the file path. The default is `clean`.  |
+| bamboo.jmsService.annotations | object | `{}` | Additional annotations to apply to the JMS Service  |
+| bamboo.jmsService.enabled | bool | `false` | Whether to create a separate Service for JMS Agent traffic  |
+| bamboo.jmsService.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer.  |
+| bamboo.jmsService.port | int | `54663` | The port on which the Bamboo K8s Service will listen for Agent traffic  |
+| bamboo.jmsService.type | string | `"ClusterIP"` | The type of K8s service to use for JMS  |
 | bamboo.license | object | `{"secretKey":"license","secretName":null}` | The Bamboo DC license that should be used. If supplied here the license configuration will be skipped in the setup wizard.  |
 | bamboo.license.secretKey | string | `"license"` | The key (default 'licenseKey') in the Secret used to store the license information  |
 | bamboo.license.secretName | string | `nil` | The secret that contains the license information  |
@@ -63,7 +68,7 @@ Kubernetes: `>=1.21.x-0`
 | bamboo.service.annotations | object | `{}` | Additional annotations to apply to the Service  |
 | bamboo.service.contextPath | string | `nil` | The Tomcat context path that Bamboo will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically.  |
 | bamboo.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer.  |
-| bamboo.service.port | int | `80` | The port on which the Bamboo K8s Service will listen  |
+| bamboo.service.port | int | `80` | The port on which the Bamboo K8s Service will listen for http traffic  |
 | bamboo.service.type | string | `"ClusterIP"` | The type of K8s service to use for Bamboo  |
 | bamboo.setPermissions | bool | `true` | Boolean to define whether to set local home directory permissions on startup of Bamboo container. Set to 'false' to disable this behaviour.  |
 | bamboo.shutdown.command | string | `"/shutdown-wait.sh"` | By default pods will be stopped via a [preStop hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/), using a script supplied by the Docker image. If any other shutdown behaviour is needed it can be achieved by overriding this value. Note that the shutdown command needs to wait for the application shutdown completely before exiting; see [the default command](https://bitbucket.org/atlassian-docker/docker-bamboo-server/src/master/shutdown-wait.sh) for details.  |

--- a/src/main/charts/bamboo/templates/service-jms.yaml
+++ b/src/main/charts/bamboo/templates/service-jms.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.bamboo.jmsService.enabled}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-jms
+  labels:
+  {{- include "common.labels.commonLabels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.bamboo.jmsService.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.bamboo.jmsService.type }}
+  {{- if and (eq .Values.bamboo.jmsService.type "LoadBalancer") (not (empty .Values.bamboo.jmsService.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.bamboo.jmsService.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.bamboo.jmsService.port }}
+      targetPort: jms
+      protocol: TCP
+      name: jms
+  selector:
+  {{- include "common.labels.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -489,7 +489,7 @@ bamboo:
   #
   service:
 
-    # -- The port on which the Bamboo K8s Service will listen
+    # -- The port on which the Bamboo K8s Service will listen for http traffic
     #
     port: 80
 
@@ -507,6 +507,30 @@ bamboo:
     contextPath:
 
     # -- Additional annotations to apply to the Service
+    #
+    annotations: {}
+
+  # K8s Service configuration for JMS
+  #
+  jmsService:
+
+    # -- Whether to create a separate Service for JMS Agent traffic
+    #
+    enabled: false
+
+    # -- The port on which the Bamboo K8s Service will listen for Agent traffic
+    #
+    port: 54663
+
+    # -- The type of K8s service to use for JMS
+    #
+    type: ClusterIP
+
+    # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
+    #
+    loadBalancerIP:
+
+    # -- Additional annotations to apply to the JMS Service
     #
     annotations: {}
 

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -47,6 +47,29 @@ data:
     rules:
       - pattern: ".*"
 ---
+# Source: bamboo/templates/service-jms.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: unittest-bamboo-jms
+  labels:
+    helm.sh/chart: bamboo-1.12.0
+    app.kubernetes.io/name: bamboo
+    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/version: "9.2.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 54663
+      targetPort: jms
+      protocol: TCP
+      name: jms
+  selector:
+    app.kubernetes.io/name: bamboo
+    app.kubernetes.io/instance: unittest-bamboo
+---
 # Source: bamboo/templates/service-jmx.yaml
 apiVersion: v1
 kind: Service
@@ -113,7 +136,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 6a2d1b3064ea870e5fb6beb167be510c3f11d8d9528a1b920be7fe6611f12cc2
       labels:
         app.kubernetes.io/name: bamboo
         app.kubernetes.io/instance: unittest-bamboo

--- a/src/test/resources/expected_helm_output/bamboo/values.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/values.yaml
@@ -27,6 +27,9 @@ bamboo:
   import:
     type: "clean"
 
+  jmsService:
+    enabled: true
+
 
 priorityClassName: "high"
 additionalHosts:


### PR DESCRIPTION
## Pull request description

This enables forwarding traffic to the pod's JMS port via Kubernetes service. There is a new variable `bamboo.service.jmsPort` to configure it. It enables traffic from remote agents outside of the Kubernetes cluster Bamboo is running in the same way SSH git connections are possible as explained here: https://atlassian.github.io/data-center-helm-charts/examples/bitbucket/BITBUCKET_SSH/

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
