### PR TITLE
Synchrony missing container limits

### DIFF
--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -1005,9 +1005,9 @@ synchrony:
         # -- Initial Memory request Synchrony pod
         #
         memory: "2.5G"
-    #  limits:
-    #    cpu: "2"
-    #    memory: "2.5G"      
+      #  limits:
+      #    cpu: "2"
+      #    memory: "2.5G"      
 
   # -- Specifies a list of additional arguments that can be passed to the Synchrony JVM, e.g.
   # system properties.

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -1007,7 +1007,7 @@ synchrony:
         memory: "2.5G"
     #  limits:
     #    cpu: "2"
-    #    memory: "2G"      
+    #    memory: "2.5G"      
 
   # -- Specifies a list of additional arguments that can be passed to the Synchrony JVM, e.g.
   # system properties.

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -696,9 +696,14 @@ confluence:
         # -- Initial Memory request by Confluence pod
         #
         memory: "2G"
-      #  limits:
-      #    cpu: "2"
-      #    memory: "2G"
+      limits:
+        # -- Initial CPU limit by Confluence pod.
+        #
+        cpu: "2"
+
+        # -- Initial Memory limit by Confluence pod
+        #
+        memory: "2G"
 
   shutdown:
 
@@ -1005,9 +1010,14 @@ synchrony:
         # -- Initial Memory request Synchrony pod
         #
         memory: "2.5G"
-      #  limits:
-      #    cpu: "2"
-      #    memory: "2.5G"      
+      limits:
+        # -- Initial CPU limit by Synchrony pod
+        #
+        cpu: "2"
+
+        # -- Initial Memory limit by Synchrony pod
+        #
+        memory: "2.5G"      
 
   # -- Specifies a list of additional arguments that can be passed to the Synchrony JVM, e.g.
   # system properties.

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -1005,6 +1005,9 @@ synchrony:
         # -- Initial Memory request Synchrony pod
         #
         memory: "2.5G"
+    #  limits:
+    #    cpu: "2"
+    #    memory: "2G"      
 
   # -- Specifies a list of additional arguments that can be passed to the Synchrony JVM, e.g.
   # system properties.

--- a/src/test/java/test/RequestsTest.java
+++ b/src/test/java/test/RequestsTest.java
@@ -22,7 +22,7 @@ public class RequestsTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    @EnumSource(value = Product.class, names = {"bamboo_agent", "confluence"}, mode = EnumSource.Mode.EXCLUDE)
     void sts_empty_limits(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of());
 

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -218,6 +218,9 @@ spec:
             requests:
               cpu: "2"
               memory: 2.5G
+            limits:
+              cpu: "2"
+              memory: 2.5G
           env:
             - name: SET_PERMISSIONS
               value: "true"
@@ -316,6 +319,9 @@ spec:
             requests:
               cpu: "2"
               memory: 2G
+            limits:
+              cpu: "2"
+              memory: 2.5G
           volumeMounts:
             - name: local-home
               mountPath: "/var/atlassian/application-data/confluence"

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -318,7 +318,7 @@ spec:
           resources:
             limits:
               cpu: "2"
-              memory: 2.5G
+              memory: 2G
             requests:
               cpu: "2"
               memory: 2G

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -215,10 +215,10 @@ spec:
             periodSeconds: 1
             failureThreshold: 10
           resources:
-            requests:
+            limits:
               cpu: "2"
               memory: 2.5G
-            limits:
+            requests:
               cpu: "2"
               memory: 2.5G
           env:
@@ -316,12 +316,12 @@ spec:
             periodSeconds: 5
             failureThreshold: 6
           resources:
-            requests:
-              cpu: "2"
-              memory: 2G
             limits:
               cpu: "2"
               memory: 2.5G
+            requests:
+              cpu: "2"
+              memory: 2G
           volumeMounts:
             - name: local-home
               mountPath: "/var/atlassian/application-data/confluence"


### PR DESCRIPTION
Only container requests are supported in the config, but it is also very critical to specify the limits as well so the container doesn't crash other pods as when limits are not specified, the container can use all the resource available on the node.

As we want to make sure other pods are not affected in case of cpu or memory spikes, we need to be able to set the container limits as well.

## Pull request description

Tested this out locally (uncommented):

kubectl get pod synchrony -n confluence -o=jsonpath='{.spec.containers[0].name}'
synchrony%                                                                                                                                                                           
kubectl get pod synchrony -n confluence -o=jsonpath='{.spec.containers[0].resources}'
{"limits":{"cpu":"2","memory":"4G"},"requests":{"cpu":"2","memory":"4G"}}%                                                                                                           
kubectl get pod synchrony -n confluence
NAME                     READY   STATUS    RESTARTS   AGE
synchrony                    2/2   Running    0                   16m

_Provide description for the PR_

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
