### PR TITLE
Remove references to Atlassian CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,3 @@ _Provide description for the PR_
 - [ ] I have added unit tests
 - [ ] I have applied the change to all applicable products
 - [ ] The E2E test has passed (use `e2e` label)
-- [ ] (Atlassian only) Internal Bamboo CI is passing


### PR DESCRIPTION
Bamboo jobs have been decommissioned, so removing them from PR template
