### PR TITLE
Make sharedHome.permissionFix.command helper to be per-product

### DIFF
--- a/docs/docs/examples/external_libraries/EXTERNAL_LIBS.md
+++ b/docs/docs/examples/external_libraries/EXTERNAL_LIBS.md
@@ -144,7 +144,7 @@ nfsPermissionFixer:
     If taking this approach ensure the last thing your custom command does is apply the relevant permissions to the `shared-home` mount, see line `10` in `yaml` 
     snippet above. 
 
-    Each product chart has a `sharedHome.permissionFix.command` helper for doing this. look at Jira's helper [sharedHome.permissionFix.command](https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/jira/templates/_helpers.tpl#L102) 
+    Each product chart has a `<product>.sharedHome.permissionFix.command` helper for doing this. look at Jira's helper [jira.sharedHome.permissionFix.command](https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/jira/templates/_helpers.tpl#L102) 
     for more details on how these permissions are applied by default.
 
 Remember to also update the `additionalLibraries` stanza accordingly:

--- a/src/main/charts/bamboo/templates/_helpers.tpl
+++ b/src/main/charts/bamboo/templates/_helpers.tpl
@@ -64,7 +64,7 @@ Pod labels
 {{/*
 The command that should be run by the nfs-fixer init container to correct the permissions of the shared-home root directory.
 */}}
-{{- define "sharedHome.permissionFix.command" -}}
+{{- define "bamboo.sharedHome.permissionFix.command" -}}
 {{- $securityContext := .Values.bamboo.securityContext }}
 {{- with .Values.volumes.sharedHome.nfsPermissionFixer }}
     {{- if .command }}

--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
               {{- if .Values.volumes.sharedHome.subPath }}
               subPath: {{ .Values.volumes.sharedHome.subPath | quote }}
               {{- end }}
-          command: ["sh", "-c", {{ include "sharedHome.permissionFix.command" . | quote }}]
+          command: ["sh", "-c", {{ include "bamboo.sharedHome.permissionFix.command" . | quote }}]
         {{- end }}
         {{- include "common.jmx.initContainer" . | nindent 8 }}
       containers:

--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -89,7 +89,7 @@ Create default value for ingress path
 {{/*
 The command that should be run by the nfs-fixer init container to correct the permissions of the shared-home root directory.
 */}}
-{{- define "sharedHome.permissionFix.command" -}}
+{{- define "bitbucket.sharedHome.permissionFix.command" -}}
 {{- $securityContext := .Values.bitbucket.securityContext }}
 {{- with .Values.volumes.sharedHome.nfsPermissionFixer }}
     {{- if .command }}

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -62,7 +62,7 @@ spec:
               {{- if .Values.volumes.sharedHome.subPath }}
               subPath: {{ .Values.volumes.sharedHome.subPath | quote }}
               {{- end }}
-          command: ["sh", "-c", {{ include "sharedHome.permissionFix.command" . | quote }}]
+          command: ["sh", "-c", {{ include "bitbucket.sharedHome.permissionFix.command" . | quote }}]
         {{- end }}
         {{- include "common.jmx.initContainer" . | nindent 8 }}
       containers:

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -160,7 +160,7 @@ Create default value for ingress path
 {{/*
 The command that should be run by the nfs-fixer init container to correct the permissions of the shared-home root directory.
 */}}
-{{- define "sharedHome.permissionFix.command" -}}
+{{- define "confluence.sharedHome.permissionFix.command" -}}
 {{- $securityContext := .Values.confluence.securityContext }}
 {{- with .Values.volumes.sharedHome.nfsPermissionFixer }}
     {{- if .command }}

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
               {{- if .Values.volumes.sharedHome.subPath }}
               subPath: {{ .Values.volumes.sharedHome.subPath | quote }}
               {{- end }}
-          command: ["sh", "-c", {{ include "sharedHome.permissionFix.command" . | quote }}]
+          command: ["sh", "-c", {{ include "confluence.sharedHome.permissionFix.command" . | quote }}]
         {{- end }}
         {{- include "common.jmx.initContainer" . | nindent 8 }}
       containers:

--- a/src/main/charts/crowd/templates/_helpers.tpl
+++ b/src/main/charts/crowd/templates/_helpers.tpl
@@ -44,7 +44,7 @@ Pod labels
 {{/*
 The command that should be run by the nfs-fixer init container to correct the permissions of the shared-home root directory.
 */}}
-{{- define "sharedHome.permissionFix.command" -}}
+{{- define "crowd.sharedHome.permissionFix.command" -}}
 {{- $securityContext := .Values.crowd.securityContext }}
 {{- with .Values.volumes.sharedHome.nfsPermissionFixer }}
     {{- if .command }}

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
               {{- if .Values.volumes.sharedHome.subPath }}
               subPath: {{ .Values.volumes.sharedHome.subPath | quote }}
               {{- end }}
-          command: ["sh", "-c", {{ include "sharedHome.permissionFix.command" . | quote }}]
+          command: ["sh", "-c", {{ include "crowd.sharedHome.permissionFix.command" . | quote }}]
         {{- end }}
         {{- include "common.jmx.initContainer" . | nindent 8 }}
       containers:

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -47,7 +47,7 @@ Pod labels
 {{/*
 The command that should be run by the nfs-fixer init container to correct the permissions of the shared-home root directory.
 */}}
-{{- define "sharedHome.permissionFix.command" -}}
+{{- define "jira.sharedHome.permissionFix.command" -}}
 {{- $securityContext := .Values.jira.securityContext }}
 {{- with .Values.volumes.sharedHome.nfsPermissionFixer }}
     {{- if .command }}

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
               {{- if .Values.volumes.sharedHome.subPath }}
               subPath: {{ .Values.volumes.sharedHome.subPath | quote }}
               {{- end }}
-          command: ["sh", "-c", {{ include "sharedHome.permissionFix.command" . | quote }}]
+          command: ["sh", "-c", {{ include "jira.sharedHome.permissionFix.command" . | quote }}]
         {{- end }}
         {{- include "common.jmx.initContainer" . | nindent 8 }}
       containers:


### PR DESCRIPTION
## Pull request description
When attempting to deploy multiple charts as dependencies of a parent chart, it is not possible to load multiple charts with the same helper name.

Example:
```
$ cat chart/atlassian-stack/Chart.yaml
apiVersion: v2
name: atlassian-stack
description: Helper-chart to install multiple Atlassian products
type: application 
version: 0.1.0 
appVersion: "0.1.0"
dependencies:
- name: bamboo
  version: "1.13.1"
  repository: "https://atlassian.github.io/data-center-helm-charts"
- name: elasticsearch
  version: "8.5.1"
  repository: "https://helm.elastic.co"
- name: bitbucket
  version: "1.13.1"
  repository: "https://atlassian.github.io/data-center-helm-charts"


$ helm upgrade --install atlassian-stack chart/atlassian-stack -f values.yaml
Error: UPGRADE FAILED: template: atlassian-stack/charts/bitbucket/templates/statefulset.yaml:65:35: executing "atlassian-stack/charts/bitbucket/templates/statefulset.yaml" at <include "sharedHome.permissionFix.command" .>: error calling include: template: atlassian-stack/charts/bamboo/templates/_helpers.tpl:68:31: executing "sharedHome.permissionFix.command" at <.Values.bamboo.securityContext>: nil pointer evaluating interface {}.securityContext
```

## Checklist
- [ ] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
