### PR TITLE
CLIP-1804:Make sessionAffinity configurable for k8s services

### DIFF
--- a/src/main/charts/bamboo/templates/service.yaml
+++ b/src/main/charts/bamboo/templates/service.yaml
@@ -10,6 +10,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.bamboo.service.type }}
+  sessionAffinity: {{ .Values.bamboo.service.sessionAffinity }}
+  {{- if .Values.bamboo.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.bamboo.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  {{- end }}
   {{- if and (eq .Values.bamboo.service.type "LoadBalancer") (not (empty .Values.bamboo.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.bamboo.service.loadBalancerIP }}
   {{- end }}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -497,6 +497,23 @@ bamboo:
     #
     type: ClusterIP
 
+    # -- Session affinity type. If you want to make sure that connections from a particular client
+    # are passed to the same pod each time, set sessionAffinity to ClientIP.
+    # See: https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity
+    #
+    sessionAffinity: None
+
+    # -- Session affinity configuration
+    #
+    sessionAffinityConfig:
+
+      clientIP:
+
+        # -- Specifies the seconds of ClientIP type session sticky time.
+        # The value must be > 0 && <= 86400 (for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800 (for 3 hours).
+        #
+        timeoutSeconds:
+
     # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
     #
     loadBalancerIP:

--- a/src/main/charts/bitbucket/templates/service.yaml
+++ b/src/main/charts/bitbucket/templates/service.yaml
@@ -11,6 +11,12 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.bitbucket.service.type }}
+  sessionAffinity: {{ .Values.bitbucket.service.sessionAffinity }}
+  {{- if .Values.bitbucket.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.bitbucket.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  {{- end }}
   {{- if and (eq .Values.bitbucket.service.type "LoadBalancer") (not (empty .Values.bitbucket.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.bitbucket.service.loadBalancerIP }}
   {{- end }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -475,6 +475,23 @@ bitbucket:
     #
     type: ClusterIP
 
+    # -- Session affinity type. If you want to make sure that connections from a particular client
+    # are passed to the same pod each time, set sessionAffinity to ClientIP.
+    # See: https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity
+    #
+    sessionAffinity: None
+
+    # -- Session affinity configuration
+    #
+    sessionAffinityConfig:
+
+      clientIP:
+
+        # -- Specifies the seconds of ClientIP type session sticky time.
+        # The value must be > 0 && <= 86400 (for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800 (for 3 hours).
+        #
+        timeoutSeconds:
+
     # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
     #
     loadBalancerIP:

--- a/src/main/charts/confluence/templates/service.yaml
+++ b/src/main/charts/confluence/templates/service.yaml
@@ -10,6 +10,12 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.confluence.service.type }}
+  sessionAffinity: {{ .Values.confluence.service.sessionAffinity }}
+  {{- if .Values.confluence.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.confluence.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  {{- end }}
   {{- if and (eq .Values.confluence.service.type "LoadBalancer") (not (empty .Values.confluence.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.confluence.service.loadBalancerIP }}
   {{- end }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -495,6 +495,23 @@ confluence:
     #
     type: ClusterIP
 
+    # -- Session affinity type. If you want to make sure that connections from a particular client
+    # are passed to the same pod each time, set sessionAffinity to ClientIP.
+    # See: https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity
+    #
+    sessionAffinity: None
+
+    # -- Session affinity configuration
+    #
+    sessionAffinityConfig:
+
+      clientIP:
+
+        # -- Specifies the seconds of ClientIP type session sticky time.
+        # The value must be > 0 && <= 86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800 (for 3 hours).
+        #
+        timeoutSeconds:
+
     # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
     #
     loadBalancerIP:

--- a/src/main/charts/crowd/templates/service.yaml
+++ b/src/main/charts/crowd/templates/service.yaml
@@ -10,6 +10,12 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.crowd.service.type }}
+  sessionAffinity: {{ .Values.crowd.service.sessionAffinity }}
+  {{- if .Values.crowd.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.crowd.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  {{- end }}
   {{- if and (eq .Values.crowd.service.type "LoadBalancer") (not (empty .Values.crowd.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.crowd.service.loadBalancerIP }}
   {{- end }}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -92,6 +92,23 @@ crowd:
     #
     type: ClusterIP
 
+    # -- Session affinity type. If you want to make sure that connections from a particular client
+    # are passed to the same pod each time, set sessionAffinity to ClientIP.
+    # See: https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity
+    #
+    sessionAffinity: None
+
+    # -- Session affinity configuration
+    #
+    sessionAffinityConfig:
+
+      clientIP:
+
+        # -- Specifies the seconds of ClientIP type session sticky time.
+        # The value must be > 0 && <= 86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800 (for 3 hours).
+        #
+        timeoutSeconds:
+
     # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
     #
     loadBalancerIP:

--- a/src/main/charts/jira/templates/service.yaml
+++ b/src/main/charts/jira/templates/service.yaml
@@ -10,6 +10,12 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.jira.service.type }}
+  sessionAffinity: {{ .Values.jira.service.sessionAffinity }}
+  {{- if .Values.jira.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.jira.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
+  {{- end }}
   {{- if and (eq .Values.jira.service.type "LoadBalancer") (not (empty .Values.jira.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.jira.service.loadBalancerIP }}
   {{- end }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -393,6 +393,23 @@ jira:
     #
     type: ClusterIP
 
+    # -- Session affinity type. If you want to make sure that connections from a particular client
+    # are passed to the same pod each time, set sessionAffinity to ClientIP.
+    # See: https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity
+    #
+    sessionAffinity: None
+
+    # -- Session affinity configuration
+    #
+    sessionAffinityConfig:
+
+      clientIP:
+
+        # -- Specifies the seconds of ClientIP type session sticky time.
+        # The value must be > 0 && <= 86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800 (for 3 hours).
+        #
+        timeoutSeconds:
+
     # -- Use specific loadBalancerIP. Only applies to service type LoadBalancer.
     #
     loadBalancerIP:
@@ -705,7 +722,7 @@ monitoring:
   # jmx-config: |
   #   rules:
   #     - pattern: ".*"
-  
+
   serviceMonitor:
 
     # -- Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.
@@ -716,7 +733,7 @@ monitoring:
     #
     prometheusLabelSelector: {}
       # release: prometheus
-    
+
     # -- Scrape interval for the JMX service.
     #
     scrapeIntervalSeconds: 30

--- a/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
@@ -46,7 +46,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 5316a1fbcdb25d3d92d65013915316d27ace881a6f71e00104703c06c2c3a234
       labels:
         app.kubernetes.io/name: bamboo-agent
         app.kubernetes.io/instance: unittest-bamboo-agent

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -106,6 +106,7 @@ metadata:
   annotations:
 spec:
   type: ClusterIP
+  sessionAffinity: None
   ports:
     - port: 80
       targetPort: http

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -176,6 +176,7 @@ metadata:
   annotations:
 spec:
   type: ClusterIP
+  sessionAffinity: None
   ports:
     - port: 80
       targetPort: http
@@ -219,7 +220,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 196e61f853214d77e3fb5b3c57c04464c4fb28e1ffdec69f257ad84f553c6825
       labels:
         app.kubernetes.io/name: bitbucket-mesh
         app.kubernetes.io/instance: unittest-bitbucket
@@ -342,7 +342,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 3ad8dba1613e51f049cfe401770a5058ab0b91a5d802503f3413e3c51a2df22a
       labels:
         app.kubernetes.io/name: bitbucket
         app.kubernetes.io/instance: unittest-bitbucket

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -142,6 +142,7 @@ metadata:
   annotations:
 spec:
   type: ClusterIP
+  sessionAffinity: None
   ports:
     - port: 80
       targetPort: http
@@ -176,7 +177,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 5c7e4f3183d49bd4e8c82a29b06246e551e4120042495652f1f9b27a0599a882
       labels:
         app.kubernetes.io/name: confluence-synchrony
         app.kubernetes.io/instance: unittest-confluence
@@ -258,7 +258,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 705b517555fce927c54cb9ef8407e808a74f44a4c09a077cb2edc3824d117e22
       labels:
         app.kubernetes.io/name: confluence
         app.kubernetes.io/instance: unittest-confluence

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -85,6 +85,7 @@ metadata:
   annotations:
 spec:
   type: ClusterIP
+  sessionAffinity: None
   ports:
     - port: 80
       targetPort: http
@@ -115,7 +116,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 4834f01ea3048f73429ddc4d0b09d6872e19993dbc277ea450f824b1aae8c4e1
       labels:
         app.kubernetes.io/name: crowd
         app.kubernetes.io/instance: unittest-crowd

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -93,6 +93,7 @@ metadata:
   annotations:
 spec:
   type: ClusterIP
+  sessionAffinity: None
   ports:
     - port: 80
       targetPort: http
@@ -123,7 +124,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 810997b0ead21fd8586aba9d673c90de10df01b7b6f523ac00a043e1937d9d87
       labels:
         app.kubernetes.io/name: jira
         app.kubernetes.io/instance: unittest-jira


### PR DESCRIPTION
This PR makes it possible to override service sessionAffinity (set to None by default). This can be necessary when no ingress controller is involved

Added a few simple unit tests and some docs.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [x] (Atlassian only) Internal Bamboo CI is passing
