### PR TITLE
Run jmx fetcher init container as root

### DIFF
--- a/src/main/charts/common/Chart.yaml
+++ b/src/main/charts/common/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: common
 description: A Library Helm Chart for grouping common logic between Atlassian charts. This chart is not deployable by itself.
 type: library
-version: 1.2.2
+version: 1.2.3
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.2.2
+appVersion: 1.2.3
 keywords:
   - common
   - helper

--- a/src/main/charts/common/templates/_jmx.tpl
+++ b/src/main/charts/common/templates/_jmx.tpl
@@ -30,6 +30,8 @@ Jmx init container
   image: {{ .Values.monitoring.jmxExporterImageRepo}}:{{ .Values.monitoring.jmxExporterImageTag}}
   command: ["cp"]
   args: ["/opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar", "{{ .Values.volumes.sharedHome.mountPath }}"]
+  securityContext:
+    runAsUser: 0
   volumeMounts:
     - mountPath: {{ .Values.volumes.sharedHome.mountPath | quote }}
       name: shared-home


### PR DESCRIPTION
If shared home isn't writable to other users, the init container will fail to copy jmx jar. The default bitnami image runs as 1001. This init container needs to run as root

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
