### PR TITLE
DCCLIP-501: Add optional ServiceMonitors to DC Helm Charts

### DIFF
--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -120,6 +120,9 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
+| monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
+| monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |
 | nodeSelector | object | `{}` | Standard K8s node-selectors that will be applied to all Bamboo pods  |
 | podAnnotations | object | `{}` | Custom annotations that will be applied to all Bamboo pods  |
 | podLabels | object | `{}` | Custom labels that will be applied to all Bamboo pods  |

--- a/src/main/charts/bamboo/templates/service-monitor.yaml
+++ b/src/main/charts/bamboo/templates/service-monitor.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/bamboo/templates/service-monitor.yaml
+++ b/src/main/charts/bamboo/templates/service-monitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.monitoring.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-service-monitor
+  labels:
+  {{- with .Values.monitoring.serviceMonitor.prometheusLabelSelector }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+    path: /metrics
+    port: jmx
+    scheme: http
+  selector:
+    matchLabels:
+    {{- include "common.labels.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/src/main/charts/bamboo/templates/service-monitor.yaml
+++ b/src/main/charts/bamboo/templates/service-monitor.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
+  - interval: {{ printf "%.0fs" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -784,6 +784,21 @@ monitoring:
   #   rules:
   #     - pattern: ".*"
 
+  serviceMonitor:
+
+    # -- Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.
+    #
+    create: false
+
+    # -- ServiceMonitorSelector of the prometheus instance.
+    #
+    prometheusLabelSelector: {}
+      # release: prometheus
+
+    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    #
+    scrapeIntervalSeconds:
+
 # Fluentd configuration
 #
 # Bamboo log collection and aggregation can be enabled using Fluentd. This config

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -795,9 +795,9 @@ monitoring:
     prometheusLabelSelector: {}
       # release: prometheus
 
-    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    # -- Scrape interval for the JMX service.
     #
-    scrapeIntervalSeconds:
+    scrapeIntervalSeconds: 30
 
 # Fluentd configuration
 #

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -149,6 +149,9 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
+| monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
+| monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |
 | nodeSelector | object | `{}` | Standard K8s node-selectors that will be applied to all Bitbucket pods  |
 | podAnnotations | object | `{}` | Custom annotations that will be applied to all Bitbucket pods  |
 | podLabels | object | `{}` | Custom labels that will be applied to all Bitbucket pods  |

--- a/src/main/charts/bitbucket/templates/service-monitor-mesh.yaml
+++ b/src/main/charts/bitbucket/templates/service-monitor-mesh.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.bitbucket.mesh.enabled .Values.monitoring.serviceMonitor.create }}
+{{- range $index := until (.Values.bitbucket.mesh.replicaCount | int) }}
+{{- with $ }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-mesh-{{ $index }}-service-monitor
+  labels:
+  {{- include "common.labels.commonLabels" . | nindent 4 }}
+  {{- with .Values.monitoring.serviceMonitor.prometheusLabelSelector }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+    path: /metrics
+    port: jmx
+    scheme: http
+  selector:
+    matchLabels:
+      statefulset.kubernetes.io/pod-name: {{ include "common.names.fullname" . }}-mesh-{{ $index }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/src/main/charts/bitbucket/templates/service-monitor-mesh.yaml
+++ b/src/main/charts/bitbucket/templates/service-monitor-mesh.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
+  - interval: {{ printf "%.0fs" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/bitbucket/templates/service-monitor-mesh.yaml
+++ b/src/main/charts/bitbucket/templates/service-monitor-mesh.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/bitbucket/templates/service-monitor.yaml
+++ b/src/main/charts/bitbucket/templates/service-monitor.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/bitbucket/templates/service-monitor.yaml
+++ b/src/main/charts/bitbucket/templates/service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.monitoring.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-service-monitor
+  labels:
+  {{- include "common.labels.commonLabels" . | nindent 4 }}
+  {{- with .Values.monitoring.serviceMonitor.prometheusLabelSelector }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+    path: /metrics
+    port: jmx
+    scheme: http
+  selector:
+    matchLabels:
+    {{- include "common.labels.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/src/main/charts/bitbucket/templates/service-monitor.yaml
+++ b/src/main/charts/bitbucket/templates/service-monitor.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
+  - interval: {{ printf "%.0fs" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -1043,6 +1043,21 @@ monitoring:
   #   rules:
   #     - pattern: ".*"
 
+  serviceMonitor:
+
+    # -- Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.
+    #
+    create: false
+
+    # -- ServiceMonitorSelector of the prometheus instance.
+    #
+    prometheusLabelSelector: {}
+      # release: prometheus
+
+    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    #
+    scrapeIntervalSeconds:
+
 # Fluentd configuration
 #
 # Bitbucket log collection and aggregation can be enabled using Flunetd. This config

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -1054,9 +1054,9 @@ monitoring:
     prometheusLabelSelector: {}
       # release: prometheus
 
-    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    # -- Scrape interval for the JMX service.
     #
-    scrapeIntervalSeconds:
+    scrapeIntervalSeconds: 30
 
 # Fluentd configuration
 #

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -110,6 +110,9 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
+| monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
+| monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |
 | nodeSelector | object | `{}` | Standard K8s node-selectors that will be applied to all Confluence pods  |
 | podAnnotations | object | `{}` | Custom annotations that will be applied to all Confluence pods  |
 | podLabels | object | `{}` | Custom labels that will be applied to all Confluence pods  |

--- a/src/main/charts/confluence/templates/service-monitor.yaml
+++ b/src/main/charts/confluence/templates/service-monitor.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/confluence/templates/service-monitor.yaml
+++ b/src/main/charts/confluence/templates/service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.monitoring.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-service-monitor
+  labels:
+  {{- include "common.labels.commonLabels" . | nindent 4 }}
+  {{- with .Values.monitoring.serviceMonitor.prometheusLabelSelector }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+    path: /metrics
+    port: jmx
+    scheme: http
+  selector:
+    matchLabels:
+    {{- include "common.labels.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/src/main/charts/confluence/templates/service-monitor.yaml
+++ b/src/main/charts/confluence/templates/service-monitor.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
+  - interval: {{ printf "%.0fs" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -842,9 +842,9 @@ monitoring:
     prometheusLabelSelector: {}
       # release: prometheus
 
-    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    # -- Scrape interval for the JMX service.
     #
-    scrapeIntervalSeconds:
+    scrapeIntervalSeconds: 30
 
 # Confluence Synchrony configuration
 # https://confluence.atlassian.com/doc/configuring-synchrony-858772125.html

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -831,6 +831,21 @@ monitoring:
   #   rules:
   #     - pattern: ".*"
 
+  serviceMonitor:
+
+    # -- Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.
+    #
+    create: false
+
+    # -- ServiceMonitorSelector of the prometheus instance.
+    #
+    prometheusLabelSelector: {}
+      # release: prometheus
+
+    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    #
+    scrapeIntervalSeconds:
+
 # Confluence Synchrony configuration
 # https://confluence.atlassian.com/doc/configuring-synchrony-858772125.html
 synchrony:

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -99,6 +99,9 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
+| monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
+| monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |
 | nodeSelector | object | `{}` | Standard K8s node-selectors that will be applied to all Crowd pods  |
 | podAnnotations | object | `{}` | Custom annotations that will be applied to all Crowd pods  |
 | podLabels | object | `{}` | Custom labels that will be applied to all Crowd pods  |

--- a/src/main/charts/crowd/templates/service-monitor.yaml
+++ b/src/main/charts/crowd/templates/service-monitor.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/crowd/templates/service-monitor.yaml
+++ b/src/main/charts/crowd/templates/service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.monitoring.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-service-monitor
+  labels:
+  {{- include "common.labels.commonLabels" . | nindent 4 }}
+  {{- with .Values.monitoring.serviceMonitor.prometheusLabelSelector }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+    path: /metrics
+    port: jmx
+    scheme: http
+  selector:
+    matchLabels:
+    {{- include "common.labels.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/src/main/charts/crowd/templates/service-monitor.yaml
+++ b/src/main/charts/crowd/templates/service-monitor.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
+  - interval: {{ printf "%.0fs" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -773,3 +773,18 @@ monitoring:
   # jmx-config: |
   #   rules:
   #     - pattern: ".*"
+  
+  serviceMonitor:
+
+    # -- Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.
+    #
+    create: false
+
+    # -- ServiceMonitorSelector of the prometheus instance.
+    #
+    prometheusLabelSelector: {}
+      # release: prometheus
+    
+    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    #
+    scrapeIntervalSeconds:

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -785,6 +785,6 @@ monitoring:
     prometheusLabelSelector: {}
       # release: prometheus
     
-    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    # -- Scrape interval for the JMX service.
     #
-    scrapeIntervalSeconds:
+    scrapeIntervalSeconds: 30

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -108,6 +108,9 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
+| monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
+| monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |
 | nodeSelector | object | `{}` | Standard K8s node-selectors that will be applied to all Jira pods  |
 | podAnnotations | object | `{}` | Custom annotations that will be applied to all Jira pods  |
 | podLabels | object | `{}` | Custom labels that will be applied to all Jira pods  |

--- a/src/main/charts/jira/templates/service-monitor.yaml
+++ b/src/main/charts/jira/templates/service-monitor.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/jira/templates/service-monitor.yaml
+++ b/src/main/charts/jira/templates/service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.monitoring.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "common.names.fullname" . }}-service-monitor
+  labels:
+  {{- include "common.labels.commonLabels" . | nindent 4 }}
+  {{- with .Values.monitoring.serviceMonitor.prometheusLabelSelector }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ printf "%ds" (default 30 .Values.monitoring.serviceMonitor.scrapeIntervalSeconds)}}
+    path: /metrics
+    port: jmx
+    scheme: http
+  selector:
+    matchLabels:
+    {{- include "common.labels.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/src/main/charts/jira/templates/service-monitor.yaml
+++ b/src/main/charts/jira/templates/service-monitor.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - interval: {{ printf "%ds" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds | quote }}
+  - interval: {{ printf "%.0fs" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds }}
     path: /metrics
     port: jmx
     scheme: http

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -705,6 +705,21 @@ monitoring:
   # jmx-config: |
   #   rules:
   #     - pattern: ".*"
+  
+  serviceMonitor:
+
+    # -- Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.
+    #
+    create: false
+
+    # -- ServiceMonitorSelector of the prometheus instance.
+    #
+    prometheusLabelSelector: {}
+      # release: prometheus
+    
+    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    #
+    scrapeIntervalSeconds:
 
 # Fluentd configuration
 #

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -717,9 +717,9 @@ monitoring:
     prometheusLabelSelector: {}
       # release: prometheus
     
-    # -- Scrape interval for the JMX service. Defaults to 30 seconds
+    # -- Scrape interval for the JMX service.
     #
-    scrapeIntervalSeconds:
+    scrapeIntervalSeconds: 30
 
 # Fluentd configuration
 #

--- a/src/test/java/test/JmxMetricsTest.java
+++ b/src/test/java/test/JmxMetricsTest.java
@@ -200,14 +200,13 @@ class JmxMetricsTest {
     void service_monitor_enabled_with_custom_values(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "monitoring.serviceMonitor.create", "true",
-                "monitoring.serviceMonitor.prometheusLabelSelector.release", "myprometheus",
-                "monitoring.serviceMonitor.scrapeIntervalSeconds", "60"
+                "monitoring.serviceMonitor.prometheusLabelSelector.release", "myprometheus"
         ));
 
         resources.assertContains(ServiceMonitor, product.getHelmReleaseName() + "-service-monitor");
 
         final var serviceMonitorSpec = resources.get(ServiceMonitor).getSpec();
-        assertThat(serviceMonitorSpec.path("endpoints").path(0).path("interval")).hasTextEqualTo("60s");
+        assertThat(serviceMonitorSpec.path("endpoints").path(0).path("interval")).hasTextEqualTo("30s");
 
         final var serviceMonitorMetadata = resources.get(ServiceMonitor).getMetadata();
         assertThat(serviceMonitorMetadata.path("labels").path("release")).hasTextEqualTo("myprometheus");

--- a/src/test/java/test/JmxMetricsTest.java
+++ b/src/test/java/test/JmxMetricsTest.java
@@ -185,7 +185,8 @@ class JmxMetricsTest {
     void service_monitor_bitbucket_mesh(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "monitoring.serviceMonitor.create", "true",
-                product + ".mesh.enabled", "true"
+                product + ".mesh.enabled", "true",
+                product + ".mesh.replicaCount", "3"
         ));
 
         for (int i = 0; i < 3; i++) {

--- a/src/test/java/test/model/Kind.java
+++ b/src/test/java/test/model/Kind.java
@@ -4,5 +4,5 @@ package test.model;
  * The different types of Kubernetes resource we use.
  */
 public enum Kind {
-    StatefulSet, Deployment, ServiceAccount, ConfigMap, Secret, Service, Pod, Job, ClusterRole, Role, ClusterRoleBinding, RoleBinding, PersistentVolume, PersistentVolumeClaim, Ingress
+    StatefulSet, Deployment, ServiceAccount, ConfigMap, Secret, Service, Pod, Job, ClusterRole, Role, ClusterRoleBinding, RoleBinding, PersistentVolume, PersistentVolumeClaim, Ingress, ServiceMonitor
 }


### PR DESCRIPTION
This PR adds [ServiceMonitors](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor) to DC Helm charts templates.

By default `monitoring.serviceMonitor.create=false` so it needs to be explicitly set to `true`.
Helm charts do not create `ServiceMonitor` CRDs, so it is expected that Kube API knows what a ServiceMonitor is (otherwise helm install/upgrade will fail).

Deploying [Kube prometheus stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) is one of the ways to deploy this CRD (but not the only one).

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
