### PR TITLE
Add additionalFiles to bamboo-agent Helm chart

### DIFF
--- a/src/main/charts/bamboo-agent/README.md
+++ b/src/main/charts/bamboo-agent/README.md
@@ -24,13 +24,14 @@ Kubernetes: `>=1.21.x-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalContainers | list | `[]` | Additional container definitions that will be added to all Bamboo agent pods  |
+| additionalFiles | list | `[]` | Additional existing ConfigMaps and Secrets not managed by Helm that should be mounted into service container. Configuration details below (camelCase is important!): 'name'      - References existing ConfigMap or secret name. 'type'      - 'configMap' or 'secret' 'key'       - The file name. 'mountPath' - The destination directory in a container. VolumeMount and Volumes are added with this name and index position, for example; custom-config-0, keystore-2  |
 | additionalHosts | list | `[]` | Additional host aliases for each pod, equivalent to adding them to the /etc/hosts file. https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ |
 | additionalInitContainers | list | `[]` | Additional initContainer definitions that will be added to all Bamboo agent pods  |
 | additionalLabels | object | `{}` | Additional labels that should be applied to all resources  |
 | affinity | object | `{}` | Standard K8s affinities that will be applied to all Bamboo agent pods  |
 | agent.additionalEnvironmentVariables | list | `[]` | Defines any additional environment variables to be passed to the Bamboo agent container. See https://bitbucket.org/atlassian-docker/docker-bamboo-agent-base for supported variables.  |
 | agent.additionalPorts | list | `[]` | Defines any additional ports for the Bamboo agent container.  |
-| agent.additionalVolumeMounts | object | `{}` | Defines any additional volumes mounts for the Bamboo agent container. These can refer to existing volumes, or new volumes can be defined via 'volumes.additional'.  |
+| agent.additionalVolumeMounts | object | `{}` | Defines any additional volume mounts for the Bamboo agent container. These can refer to existing volumes, or new volumes can be defined via 'volumes.additional'.  |
 | agent.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. https://kubernetes.io/docs/tasks/configure-pod-container/security-context/  |
 | agent.readinessProbe.command | string | `"/probe-readiness.sh"` | Command to use to check the readiness status. This is provided by the agent image.  |
 | agent.readinessProbe.failureThreshold | int | `30` | The number of consecutive failures of the Bamboo agent container readiness probe before the pod fails readiness checks.  |

--- a/src/main/charts/bamboo-agent/templates/deployment-agent.yaml
+++ b/src/main/charts/bamboo-agent/templates/deployment-agent.yaml
@@ -85,6 +85,11 @@ spec:
           {{- end }}
           volumeMounts:
             {{- include "agent.additionalVolumeMounts" . | nindent 12 }}
+            {{- range $i, $n := .Values.additionalFiles }}
+            - name: {{ .name }}-{{$i}}
+              mountPath: {{ .mountPath }}/{{ .key }}
+              subPath: {{ .key }}
+            {{ end }}
           {{ if .Values.agent.additionalPorts }}
           ports:
           {{- include "agent.additionalPorts" . | nindent 12 }}
@@ -119,3 +124,11 @@ spec:
       {{- end }}
       volumes:
         {{ include "agent.additionalVolumes" . | nindent 8 }}
+        {{- range $i, $n := .Values.additionalFiles }}
+        - name: {{ .name }}-{{$i}}
+          {{ .type }}:
+            {{ if hasPrefix .type "secret" }}{{ .type}}Name{{ else }}name{{ end }}: {{ .name }}
+            items:
+              - key: {{ .key }}
+                path: {{ .key }}
+        {{ end }}

--- a/src/main/charts/bamboo-agent/values.yaml
+++ b/src/main/charts/bamboo-agent/values.yaml
@@ -308,6 +308,29 @@ additionalInitContainers: []
 additionalLabels: {}
 #  name: <value>
 
+# -- Additional existing ConfigMaps and Secrets not managed by Helm that should be
+# mounted into service container. Configuration details below (camelCase is important!):
+  # 'name'      - References existing ConfigMap or secret name.
+  # 'type'      - 'configMap' or 'secret'
+  # 'key'       - The file name.
+  # 'mountPath' - The destination directory in a container.
+# VolumeMount and Volumes are added with this name and index position, for example;
+# custom-config-0, keystore-2
+#
+additionalFiles: []
+#  - name: custom-config
+#    type: configMap
+#    key: log4j.properties
+#    mountPath:  /var/atlassian
+#  - name: custom-config
+#    type: configMap
+#    key: web.xml
+#    mountPath: /var/atlassian
+#  - name: keystore
+#    type: secret
+#    key: keystore.jks
+#    mountPath: /var/ssl
+
 # -- Additional host aliases for each pod, equivalent to adding them to the /etc/hosts file.
 # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 additionalHosts: []

--- a/src/main/charts/bamboo-agent/values.yaml
+++ b/src/main/charts/bamboo-agent/values.yaml
@@ -310,7 +310,7 @@ additionalLabels: {}
 
 # -- Additional existing ConfigMaps and Secrets not managed by Helm that should be
 # mounted into service container. Configuration details below (camelCase is important!):
-  # 'name'      - References existing ConfigMap or secret name.
+  # 'name'      - References existing ConfigMap or Secret name.
   # 'type'      - 'configMap' or 'secret'
   # 'key'       - The file name.
   # 'mountPath' - The destination directory in a container.


### PR DESCRIPTION
Resolves https://github.com/atlassian/data-center-helm-charts/issues/579

Mounting files like maven's settings.xml is way easier with additionalFiles rather than with init containers and additional volume(-mounts).

## Checklist
- [x] I have added unit tests
- [x] The E2E test has passed (use `e2e` label)
