### PR TITLE
DCCLIP-544: Crowd dashboard

### DIFF
--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -98,6 +98,8 @@ Kubernetes: `>=1.21.x-0`
 | ingress.tlsSecretName | string | `nil` | The name of the K8s Secret that contains the TLS private key and corresponding certificate. When utilised, TLS termination occurs at the ingress point where traffic to the Service, and it's Pods is in plaintext. Usage is optional and depends on your use case. The Ingress Controller itself can also be configured with a TLS secret for all Ingress Resources. https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets https://kubernetes.io/docs/concepts/services-networking/ingress/#tls |
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation |
+| monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards |
+| monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom jmx config with the rules. Make sure to keep jmx-config key |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home |
 | monitoring.jmxExporterImageRepo | string | `"bitnami/jmx-exporter"` | Image repository with jmx_exporter jar |

--- a/src/main/charts/crowd/templates/configmap-jmx-config.yaml
+++ b/src/main/charts/crowd/templates/configmap-jmx-config.yaml
@@ -6,5 +6,19 @@ metadata:
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
 data:
-{{- include "common.jmx.config" . | nindent 2 }}
+  jmx-config.yaml: |
+    rules:
+      - pattern: '(java.lang)<type=(\w+)><>(\w+):'
+        name: java_lang_$2_$3
+        labels:
+          product: "crowd"
+      - pattern: 'java.lang<type=Memory><HeapMemoryUsage>(\w+)'
+        name: java_lang_Memory_HeapMemoryUsage_$1
+        labels:
+          product: "crowd"
+      - pattern: 'java.lang<name=G1 (\w+) Generation, type=GarbageCollector><>(\w+)'
+        name: java_lang_G1_$1_Generation_$2
+        labels:
+          product: "crowd"
+      - pattern: '.*'
 {{- end }}

--- a/src/main/charts/crowd/templates/configmaps-grafana-dashboards.yaml
+++ b/src/main/charts/crowd/templates/configmaps-grafana-dashboards.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.monitoring.grafana.createDashboards }}
+{{- $grafanaDashboards := .Files.Glob "grafana-dashboards/*.json" -}}
+{{- range $index, $grafanaDashboard := $grafanaDashboards -}}
+{{- with $ }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+{{- $fileName := split "/" $index }}
+  name: {{ include "common.names.fullname" . }}-{{ $fileName._1 | trimSuffix ".json" }}-dashboard
+  labels:
+    {{- include "common.labels.commonLabels" . | nindent 4 }}
+    {{- with .Values.monitoring.grafana.dashboardLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  {{ include "common.names.fullname" . }}-{{ .Release.Namespace}}-{{ $fileName._1}}: |
+{{ .Files.Get $index | indent 4 }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -805,3 +805,14 @@ monitoring:
     # -- Scrape interval for the JMX service.
     #
     scrapeIntervalSeconds: 30
+
+  grafana:
+
+    # -- Create ConfigMaps with Grafana dashboards
+    #
+    createDashboards: false
+
+    # -- Label selector for Grafana dashboard importer sidecar
+    #
+    dashboardLabels: {}
+    # grafana_dashboard: dc_monitoring

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -47,7 +47,19 @@ data:
     lowercaseOutputLabelNames: true
     lowercaseOutputName: true
     rules:
-      - pattern: ".*"
+      - pattern: '(java.lang)<type=(\w+)><>(\w+):'
+        name: java_lang_$2_$3
+        labels:
+          product: "crowd"
+      - pattern: 'java.lang<type=Memory><HeapMemoryUsage>(\w+)'
+        name: java_lang_Memory_HeapMemoryUsage_$1
+        labels:
+          product: "crowd"
+      - pattern: 'java.lang<name=G1 (\w+) Generation, type=GarbageCollector><>(\w+)'
+        name: java_lang_G1_$1_Generation_$2
+        labels:
+          product: "crowd"
+      - pattern: '.*'
 ---
 # Source: crowd/templates/service-jmx.yaml
 apiVersion: v1


### PR DESCRIPTION
## Pull request description

This PR enables Grafana dashboard creation out of the box of Crowd Helm chart. 

If set `monitoring.grafana.createDashboards` to true and there are dashboard json files existing in the `grafana-dashboards` folder, dashboard configmaps will be created for you, and Grafana will pick this configmap and create the dashboard.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
