### PR TITLE
Run jmx init container as root: get fix from common chart ver 1.2.3

### DIFF
--- a/src/main/charts/bamboo-agent/Chart.lock
+++ b/src/main/charts/bamboo-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.2
-digest: sha256:a9dc19c4d6d24eced6a9dc143294ef80b1529cdc825311bb11dd86a1b763a8a5
-generated: "2023-04-26T13:06:35.172249+10:00"
+  version: 1.2.3
+digest: sha256:19b32588659e732b2f75427b8bf2040b4daf93893f72f2de19ab76cc7f0e8623
+generated: "2023-06-28T12:28:34.897846+10:00"

--- a/src/main/charts/bamboo-agent/Chart.yaml
+++ b/src/main/charts/bamboo-agent/Chart.yaml
@@ -25,5 +25,5 @@ annotations:
     - "Expose JMX beans on http endpoint (#562)"
 dependencies:
 - name: common
-  version: 1.2.2
+  version: 1.2.3
   repository: https://atlassian.github.io/data-center-helm-charts

--- a/src/main/charts/bamboo/Chart.lock
+++ b/src/main/charts/bamboo/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.2
-digest: sha256:a9dc19c4d6d24eced6a9dc143294ef80b1529cdc825311bb11dd86a1b763a8a5
-generated: "2023-04-24T19:34:44.560136+10:00"
+  version: 1.2.3
+digest: sha256:19b32588659e732b2f75427b8bf2040b4daf93893f72f2de19ab76cc7f0e8623
+generated: "2023-06-28T12:28:14.264452+10:00"

--- a/src/main/charts/bamboo/Chart.yaml
+++ b/src/main/charts/bamboo/Chart.yaml
@@ -29,5 +29,5 @@ annotations:
     - "Expose JMX beans on http endpoint (#562)"
 dependencies:
 - name: common
-  version: 1.2.2
+  version: 1.2.3
   repository: https://atlassian.github.io/data-center-helm-charts

--- a/src/main/charts/bitbucket/Chart.lock
+++ b/src/main/charts/bitbucket/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.2
-digest: sha256:a9dc19c4d6d24eced6a9dc143294ef80b1529cdc825311bb11dd86a1b763a8a5
-generated: "2023-04-24T19:35:08.062375+10:00"
+  version: 1.2.3
+digest: sha256:19b32588659e732b2f75427b8bf2040b4daf93893f72f2de19ab76cc7f0e8623
+generated: "2023-06-28T12:28:46.378103+10:00"

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -32,5 +32,5 @@ annotations:
 
 dependencies:
 - name: common
-  version: 1.2.2
+  version: 1.2.3
   repository: https://atlassian.github.io/data-center-helm-charts

--- a/src/main/charts/confluence/Chart.lock
+++ b/src/main/charts/confluence/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.2
-digest: sha256:a9dc19c4d6d24eced6a9dc143294ef80b1529cdc825311bb11dd86a1b763a8a5
-generated: "2023-04-24T19:35:22.392986+10:00"
+  version: 1.2.3
+digest: sha256:19b32588659e732b2f75427b8bf2040b4daf93893f72f2de19ab76cc7f0e8623
+generated: "2023-06-28T12:28:55.882836+10:00"

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -30,5 +30,5 @@ annotations:
 
 dependencies:
 - name: common
-  version: 1.2.2
+  version: 1.2.3
   repository: https://atlassian.github.io/data-center-helm-charts

--- a/src/main/charts/crowd/Chart.lock
+++ b/src/main/charts/crowd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.2
-digest: sha256:a9dc19c4d6d24eced6a9dc143294ef80b1529cdc825311bb11dd86a1b763a8a5
-generated: "2023-04-24T19:36:12.996699+10:00"
+  version: 1.2.3
+digest: sha256:19b32588659e732b2f75427b8bf2040b4daf93893f72f2de19ab76cc7f0e8623
+generated: "2023-06-28T12:29:08.571023+10:00"

--- a/src/main/charts/crowd/Chart.yaml
+++ b/src/main/charts/crowd/Chart.yaml
@@ -31,5 +31,5 @@ annotations:
 
 dependencies:
 - name: common
-  version: 1.2.2
+  version: 1.2.3
   repository: https://atlassian.github.io/data-center-helm-charts

--- a/src/main/charts/jira/Chart.lock
+++ b/src/main/charts/jira/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.2
-digest: sha256:a9dc19c4d6d24eced6a9dc143294ef80b1529cdc825311bb11dd86a1b763a8a5
-generated: "2023-04-24T19:35:47.28639+10:00"
+  version: 1.2.3
+digest: sha256:19b32588659e732b2f75427b8bf2040b4daf93893f72f2de19ab76cc7f0e8623
+generated: "2023-06-28T12:29:27.369749+10:00"

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -32,5 +32,5 @@ annotations:
 
 dependencies:
 - name: common
-  version: 1.2.2
+  version: 1.2.3
   repository: https://atlassian.github.io/data-center-helm-charts

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -175,6 +175,8 @@ spec:
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
           args: ["/opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar", "/var/atlassian/application-data/shared-home"]
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: "/var/atlassian/application-data/shared-home"
               name: shared-home

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -228,7 +228,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 7326894755525f6bc6852ed1c786e59edd9835655aff54a10d23984b78dbfa6e
+        checksum/config-jvm: 555059c124174714f5af246982a12557062630668dc4091f918588d717a7158a
       labels:
         app.kubernetes.io/name: bitbucket-mesh
         app.kubernetes.io/instance: unittest-bitbucket
@@ -351,7 +351,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 23593e00dee3ed0e0e14d7602f385e78ffe991965b0651c13946a3044f86d5be
+        checksum/config-jvm: e7b1c55864ed92e419c97ddcd716baf79a8f2e0134799d945f65df0c445d149f
       labels:
         app.kubernetes.io/name: bitbucket
         app.kubernetes.io/instance: unittest-bitbucket
@@ -370,6 +370,8 @@ spec:
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
           args: ["/opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar", "/var/atlassian/application-data/shared-home"]
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: "/var/atlassian/application-data/shared-home"
               name: shared-home

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -259,7 +259,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 855a67744b9013e47f59dd74544e466523e27aa83089eb47e4f13669b2eb47e2
+        checksum/config-jvm: e0074ebdb2ca8c75025a320cd06e1f7f91a4e6ba9373aa2613dea60173b6820a
       labels:
         app.kubernetes.io/name: confluence
         app.kubernetes.io/instance: unittest-confluence
@@ -286,6 +286,8 @@ spec:
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
           args: ["/opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar", "/var/atlassian/application-data/shared-home"]
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: "/var/atlassian/application-data/shared-home"
               name: shared-home

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -154,6 +154,8 @@ spec:
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
           args: ["/opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar", "/var/atlassian/application-data/crowd/shared"]
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: "/var/atlassian/application-data/crowd/shared"
               name: shared-home

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -152,6 +152,8 @@ spec:
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
           args: ["/opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar", "/var/atlassian/application-data/shared-home"]
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: "/var/atlassian/application-data/shared-home"
               name: shared-home


### PR DESCRIPTION
See: https://github.com/atlassian/data-center-helm-charts/pull/606 which fixes fetching jmx jar if shared home permissions do not allow others to write.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
