### PR TITLE
Disable liveness probes by default, make timeoutSeconds configurable

### DIFF
--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -52,10 +52,11 @@ Kubernetes: `>=1.21.x-0`
 | bamboo.license | object | `{"secretKey":"license","secretName":null}` | The Bamboo DC license that should be used. If supplied here the license configuration will be skipped in the setup wizard.  |
 | bamboo.license.secretKey | string | `"license"` | The key (default 'licenseKey') in the Secret used to store the license information  |
 | bamboo.license.secretName | string | `nil` | The secret that contains the license information  |
-| bamboo.livenessProbe.enabled | bool | `true` | Whether to apply the livenessProbe check to pod.  |
+| bamboo.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | bamboo.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Bamboo container liveness probe before the pod fails liveness checks.  |
 | bamboo.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |
 | bamboo.livenessProbe.periodSeconds | int | `5` | How often (in seconds) the Bamboo container liveness probe will run  |
+| bamboo.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | bamboo.ports.http | int | `8085` | The port on which the Bamboo container listens for HTTP traffic  |
 | bamboo.ports.jms | int | `54663` | JMS port  |
 | bamboo.readinessProbe.customProbe | object | `{}` | Custom ReadinessProbe to override the default /status httpGet  |
@@ -63,6 +64,7 @@ Kubernetes: `>=1.21.x-0`
 | bamboo.readinessProbe.failureThreshold | int | `30` | The number of consecutive failures of the Bamboo container readiness probe before the pod fails readiness checks.  |
 | bamboo.readinessProbe.initialDelaySeconds | int | `30` | The initial delay (in seconds) for the Bamboo container readiness probe, after which the probe will start running.  |
 | bamboo.readinessProbe.periodSeconds | int | `10` | How often (in seconds) the Bamboo container readiness probe will run  |
+| bamboo.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | bamboo.resources.container.requests.cpu | string | `"2"` | Initial CPU request by Bamboo pod  |
 | bamboo.resources.container.requests.memory | string | `"2G"` | Initial Memory request by Bamboo pod  |
 | bamboo.resources.jvm.maxHeap | string | `"1024m"` | The maximum amount of heap memory that will be used by the Bamboo JVM  |

--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -171,6 +171,7 @@ spec:
               path: {{ .Values.bamboo.service.contextPath }}/rest/api/latest/status
             initialDelaySeconds: {{ .Values.bamboo.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.bamboo.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.bamboo.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.bamboo.readinessProbe.failureThreshold }}
             {{- end }}
           {{- end }}
@@ -185,6 +186,7 @@ spec:
               port: {{ .Values.bamboo.ports.http }}
             initialDelaySeconds: {{ .Values.bamboo.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.bamboo.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.bamboo.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.bamboo.livenessProbe.failureThreshold }}
           {{ end }}
           {{- with .Values.bamboo.containerSecurityContext}}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -608,6 +608,10 @@ bamboo:
     #
     periodSeconds: 10
 
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
+
     # -- The number of consecutive failures of the Bamboo container readiness probe
     # before the pod fails readiness checks.
     #
@@ -642,7 +646,7 @@ bamboo:
 
     # -- Whether to apply the livenessProbe check to pod.
     #
-    enabled: true
+    enabled: false
 
     # -- Time to wait before starting the first probe
     #
@@ -651,6 +655,10 @@ bamboo:
     # -- How often (in seconds) the Bamboo container liveness probe will run
     #
     periodSeconds: 5
+
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
 
     # -- The number of consecutive failures of the Bamboo container liveness probe
     # before the pod fails liveness checks.

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -49,10 +49,11 @@ Kubernetes: `>=1.21.x-0`
 | bitbucket.elasticSearch.credentials.usernameSecretKey | string | `"username"` | The key in the Kubernetes Secret that contains the Elasticsearch username.  |
 | bitbucket.license.secretKey | string | `"license-key"` | The key in the K8s Secret that contains the Bitbucket license key  |
 | bitbucket.license.secretName | string | `nil` | The name of the K8s Secret that contains the Bitbucket license key. If specified, then the license will be automatically populated during Bitbucket setup. Otherwise, it will need to be provided via the browser after initial startup. An Example of creating a K8s secret for the license below: 'kubectl create secret generic <secret-name> --from-literal=license-key=<license> https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets  |
-| bitbucket.livenessProbe.enabled | bool | `true` | Whether to apply the livenessProbe check to pod.  |
+| bitbucket.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | bitbucket.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Bitbucket container liveness probe before the pod fails liveness checks.  |
 | bitbucket.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |
 | bitbucket.livenessProbe.periodSeconds | int | `5` | How often (in seconds) the Bitbucket container liveness probe will run  |
+| bitbucket.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | bitbucket.mesh.additionalEnvironmentVariables | object | `{}` | Defines any additional environment variables to be passed to the Bitbucket mesh containers.  |
 | bitbucket.mesh.additionalFiles | string | `nil` | Additional existing ConfigMaps and Secrets not managed by Helm that should be mounted into service container  |
 | bitbucket.mesh.additionalInitContainers | object | `{}` | Additional initContainer definitions that will be added to all Bitbucket pods  |
@@ -93,6 +94,7 @@ Kubernetes: `>=1.21.x-0`
 | bitbucket.readinessProbe.failureThreshold | int | `60` | The number of consecutive failures of the Bitbucket container readiness probe before the pod fails readiness checks.  |
 | bitbucket.readinessProbe.initialDelaySeconds | int | `10` | The initial delay (in seconds) for the Bitbucket container readiness probe, after which the probe will start running.  |
 | bitbucket.readinessProbe.periodSeconds | int | `5` | How often (in seconds) the Bitbucket container readiness probe will run  |
+| bitbucket.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | bitbucket.resources.container.requests.cpu | string | `"2"` | Initial CPU request by Bitbucket pod  |
 | bitbucket.resources.container.requests.memory | string | `"2G"` | Initial Memory request by Bitbucket pod  |
 | bitbucket.resources.jvm.maxHeap | string | `"1g"` | The maximum amount of heap memory that will be used by the Bitbucket JVM The same value will be used by the Elasticsearch JVM. |

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -93,6 +93,7 @@ spec:
               path: {{ .Values.bitbucket.service.contextPath }}/status
             initialDelaySeconds: {{ .Values.bitbucket.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.bitbucket.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.bitbucket.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.bitbucket.readinessProbe.failureThreshold }}
             {{- end }}
           {{- end }}
@@ -107,6 +108,7 @@ spec:
               port: {{ .Values.bitbucket.ports.http }}
             initialDelaySeconds: {{ .Values.bitbucket.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.bitbucket.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.bitbucket.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.bitbucket.livenessProbe.failureThreshold }}
           {{ end }}
           {{- with .Values.bitbucket.containerSecurityContext}}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -674,6 +674,10 @@ bitbucket:
     #
     periodSeconds: 5
 
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
+
     # -- The number of consecutive failures of the Bitbucket container readiness probe
     # before the pod fails readiness checks.
     #
@@ -708,7 +712,7 @@ bitbucket:
 
     # -- Whether to apply the livenessProbe check to pod.
     #
-    enabled: true
+    enabled: false
 
     # -- Time to wait before starting the first probe
     #
@@ -717,6 +721,10 @@ bitbucket:
     # -- How often (in seconds) the Bitbucket container liveness probe will run
     #
     periodSeconds: 5
+
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
 
     # -- The number of consecutive failures of the Bitbucket container liveness probe
     # before the pod fails liveness checks.

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -46,10 +46,11 @@ Kubernetes: `>=1.21.x-0`
 | confluence.jvmDebug.enabled | bool | `false` | Set to 'true' for remote debugging. Confluence JVM will be started with debugging port 5005 open. |
 | confluence.license.secretKey | string | `"license-key"` | The key in the K8s Secret that contains the Confluence license key  |
 | confluence.license.secretName | string | `nil` | The name of the K8s Secret that contains the Confluence license key. If specified, then the license will be automatically populated during Confluence setup. Otherwise, it will need to be provided via the browser after initial startup. An Example of creating a K8s secret for the license below: 'kubectl create secret generic <secret-name> --from-literal=license-key=<license> https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets  |
-| confluence.livenessProbe.enabled | bool | `true` | Whether to apply the livenessProbe check to pod.  |
+| confluence.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | confluence.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Confluence container liveness probe before the pod fails liveness checks.  |
 | confluence.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |
 | confluence.livenessProbe.periodSeconds | int | `5` | How often (in seconds) the Confluence container liveness probe will run  |
+| confluence.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | confluence.ports.hazelcast | int | `5701` | The port on which the Confluence container listens for Hazelcast traffic  |
 | confluence.ports.http | int | `8090` | The port on which the Confluence container listens for HTTP traffic  |
 | confluence.readinessProbe.customProbe | object | `{}` | Custom readinessProbe to override the default /status httpGet  |
@@ -57,6 +58,7 @@ Kubernetes: `>=1.21.x-0`
 | confluence.readinessProbe.failureThreshold | int | `6` | The number of consecutive failures of the Confluence container readiness probe before the pod fails readiness checks.  |
 | confluence.readinessProbe.initialDelaySeconds | int | `10` | The initial delay (in seconds) for the Confluence container readiness probe, after which the probe will start running.  |
 | confluence.readinessProbe.periodSeconds | int | `5` | How often (in seconds) the Confluence container readiness probe will run  |
+| confluence.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | confluence.resources.container.requests.cpu | string | `"2"` | Initial CPU request by Confluence pod.  |
 | confluence.resources.container.requests.memory | string | `"2G"` | Initial Memory request by Confluence pod  |
 | confluence.resources.jvm.maxHeap | string | `"1g"` | The maximum amount of heap memory that will be used by the Confluence JVM  |

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -82,6 +82,7 @@ spec:
               path: {{ .Values.confluence.service.contextPath }}/status
             initialDelaySeconds: {{ .Values.confluence.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.confluence.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.confluence.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.confluence.readinessProbe.failureThreshold }}
             {{- end }}
           {{- end }}
@@ -96,6 +97,7 @@ spec:
               port: {{ .Values.confluence.ports.http }}
             initialDelaySeconds: {{ .Values.confluence.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.confluence.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.confluence.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.confluence.livenessProbe.failureThreshold }}
           {{ end }}
           {{- with .Values.confluence.containerSecurityContext}}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -606,6 +606,10 @@ confluence:
     #
     periodSeconds: 5
 
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
+
     # -- The number of consecutive failures of the Confluence container readiness probe
     # before the pod fails readiness checks.
     #
@@ -640,7 +644,7 @@ confluence:
 
     # -- Whether to apply the livenessProbe check to pod.
     #
-    enabled: true
+    enabled: false
 
     # -- Time to wait before starting the first probe
     #
@@ -649,6 +653,10 @@ confluence:
     # -- How often (in seconds) the Confluence container liveness probe will run
     #
     periodSeconds: 5
+
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
 
     # -- The number of consecutive failures of the Confluence container liveness probe
     # before the pod fails liveness checks.

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -40,16 +40,18 @@ Kubernetes: `>=1.21.x-0`
 | crowd.additionalVolumeClaimTemplates | list | `[]` | Defines additional volumeClaimTemplates that should be applied to the Crowd pod. Note that this will not create any corresponding volume mounts; those needs to be defined in crowd.additionalVolumeMounts  |
 | crowd.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Crowd container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
 | crowd.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. https://kubernetes.io/docs/tasks/configure-pod-container/security-context/  |
-| crowd.livenessProbe.enabled | bool | `true` | Whether to apply the livenessProbe check to pod.  |
+| crowd.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | crowd.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Crowd container liveness probe before the pod fails liveness checks.  |
 | crowd.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |
 | crowd.livenessProbe.periodSeconds | int | `5` | How often (in seconds) the Crowd container liveness probe will run  |
+| crowd.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | crowd.ports.http | int | `8095` | The port on which the Crowd container listens for HTTP traffic  |
 | crowd.readinessProbe.customProbe | object | `{}` | Custom readinessProbe to override the default /status httpGet  |
 | crowd.readinessProbe.enabled | bool | `true` | Whether to apply the readinessProbe check to pod.  |
 | crowd.readinessProbe.failureThreshold | int | `10` | The number of consecutive failures of the Crowd container readiness probe before the pod fails readiness checks.  |
 | crowd.readinessProbe.initialDelaySeconds | int | `10` | The initial delay (in seconds) for the Crowd container readiness probe, after which the probe will start running.  |
 | crowd.readinessProbe.periodSeconds | int | `5` | How often (in seconds) the Crowd container readiness probe will run  |
+| crowd.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | crowd.resources.container.requests.cpu | string | `"2"` | Initial CPU request by Crowd pod  |
 | crowd.resources.container.requests.memory | string | `"1G"` | Initial Memory request by Crowd pod  |
 | crowd.resources.jvm.maxHeap | string | `"768m"` | The maximum amount of heap memory that will be used by the Crowd JVM  |

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -79,6 +79,7 @@ spec:
               path: /crowd/status
             initialDelaySeconds: {{ .Values.crowd.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.crowd.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.crowd.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.crowd.readinessProbe.failureThreshold }}
             {{- end }}
           {{- end }}
@@ -93,6 +94,7 @@ spec:
               port: {{ .Values.crowd.ports.http }}
             initialDelaySeconds: {{ .Values.crowd.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.crowd.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.crowd.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.crowd.livenessProbe.failureThreshold }}
           {{ end }}
           {{- with .Values.crowd.containerSecurityContext}}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -178,6 +178,10 @@ crowd:
     #
     periodSeconds: 5
 
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
+
     # -- The number of consecutive failures of the Crowd container readiness probe
     # before the pod fails readiness checks.
     #
@@ -209,7 +213,7 @@ crowd:
 
     # -- Whether to apply the livenessProbe check to pod.
     #
-    enabled: true
+    enabled: false
 
     # -- Time to wait before starting the first probe
     #
@@ -218,6 +222,10 @@ crowd:
     # -- How often (in seconds) the Crowd container liveness probe will run
     #
     periodSeconds: 5
+
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
 
     # -- The number of consecutive failures of the Crowd container liveness probe
     # before the pod fails liveness checks.

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -73,10 +73,11 @@ Kubernetes: `>=1.21.x-0`
 | jira.clustering.enabled | bool | `false` | Set to 'true' if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes.  |
 | jira.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. https://kubernetes.io/docs/tasks/configure-pod-container/security-context/  |
 | jira.forceConfigUpdate | bool | `false` | The Docker entrypoint.py generates application configuration on first start; not all of these files are regenerated on subsequent starts. By default, dbconfig.xml is generated only once. Set `forceConfigUpdate` to true to change this behavior.  |
-| jira.livenessProbe.enabled | bool | `true` | Whether to apply the livenessProbe check to pod.  |
+| jira.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | jira.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Jira container liveness probe before the pod fails liveness checks.  |
 | jira.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |
 | jira.livenessProbe.periodSeconds | int | `5` | How often (in seconds) the Jira container liveness probe will run  |
+| jira.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | jira.ports.ehcache | int | `40001` | Ehcache port  |
 | jira.ports.ehcacheobject | int | `40011` | Ehcache object port  |
 | jira.ports.http | int | `8080` | The port on which the Jira container listens for HTTP traffic  |
@@ -85,6 +86,7 @@ Kubernetes: `>=1.21.x-0`
 | jira.readinessProbe.failureThreshold | int | `10` | The number of consecutive failures of the Jira container readiness probe before the pod fails readiness checks.  |
 | jira.readinessProbe.initialDelaySeconds | int | `10` | The initial delay (in seconds) for the Jira container readiness probe, after which the probe will start running.  |
 | jira.readinessProbe.periodSeconds | int | `5` | How often (in seconds) the Jira container readiness probe will run  |
+| jira.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | jira.resources.container.requests.cpu | string | `"2"` | Initial CPU request by Jira pod  |
 | jira.resources.container.requests.memory | string | `"2G"` | Initial Memory request by Jira pod  |
 | jira.resources.jvm.maxHeap | string | `"768m"` | The maximum amount of heap memory that will be used by the Jira JVM  |

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -132,6 +132,7 @@ spec:
               path: {{ .Values.jira.service.contextPath }}/status
             initialDelaySeconds: {{ .Values.jira.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.jira.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.jira.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.jira.readinessProbe.failureThreshold }}
             {{- end }}
           {{- end }}
@@ -146,6 +147,7 @@ spec:
               port: {{ .Values.jira.ports.http }}
             initialDelaySeconds: {{ .Values.jira.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.jira.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.jira.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.jira.livenessProbe.failureThreshold }}
           {{ end }}
           {{- with .Values.jira.containerSecurityContext}}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -494,6 +494,10 @@ jira:
     #
     periodSeconds: 5
 
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
+
     # -- The number of consecutive failures of the Jira container readiness probe
     # before the pod fails readiness checks.
     #
@@ -528,7 +532,7 @@ jira:
 
     # -- Whether to apply the livenessProbe check to pod.
     #
-    enabled: true
+    enabled: false
 
     # -- Time to wait before starting the first probe
     #
@@ -537,6 +541,10 @@ jira:
     # -- How often (in seconds) the Jira container liveness probe will run
     #
     periodSeconds: 5
+
+    # -- Number of seconds after which the probe times out
+    #
+    timeoutSeconds: 1
 
     # -- The number of consecutive failures of the Jira container liveness probe
     # before the pod fails liveness checks.

--- a/src/test/java/test/ReadinessLivenessProbesTest.java
+++ b/src/test/java/test/ReadinessLivenessProbesTest.java
@@ -34,8 +34,7 @@ public class ReadinessLivenessProbesTest {
     @ParameterizedTest
     @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
     void test_liveness_probe_disabled(Product product) throws Exception {
-        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
-                product + ".livenessProbe.enabled", "false"));
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of());
 
         assertThat(resources.getStatefulSet(
                 product.getHelmReleaseName()).getContainer().get("livenessProbe")).isEmpty();
@@ -45,31 +44,23 @@ public class ReadinessLivenessProbesTest {
 
     @ParameterizedTest
     @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
-    void test_liveness_probe_defaults(Product product) throws Exception {
-        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of());
-
-        assertEquals("60", resources.getStatefulSet(
-                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("initialDelaySeconds").asText());
-        assertEquals("5", resources.getStatefulSet(
-                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("periodSeconds").asText());
-        assertEquals("12", resources.getStatefulSet(
-                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("failureThreshold").asText());
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
     void test_liveness_probe_overrides(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".livenessProbe.enabled", "true",
                 product + ".livenessProbe.initialDelaySeconds", "1111",
-                product + ".livenessProbe.periodSeconds", "1111",
-                product + ".livenessProbe.failureThreshold", "1111"));
+                product + ".livenessProbe.periodSeconds", "2222",
+                product + ".livenessProbe.failureThreshold", "3333",
+                product + ".livenessProbe.timeoutSeconds", "4444"));
 
         assertEquals("1111", resources.getStatefulSet(
                 product.getHelmReleaseName()).getContainer().get("livenessProbe").get("initialDelaySeconds").asText());
-        assertEquals("1111", resources.getStatefulSet(
+        assertEquals("2222", resources.getStatefulSet(
                         product.getHelmReleaseName()).getContainer().get("livenessProbe").get("periodSeconds").asText());
-        assertEquals("1111", resources.getStatefulSet(
+        assertEquals("3333", resources.getStatefulSet(
                 product.getHelmReleaseName()).getContainer().get("livenessProbe").get("failureThreshold").asText());
+        assertEquals("4444", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("timeoutSeconds").asText());
+
     }
 
     @ParameterizedTest
@@ -78,7 +69,8 @@ public class ReadinessLivenessProbesTest {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 product + ".readinessProbe.initialDelaySeconds", "2222",
                 product + ".readinessProbe.periodSeconds", "2222",
-                product + ".readinessProbe.failureThreshold", "2222"));
+                product + ".readinessProbe.failureThreshold", "2222",
+                product + ".readinessProbe.timeoutSeconds", "3333"));
 
         assertEquals("2222", resources.getStatefulSet(
                 product.getHelmReleaseName()).getContainer().get("readinessProbe").get("initialDelaySeconds").asText());
@@ -86,6 +78,9 @@ public class ReadinessLivenessProbesTest {
                 product.getHelmReleaseName()).getContainer().get("readinessProbe").get("periodSeconds").asText());
         assertEquals("2222", resources.getStatefulSet(
                 product.getHelmReleaseName()).getContainer().get("readinessProbe").get("failureThreshold").asText());
+        assertEquals("3333", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("readinessProbe").get("timeoutSeconds").asText());
+
     }
 
     @ParameterizedTest
@@ -95,6 +90,7 @@ public class ReadinessLivenessProbesTest {
                 product + ".readinessProbe.customProbe.tcpSocket.port", "9999",
                 product + ".readinessProbe.customProbe.periodSeconds", "3333",
                 product + ".readinessProbe.customProbe.failureThreshold", "3333",
+                product + ".readinessProbe.customProbe.timeoutSeconds", "4444",
                 product + ".readinessProbe.customProbe.foo", "bar"));
 
         assertEquals("9999", resources.getStatefulSet(
@@ -103,6 +99,8 @@ public class ReadinessLivenessProbesTest {
                 product.getHelmReleaseName()).getContainer().get("readinessProbe").get("periodSeconds").asText());
         assertEquals("3333", resources.getStatefulSet(
                 product.getHelmReleaseName()).getContainer().get("readinessProbe").get("failureThreshold").asText());
+        assertEquals("4444", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("readinessProbe").get("timeoutSeconds").asText());
         assertEquals("bar", resources.getStatefulSet(
                 product.getHelmReleaseName()).getContainer().get("readinessProbe").get("foo").asText());
     }

--- a/src/test/java/test/ReadinessLivenessProbesTest.java
+++ b/src/test/java/test/ReadinessLivenessProbesTest.java
@@ -60,7 +60,22 @@ public class ReadinessLivenessProbesTest {
                 product.getHelmReleaseName()).getContainer().get("livenessProbe").get("failureThreshold").asText());
         assertEquals("4444", resources.getStatefulSet(
                 product.getHelmReleaseName()).getContainer().get("livenessProbe").get("timeoutSeconds").asText());
+    }
 
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    void test_liveness_probe_enabled_defaults(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".livenessProbe.enabled", "true"));
+
+        assertEquals("60", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("initialDelaySeconds").asText());
+        assertEquals("5", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("periodSeconds").asText());
+        assertEquals("12", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("failureThreshold").asText());
+        assertEquals("1", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("timeoutSeconds").asText());
     }
 
     @ParameterizedTest

--- a/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
@@ -46,7 +46,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 9d6df9e842a16c8d113b526a2407380613910a3cbc5b059d3e308f4c62f7d609
       labels:
         app.kubernetes.io/name: bamboo-agent
         app.kubernetes.io/instance: unittest-bamboo-agent

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -147,7 +147,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 709d1619d8b17d03e760ca2db4259440ede2b18986fc03218b826c7a60bf10df
       labels:
         app.kubernetes.io/name: bamboo
         app.kubernetes.io/instance: unittest-bamboo
@@ -266,18 +265,13 @@ spec:
               path: /rest/api/latest/status
             initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 1
             failureThreshold: 30
           startupProbe:
             tcpSocket:
               port: 8085
             periodSeconds: 5
             failureThreshold: 120
-          livenessProbe:
-            tcpSocket:
-              port: 8085
-            initialDelaySeconds: 60
-            periodSeconds: 5
-            failureThreshold: 12
           resources:
             requests:
               cpu: "2"

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -228,7 +228,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 0ea032a1623ffae83c3ce0bca16d5e4c438bf579a5e2d19574f44e5db0da1aae
       labels:
         app.kubernetes.io/name: bitbucket-mesh
         app.kubernetes.io/instance: unittest-bitbucket
@@ -351,7 +350,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: d91a30f5b871fcb02a5dd509ac21fe4d7e30f799b8583caa7a3bdac1d16118a3
       labels:
         app.kubernetes.io/name: bitbucket
         app.kubernetes.io/instance: unittest-bitbucket
@@ -398,18 +396,13 @@ spec:
               path: /status
             initialDelaySeconds: 10
             periodSeconds: 5
+            timeoutSeconds: 1
             failureThreshold: 60
           startupProbe:
             tcpSocket:
               port: 7990
             periodSeconds: 5
             failureThreshold: 120
-          livenessProbe:
-            tcpSocket:
-              port: 7990
-            initialDelaySeconds: 60
-            periodSeconds: 5
-            failureThreshold: 12
           volumeMounts:
             - name: local-home
               mountPath: "/var/atlassian/application-data/bitbucket"

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -177,7 +177,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 5c7e4f3183d49bd4e8c82a29b06246e551e4120042495652f1f9b27a0599a882
       labels:
         app.kubernetes.io/name: confluence-synchrony
         app.kubernetes.io/instance: unittest-confluence
@@ -259,7 +258,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 4fdfde7465372cf9f07fb2cd16f1cb099cee19b89e16e62e49bb08f1ad7b7a64
       labels:
         app.kubernetes.io/name: confluence
         app.kubernetes.io/instance: unittest-confluence
@@ -311,18 +309,13 @@ spec:
               path: /status
             initialDelaySeconds: 10
             periodSeconds: 5
+            timeoutSeconds: 1
             failureThreshold: 6
           startupProbe:
             tcpSocket:
               port: 8090
             periodSeconds: 5
             failureThreshold: 120
-          livenessProbe:
-            tcpSocket:
-              port: 8090
-            initialDelaySeconds: 60
-            periodSeconds: 5
-            failureThreshold: 12
           resources:
             requests:
               cpu: "2"

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -126,7 +126,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 8128b3aa5ee43a553b5c6f6c3cd46cd80433d3332a1b5b9c934121d91f512441
       labels:
         app.kubernetes.io/name: crowd
         app.kubernetes.io/instance: unittest-crowd
@@ -176,18 +175,13 @@ spec:
               path: /crowd/status
             initialDelaySeconds: 10
             periodSeconds: 5
+            timeoutSeconds: 1
             failureThreshold: 10
           startupProbe:
             tcpSocket:
               port: 8095
             periodSeconds: 5
             failureThreshold: 120
-          livenessProbe:
-            tcpSocket:
-              port: 8095
-            initialDelaySeconds: 60
-            periodSeconds: 5
-            failureThreshold: 12
           resources:
             requests:
               cpu: "2"

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -124,7 +124,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 595c1112fd40d0b864b14b94e49d4f08e724ee5433b78417e4bfb4a0326b1049
       labels:
         app.kubernetes.io/name: jira
         app.kubernetes.io/instance: unittest-jira
@@ -211,18 +210,13 @@ spec:
               path: /status
             initialDelaySeconds: 10
             periodSeconds: 5
+            timeoutSeconds: 1
             failureThreshold: 10
           startupProbe:
             tcpSocket:
               port: 8080
             periodSeconds: 5
             failureThreshold: 120
-          livenessProbe:
-            tcpSocket:
-              port: 8080
-            initialDelaySeconds: 60
-            periodSeconds: 5
-            failureThreshold: 12
           resources:
             requests:
               cpu: "2"


### PR DESCRIPTION
In certain situations livenessProbes can be disruptive. This PR makes them off by default. Also, adding timeoutSeconds for both readiness and liveness probes.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
