### PR TITLE
CLIP-1807: Update Bitbucket mesh tag

### DIFF
--- a/.github/workflows/update-lts-tags.yaml
+++ b/.github/workflows/update-lts-tags.yaml
@@ -3,7 +3,6 @@ name: Update LTS Tags
 on:
   schedule:
     - cron: '0 0 * * SUN' # At 00:00 on every Sunday
-  workflow_dispatch:
 
 jobs:
   lts_check:

--- a/.github/workflows/update-lts-tags.yaml
+++ b/.github/workflows/update-lts-tags.yaml
@@ -3,6 +3,7 @@ name: Update LTS Tags
 on:
   schedule:
     - cron: '0 0 * * SUN' # At 00:00 on every Sunday
+  workflow_dispatch:
 
 jobs:
   lts_check:

--- a/src/test/scripts/product_versions.py
+++ b/src/test/scripts/product_versions.py
@@ -8,6 +8,7 @@ known_supported_version = {
 	'jira-software': '8.13.8',
 	'confluence': '7.12.2',
 	'stash': '7.12.1',
+	'mesh': '2.0.1',
 	'bamboo': '8.1.1'  # Bamboo has not LTS versions.
 }
 

--- a/src/test/scripts/product_versions.py
+++ b/src/test/scripts/product_versions.py
@@ -9,7 +9,7 @@ known_supported_version = {
 	'confluence': '7.12.2',
 	'stash': '7.12.1',
 	'mesh': '2.0.1',
-	'bamboo': '8.1.1'  # Bamboo has not LTS versions.
+	'bamboo': '8.1.1'  # Bamboo has no LTS versions.
 }
 
 # If tag suffix is desired - e.g. 7.8.0-jdk11 -> tag_suffix = "-jdk11"

--- a/src/test/scripts/update_versions.py
+++ b/src/test/scripts/update_versions.py
@@ -104,6 +104,7 @@ def update_mesh_tag():
         doc = yaml.safe_load(content)
         current_version = doc['bitbucket']['mesh']['image']['tag']
         logging.info("Current version: %s", current_version)
+        logging.info("New version: %s", new_version)
 
     new_content = content.replace(current_version, new_version)
     with open(bitbucket_values_file, "w") as stream:

--- a/src/test/scripts/update_versions.py
+++ b/src/test/scripts/update_versions.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import urllib.request
 
 import requests
 import yaml
@@ -88,6 +90,35 @@ def latest_minor(version, mac_versions):
     return minor_versions[-1]
 
 
+def update_mesh_tag():
+    logging.info("-------------------------------")
+    logging.info('- Updating Bitbucket Mesh tag -')
+    logging.info("-------------------------------")
+    mesh_repo = 'atlassian/bitbucket-mesh'
+    new_version = product_versions.get_lts_version(['mesh']).replace(tag_suffix, "")
+    bitbucket_values_file = '../../main/charts/bitbucket/values.yaml'
+    expected_bitbucket_output_file = '../resources/expected_helm_output/bitbucket/output.yaml'
+
+    with open(bitbucket_values_file, "r") as stream:
+        content = stream.read()
+        doc = yaml.safe_load(content)
+        current_version = doc['bitbucket']['mesh']['image']['tag']
+        logging.info("Current version: %s", current_version)
+
+    new_content = content.replace(current_version, new_version)
+    with open(bitbucket_values_file, "w") as stream:
+        stream.write(new_content)
+
+    logging.info('Updated values file: %s', bitbucket_values_file)
+    with open(expected_bitbucket_output_file, "r") as file:
+        file_contents = file.read()
+
+    modified_contents = file_contents.replace(mesh_repo + ':' + current_version, mesh_repo + ':' + new_version)
+    logging.info('Updated expected output file: %s', expected_bitbucket_output_file)
+    with open(expected_bitbucket_output_file, 'w') as file:
+        file.write(modified_contents)
+
+
 logging.info("Updating product versions in helm charts")
 for product in products:
     logging.info("-------------------------")
@@ -105,4 +136,5 @@ for product in products:
     logging.info(f"Latest version: %s, tagname: {version}{tag_suffix}", version)
     update_versions(product, new_version_tag)
 
+update_mesh_tag()
 logging.info(">>>> ATTENTION - Don't forget to update the product Changelogs.md - ATTENTION <<<<")


### PR DESCRIPTION
Mesh is a bit different from other DC products as it's part of Bitbucket Helm chart, that's why it wasn't possible simply to add a new product to the list - hence adding a new function. Also, while appVersions for other products are changed in Chart.yaml, for Mesh it's Bitbucket's values.yaml. And it's a different place in expected output yaml, so it's not possible to reuse the existing functions.

Output from running the script:

```
I -------------------------------
I - Updating Bitbucket Mesh tag -
I -------------------------------
I Current version: 1.5.0
I New version: 2.0.1
I Updated values file: ../../main/charts/bitbucket/values.yaml
I Updated expected output file: ../resources/expected_helm_output/bitbucket/output.yaml
```
<details>
  <summary>git diff</summary>

```
git diff
diff --git a/src/main/charts/bitbucket/values.yaml b/src/main/charts/bitbucket/values.yaml
index 93f88b0..20600d3 100644
--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -805,7 +805,7 @@ bitbucket:

       # -- The docker image tag to be used
       #
-      tag: "1.5.0"
+      tag: "2.0.1"

     # -- Number of Bitbucket Mesh nodes. Do not change it. Currently, only the quorum of 3 mesh nodes is supported.
     # Reducing the number of replicas will result in mesh degradation while increasing the number of Mesh nodes
diff --git a/src/test/resources/expected_helm_output/bitbucket/output.yaml b/src/test/resources/expected_helm_output/bitbucket/output.yaml
index a5c33b8..cb6c689 100644
--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -251,7 +251,7 @@ spec:
             runAsUser: 0 # make sure we run as root to avoid permission denied
       containers:
         - name: bitbucket-mesh
-          image: atlassian/bitbucket-mesh:1.5.0
+          image: atlassian/bitbucket-mesh:2.0.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: mesh
diff --git a/src/test/scripts/update_versions.py b/src/test/scripts/update_versions.py
index cbf16a7..437c203 100644
--- a/src/test/scripts/update_versions.py
+++ b/src/test/scripts/update_versions.py
@@ -104,6 +104,7 @@ def update_mesh_tag():
         doc = yaml.safe_load(content)
         current_version = doc['bitbucket']['mesh']['image']['tag']
         logging.info("Current version: %s", current_version)
+        logging.info("New version: %s", new_version)

     new_content = content.replace(current_version, new_version)
     with open(bitbucket_values_file, "w") as stream:
```
</details>