### PR TITLE
Pass javaagent with jmx_exporter config to Bitbucket Mesh JVM

### DIFF
--- a/src/main/charts/bitbucket/templates/config-jvm.yaml
+++ b/src/main/charts/bitbucket/templates/config-jvm.yaml
@@ -11,5 +11,8 @@ data:
     {{- end }}
     -XX:ActiveProcessorCount={{ include "flooredCPU" .Values.bitbucket.resources.container.requests.cpu }}
     {{ include "common.jmx.javaagent" . | indent 4 | trim }}
+    {{- if .Values.monitoring.exposeJmxMetrics }}
+    -Dplugin.bitbucket-git.mesh.sidecar.jvmArgs=-javaagent:{{ .Values.monitoring.jmxExporterCustomJarLocation | default (printf "%s/jmx_prometheus_javaagent.jar"  .Values.volumes.sharedHome.mountPath) }}=9998:/opt/atlassian/jmx/jmx-config.yaml
+    {{- end }}
   max_heap: {{ .Values.bitbucket.resources.jvm.maxHeap }}
   min_heap: {{ .Values.bitbucket.resources.jvm.minHeap }}

--- a/src/main/charts/bitbucket/templates/service-jmx.yaml
+++ b/src/main/charts/bitbucket/templates/service-jmx.yaml
@@ -15,6 +15,9 @@ spec:
     - port: {{ .Values.monitoring.jmxExporterPort}}
       targetPort: jmx
       name: jmx
+    - port: 9998
+      targetPort: 9998
+      name: jmx-mesh-sidecar
   selector:
   {{- include "common.labels.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/src/main/charts/bitbucket/templates/service-monitor.yaml
+++ b/src/main/charts/bitbucket/templates/service-monitor.yaml
@@ -14,6 +14,10 @@ spec:
     path: /metrics
     port: jmx
     scheme: http
+  - interval: {{ printf "%.0fs" .Values.monitoring.serviceMonitor.scrapeIntervalSeconds }}
+    path: /metrics
+    port: jmx-mesh-sidecar
+    scheme: http
   selector:
     matchLabels:
     {{- include "common.labels.selectorLabels" . | nindent 6 }}

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -44,6 +44,7 @@ data:
   additional_jvm_args: >-
     -XX:ActiveProcessorCount=2
     -javaagent:/var/atlassian/application-data/shared-home/jmx_prometheus_javaagent.jar=9999:/opt/atlassian/jmx/jmx-config.yaml
+    -Dplugin.bitbucket-git.mesh.sidecar.jvmArgs=-javaagent:/var/atlassian/application-data/shared-home/jmx_prometheus_javaagent.jar=9998:/opt/atlassian/jmx/jmx-config.yaml
   max_heap: 1g
   min_heap: 512m
 ---
@@ -83,6 +84,9 @@ spec:
     - port: 9999
       targetPort: jmx
       name: jmx
+    - port: 9998
+      targetPort: 9998
+      name: jmx-mesh-sidecar
   selector:
     app.kubernetes.io/name: bitbucket
     app.kubernetes.io/instance: unittest-bitbucket
@@ -219,7 +223,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 196e61f853214d77e3fb5b3c57c04464c4fb28e1ffdec69f257ad84f553c6825
       labels:
         app.kubernetes.io/name: bitbucket-mesh
         app.kubernetes.io/instance: unittest-bitbucket
@@ -342,7 +345,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 3ad8dba1613e51f049cfe401770a5058ab0b91a5d802503f3413e3c51a2df22a
       labels:
         app.kubernetes.io/name: bitbucket
         app.kubernetes.io/instance: unittest-bitbucket


### PR DESCRIPTION
Bitbucket git operations are handled by a mesh sidecar that starts in a separate JVM. As a result, when javaagent with jmx_exporter jar and config is passed to Bitbucket JVM, none of mesh sidecar jmx metrics is exported, including one of the most important ones - tickets metrics.

This PR adds an additional port to jmx svc + an additional endpoint to ServiceMonitor, as well as passed an additional sysprop that mesh JVM will pick up. Metrics is then scraped on the same service, ports 9999 (bitbucket jvm) and 9998 (mesh sidecar).

There's not much sense in making mesh sidecar jmx port configurable, it will only expand values.yaml.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
