### PR TITLE
Add crowd to dashboards CI

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -79,7 +79,6 @@ jobs:
           verify_metrics
 
       - name: Verify ${{inputs.dc_app}} grafana dashboards
-        if: env.DC_APP != 'crowd'
         run: |
           source src/test/scripts/kind/deploy_app.sh
           verify_dashboards

--- a/src/main/scripts/process_dashboard.py
+++ b/src/main/scripts/process_dashboard.py
@@ -51,6 +51,8 @@ elif args.product == 'bitbucket-mesh':
     product_unique_metric = 'metrics_grpc_Value'
 elif args.product == 'bamboo':
     product_unique_metric = 'java_lang_Memory_HeapMemoryUsage_committed{product=\\"bamboo\\"}'
+elif args.product == 'crowd':
+    product_unique_metric = 'java_lang_Runtime_Uptime{product=\\"crowd\\"}'
 
 # mind double escaping // in regex
 templating_string = '{"list":[{"current":{"selected":true,"text":"default","value":"default"},"hide":0,' \

--- a/src/main/scripts/update_grafana_dashboards.sh
+++ b/src/main/scripts/update_grafana_dashboards.sh
@@ -16,7 +16,7 @@ else
     # if no arguments are passed, use the default array
     # When dashboards for a new DC product are added
     # makes sure it is added in this array
-    PRODUCTS=("bitbucket" "bitbucket-mesh" "confluence" "jira" "bamboo")
+    PRODUCTS=("bitbucket" "bitbucket-mesh" "confluence" "jira" "bamboo" "crowd")
 fi
 
 for PRODUCT in ${PRODUCTS[@]}; do \


### PR DESCRIPTION
Now that https://github.com/atlassian-labs/data-center-grafana-dashboards/pull/19 and https://github.com/atlassian/data-center-helm-charts/pull/593 are merged, it's time to add Crowd to:

* KinD testing
* workflow that generates dashboard JSONs for crowd
