### PR TITLE
DCCLIP-552: Add Grafana dashboard tests to KinD

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -78,6 +78,12 @@ jobs:
           source src/test/scripts/kind/deploy_app.sh
           verify_metrics
 
+      - name: Verify ${{inputs.dc_app}} grafana dashboards
+        if: env.DC_APP != 'crowd'
+        run: |
+          source src/test/scripts/kind/deploy_app.sh
+          verify_dashboards
+
       - name: Test scaling ${{inputs.dc_app}}
         run: |
           echo "[INFO]: Scaling ${DC_APP} to 2 replicas"

--- a/src/test/config/kind/common-values.yaml
+++ b/src/test/config/kind/common-values.yaml
@@ -49,4 +49,7 @@ ingress:
 
 monitoring:
   exposeJmxMetrics: true
-
+  grafana:
+    createDashboards: true
+    dashboardLabels:
+      grafana_dashboard: dc_monitoring

--- a/src/test/scripts/kind/deploy_app.sh
+++ b/src/test/scripts/kind/deploy_app.sh
@@ -116,7 +116,7 @@ verify_dashboards() {
     exit 1
   fi
 
-  DASHBOARDS=$(find src/main/charts/"${DC_APP}"/grafana-dashboards -name 'bitbucket-mesh' -prune -o -type f -print)
+  DASHBOARDS=($(find src/main/charts/"${DC_APP}"/grafana-dashboards -name 'bitbucket-mesh' -prune -o -type f -print))
   for dashboard in "${DASHBOARDS[@]}"; do
     echo "[INFO]: Comparing $dashboard with its respective ConfigMap"
     dashboard_json=$(cat "${dashboard}")

--- a/src/test/scripts/kind/deploy_app.sh
+++ b/src/test/scripts/kind/deploy_app.sh
@@ -107,21 +107,21 @@ verify_metrics() {
 
 verify_dashboards() {
   echo "[INFO]: Verifying ConfigMaps with Grafana dashboards"
-  DASHBPOARDS_COUNT=$(find src/main/charts/"${DC_APP}"/grafana-dashboards  -name 'bitbucket-mesh' -prune -o -type f -print | wc -l)
+  DASHBOARDS_COUNT=$(find src/main/charts/"${DC_APP}"/grafana-dashboards -name 'bitbucket-mesh' -prune -o -type f -print | wc -l)
   CONFIGMAPS_COUNT=$(kubectl get cm -l=grafana_dashboard=dc_monitoring -n atlassian --no-headers -o custom-columns=":metadata.name" | wc -l)
-  if [ "${DASHBPOARDS_COUNT}" -ne "${CONFIGMAPS_COUNT}" ]; then
-    echo "[ERROR]: Count does not match! Dashboards count is ${DASHBPOARDS_COUNT}, configmaps count is ${CONFIGMAPS_COUNT}"
+  if [ "${DASHBOARDS_COUNT}" -ne "${CONFIGMAPS_COUNT}" ]; then
+    echo "[ERROR]: Count does not match! Dashboards count is ${DASHBOARDS_COUNT}, configmaps count is ${CONFIGMAPS_COUNT}"
     echo -e "[ERROR]: ConfigMaps with grafana_dashboard=dc_monitoring label in atlassian namespace:\n"
     kubectl get cm -l=grafana_dashboard=dc_monitoring -n atlassian --no-headers -o custom-columns=":metadata.name"
     exit 1
   fi
 
-  DASHBOARDS=($(find src/main/charts/${DC_APP}/grafana-dashboards  -name 'bitbucket-mesh' -prune -o -type f -print))
+  DASHBOARDS=$(find src/main/charts/"${DC_APP}"/grafana-dashboards -name 'bitbucket-mesh' -prune -o -type f -print)
   for dashboard in "${DASHBOARDS[@]}"; do
     echo "[INFO]: Comparing $dashboard with its respective ConfigMap"
     dashboard_json=$(cat "${dashboard}")
     file_name=$(basename "${dashboard}" |cut -d '.' -f 1)
-    cm_data=$(kubectl get cm/${DC_APP}-${file_name}-dashboard -n atlassian -o jsonpath="{.data.${DC_APP}-atlassian-${file_name}\.json}")
+    cm_data=$(kubectl get cm/"${DC_APP}"-"${file_name}"-dashboard -n atlassian -o jsonpath="{.data.${DC_APP}-atlassian-${file_name}\.json}")
     if [ "${dashboard_json}" != "${cm_data}" ]; then
         echo "[ERROR]: ConfigMap ${DC_APP}-${file_name}-dashboard data isn't identical to ${file_name}.json"
         echo "******************************************************************"

--- a/src/test/scripts/kind/deploy_app.sh
+++ b/src/test/scripts/kind/deploy_app.sh
@@ -134,5 +134,3 @@ verify_dashboards() {
     fi
   done
 }
-
-

--- a/src/test/scripts/kind/deploy_app.sh
+++ b/src/test/scripts/kind/deploy_app.sh
@@ -104,3 +104,33 @@ verify_metrics() {
     exit 1
   fi
 }
+
+verify_dashboards() {
+  echo "[INFO]: Verifying ConfigMaps with Grafana dashboards"
+  DASHBPOARDS_COUNT=$(find src/main/charts/"${DC_APP}"/grafana-dashboards  -name 'bitbucket-mesh' -prune -o -type f -print | wc -l)
+  CONFIGMAPS_COUNT=$(kubectl get cm -l=grafana_dashboard=dc_monitoring -n atlassian --no-headers -o custom-columns=":metadata.name" | wc -l)
+  if [ "${DASHBPOARDS_COUNT}" -ne "${CONFIGMAPS_COUNT}" ]; then
+    echo "[ERROR]: Count does not match! Dashboards count is ${DASHBPOARDS_COUNT}, configmaps count is ${CONFIGMAPS_COUNT}"
+    exit 1
+  fi
+
+  DASHBOARDS=($(find src/main/charts/${DC_APP}/grafana-dashboards  -name 'bitbucket-mesh' -prune -o -type f -print))
+  for dashboard in "${DASHBOARDS[@]}"; do
+    echo "[INFO]: Comparing $dashboard with its respective ConfigMap"
+    dashboard_json=$(cat "${dashboard}")
+    file_name=$(basename "${dashboard}" |cut -d '.' -f 1)
+    cm_data=$(kubectl get cm/${DC_APP}-${file_name}-dashboard -n atlassian -o jsonpath="{.data.${DC_APP}-atlassian-${file_name}\.json}")
+    if [ "${dashboard_json}" != "${cm_data}" ]; then
+        echo "[ERROR]: ConfigMap ${DC_APP}-${file_name}-dashboard data isn't identical to ${file_name}.json"
+        echo "******************************************************************"
+        echo -e "JSON:\n"
+        cat "${dashboard}"
+        echo "******************************************************************"
+        echo -e "ConfigMap:\n"
+        echo "${cm_data}"
+        exit 1
+    fi
+  done
+}
+
+

--- a/src/test/scripts/kind/deploy_app.sh
+++ b/src/test/scripts/kind/deploy_app.sh
@@ -111,6 +111,8 @@ verify_dashboards() {
   CONFIGMAPS_COUNT=$(kubectl get cm -l=grafana_dashboard=dc_monitoring -n atlassian --no-headers -o custom-columns=":metadata.name" | wc -l)
   if [ "${DASHBPOARDS_COUNT}" -ne "${CONFIGMAPS_COUNT}" ]; then
     echo "[ERROR]: Count does not match! Dashboards count is ${DASHBPOARDS_COUNT}, configmaps count is ${CONFIGMAPS_COUNT}"
+    echo -e "[ERROR]: ConfigMaps with grafana_dashboard=dc_monitoring label in atlassian namespace:\n"
+    kubectl get cm -l=grafana_dashboard=dc_monitoring -n atlassian --no-headers -o custom-columns=":metadata.name"
     exit 1
   fi
 


### PR DESCRIPTION
Enabling dashboards in KinD common values to:
* ensure the number of created ConfigMaps == the number of json files in grafana-dashboards directory
* ensure content of the json file is identical to data.$key in the ConfigMap (this way we check that ConfigMaps are created with expected names, data keys and json content)

Example run: https://github.com/atlassian/data-center-helm-charts/actions/runs/5174426485/jobs/9320728709#step:12:1 (workflows run from PR are from main branch only)

