### PR TITLE
Unset default limits for Confluence

### DIFF
--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -696,14 +696,15 @@ confluence:
         # -- Initial Memory request by Confluence pod
         #
         memory: "2G"
-      limits:
-        # -- Initial CPU limit by Confluence pod.
-        #
-        cpu: "2"
 
-        # -- Initial Memory limit by Confluence pod
-        #
-        memory: "2G"
+      # limits:
+      #   # -- Initial CPU limit by Confluence pod.
+      #   #
+      #   cpu: "2"
+      #
+      #   # -- Initial Memory limit by Confluence pod
+      #   #
+      #   memory: "2G"
 
   shutdown:
 
@@ -1010,14 +1011,14 @@ synchrony:
         # -- Initial Memory request Synchrony pod
         #
         memory: "2.5G"
-      limits:
-        # -- Initial CPU limit by Synchrony pod
-        #
-        cpu: "2"
-
-        # -- Initial Memory limit by Synchrony pod
-        #
-        memory: "2.5G"      
+      # limits:
+      #   # -- Initial CPU limit by Synchrony pod
+      #   #
+      #   cpu: "2"
+      #
+      #   # -- Initial Memory limit by Synchrony pod
+      #   #
+      #   memory: "2.5G"      
 
   # -- Specifies a list of additional arguments that can be passed to the Synchrony JVM, e.g.
   # system properties.

--- a/src/test/java/test/RequestsTest.java
+++ b/src/test/java/test/RequestsTest.java
@@ -22,7 +22,7 @@ public class RequestsTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Product.class, names = {"bamboo_agent", "confluence"}, mode = EnumSource.Mode.EXCLUDE)
+    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
     void sts_empty_limits(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of());
 

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -215,9 +215,6 @@ spec:
             periodSeconds: 1
             failureThreshold: 10
           resources:
-            limits:
-              cpu: "2"
-              memory: 2.5G
             requests:
               cpu: "2"
               memory: 2.5G
@@ -316,9 +313,6 @@ spec:
             periodSeconds: 5
             failureThreshold: 6
           resources:
-            limits:
-              cpu: "2"
-              memory: 2G
             requests:
               cpu: "2"
               memory: 2G


### PR DESCRIPTION
Keeping the [limits](https://github.com/atlassian/data-center-helm-charts/pull/615)  commented out and letting users decide. Also, a few CI jobs (including [e2e tests](https://github.com/atlassian/data-center-helm-charts/actions/runs/5538682764)) set their own requests which can be bigger than limits.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
- [ ] (Atlassian only) Internal Bamboo CI is passing
