### PR TITLE
fix: swap ingress paths for priority based rules

### DIFF
--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -31,13 +31,6 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-          - path: {{ include "confluence.ingressPath" . }}
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "common.names.fullname" . }}
-                port:
-                  number: {{ $.Values.confluence.service.port }}
           {{ if .Values.synchrony.enabled }}
           - path: /synchrony
             pathType: Prefix
@@ -47,4 +40,11 @@ spec:
                 port:
                   number: {{ $.Values.synchrony.service.port }}
           {{ end }}
+          - path: {{ include "confluence.ingressPath" . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "common.names.fullname" . }}
+                port:
+                  number: {{ $.Values.confluence.service.port }}
 {{ end }}


### PR DESCRIPTION
## Pull request description

I swapped the position of the symphony ingress in the helm chart template. Priority-based ingresses like aws-elb/ alb are handled by the rule position in the ingress. You currently have to manually adjust the ingress to get the routing for syphony to work. This simple swap addresses the issue.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
