### PR TITLE
Add annotations to Grafana dashboards ConfigMaps

### DIFF
--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -128,6 +128,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom jmx config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -129,7 +129,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
-| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom jmx config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/bamboo/templates/configmaps-grafana-dashboards.yaml
+++ b/src/main/charts/bamboo/templates/configmaps-grafana-dashboards.yaml
@@ -12,6 +12,12 @@ metadata:
     {{- with .Values.monitoring.grafana.dashboardLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if .Values.monitoring.grafana.dashboardAnnotations }}
+  annotations:
+    {{- with .Values.monitoring.grafana.dashboardAnnotations}}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 data:
   {{ include "common.names.fullname" . }}-{{ .Release.Namespace}}-{{ $fileName._1}}: |
 {{ .Files.Get $index | indent 4 }}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -883,6 +883,11 @@ monitoring:
     dashboardLabels: {}
     # grafana_dashboard: dc_monitoring
 
+    # -- Annotations added to Grafana dashboards ConfigMaps
+    #
+    dashboardAnnotations: {}
+      # k8s-sidecar-target-directory: /tmp/dashboards/example-folder
+
 # Fluentd configuration
 #
 # Bamboo log collection and aggregation can be enabled using Fluentd. This config

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -883,7 +883,7 @@ monitoring:
     dashboardLabels: {}
     # grafana_dashboard: dc_monitoring
 
-    # -- Annotations added to Grafana dashboards ConfigMaps
+    # -- Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage
     #
     dashboardAnnotations: {}
       # k8s-sidecar-target-directory: /tmp/dashboards/example-folder

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -161,7 +161,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
-| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom JMX config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -160,6 +160,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom JMX config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/bitbucket/templates/configmap-mesh-grafana-dashboards.yaml
+++ b/src/main/charts/bitbucket/templates/configmap-mesh-grafana-dashboards.yaml
@@ -12,6 +12,12 @@ metadata:
     {{- with .Values.monitoring.grafana.dashboardLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if .Values.monitoring.grafana.dashboardAnnotations }}
+  annotations:
+    {{- with .Values.monitoring.grafana.dashboardAnnotations}}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 data:
   {{ include "common.names.fullname" . }}-{{ .Release.Namespace}}-{{ $fileName._2}}: |
 {{ .Files.Get $index | indent 4 }}

--- a/src/main/charts/bitbucket/templates/configmaps-grafana-dashboards.yaml
+++ b/src/main/charts/bitbucket/templates/configmaps-grafana-dashboards.yaml
@@ -12,6 +12,12 @@ metadata:
     {{- with .Values.monitoring.grafana.dashboardLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if .Values.monitoring.grafana.dashboardAnnotations }}
+  annotations:
+    {{- with .Values.monitoring.grafana.dashboardAnnotations}}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 data:
   {{ include "common.names.fullname" . }}-{{ .Release.Namespace}}-{{ $fileName._1}}: |
 {{ .Files.Get $index | indent 4 }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -1156,7 +1156,7 @@ monitoring:
     dashboardLabels: {}
       # grafana_dashboard: dc_monitoring
 
-    # -- Annotations added to Grafana dashboards ConfigMaps
+    # -- Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage
     #
     dashboardAnnotations: {}
       # k8s-sidecar-target-directory: /tmp/dashboards/example-folder

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -1156,6 +1156,11 @@ monitoring:
     dashboardLabels: {}
       # grafana_dashboard: dc_monitoring
 
+    # -- Annotations added to Grafana dashboards ConfigMaps
+    #
+    dashboardAnnotations: {}
+      # k8s-sidecar-target-directory: /tmp/dashboards/example-folder
+
 # Fluentd configuration
 #
 # Bitbucket log collection and aggregation can be enabled using Flunetd. This config

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -124,7 +124,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
-| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom jmx config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -123,6 +123,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom jmx config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/confluence/templates/configmaps-grafana-dashboards.yaml
+++ b/src/main/charts/confluence/templates/configmaps-grafana-dashboards.yaml
@@ -12,6 +12,12 @@ metadata:
     {{- with .Values.monitoring.grafana.dashboardLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if .Values.monitoring.grafana.dashboardAnnotations }}
+  annotations:
+    {{- with .Values.monitoring.grafana.dashboardAnnotations}}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 data:
   {{ include "common.names.fullname" . }}-{{ .Release.Namespace}}-{{ $fileName._1}}: |
 {{ .Files.Get $index | indent 4 }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -987,7 +987,7 @@ monitoring:
     dashboardLabels: {}
       # grafana_dashboard: dc_monitoring
 
-    # -- Annotations added to Grafana dashboards ConfigMaps
+    # -- Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage
     #
     dashboardAnnotations: {}
       # k8s-sidecar-target-directory: /tmp/dashboards/example-folder

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -987,6 +987,11 @@ monitoring:
     dashboardLabels: {}
       # grafana_dashboard: dc_monitoring
 
+    # -- Annotations added to Grafana dashboards ConfigMaps
+    #
+    dashboardAnnotations: {}
+      # k8s-sidecar-target-directory: /tmp/dashboards/example-folder
+
 # Confluence Synchrony configuration
 # https://confluence.atlassian.com/doc/configuring-synchrony-858772125.html
 synchrony:

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -103,7 +103,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
-| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom jmx config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -102,6 +102,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom jmx config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -858,7 +858,7 @@ monitoring:
     dashboardLabels: {}
     # grafana_dashboard: dc_monitoring
     
-    # -- Annotations added to Grafana dashboards ConfigMaps
+    # -- Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage
     #
     dashboardAnnotations: {}
       # k8s-sidecar-target-directory: /tmp/dashboards/example-folder

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -840,3 +840,8 @@ monitoring:
     #
     dashboardLabels: {}
     # grafana_dashboard: dc_monitoring
+    
+    # -- Annotations added to Grafana dashboards ConfigMaps
+    #
+    dashboardAnnotations: {}
+      # k8s-sidecar-target-directory: /tmp/dashboards/example-folder

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -120,7 +120,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
-| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom jmx config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -119,6 +119,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.exposeJmxMetrics | bool | `false` | Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter  |
 | monitoring.fetchJmxExporterJar | bool | `true` | Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar to shared home and provide an absolute path in jmxExporterCustomJarLocation  |
 | monitoring.grafana.createDashboards | bool | `false` | Create ConfigMaps with Grafana dashboards  |
+| monitoring.grafana.dashboardAnnotations | object | `{}` | Annotations added to Grafana dashboards ConfigMaps  |
 | monitoring.grafana.dashboardLabels | object | `{}` | Label selector for Grafana dashboard importer sidecar  |
 | monitoring.jmxExporterCustomConfig | object | `{}` | Custom jmx config with the rules. Make sure to keep jmx-config key  |
 | monitoring.jmxExporterCustomJarLocation | string | `nil` | Location of jmx_exporter jar file if mounted from a secret or manually copied to shared home  |

--- a/src/main/charts/jira/templates/configmaps-grafana-dashboards.yaml
+++ b/src/main/charts/jira/templates/configmaps-grafana-dashboards.yaml
@@ -12,6 +12,12 @@ metadata:
     {{- with .Values.monitoring.grafana.dashboardLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if .Values.monitoring.grafana.dashboardAnnotations }}
+  annotations:
+    {{- with .Values.monitoring.grafana.dashboardAnnotations}}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 data:
   {{ include "common.names.fullname" . }}-{{ .Release.Namespace}}-{{ $fileName._1}}: |
 {{ .Files.Get $index | indent 4 }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -848,6 +848,11 @@ monitoring:
     #
     dashboardLabels: {}
       # grafana_dashboard: dc_monitoring
+    
+    # -- Annotations added to Grafana dashboards ConfigMaps
+    #
+    dashboardAnnotations: {}
+      # k8s-sidecar-target-directory: /tmp/dashboards/example-folder
 
 # Fluentd configuration
 #

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -849,7 +849,7 @@ monitoring:
     dashboardLabels: {}
       # grafana_dashboard: dc_monitoring
     
-    # -- Annotations added to Grafana dashboards ConfigMaps
+    # -- Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage
     #
     dashboardAnnotations: {}
       # k8s-sidecar-target-directory: /tmp/dashboards/example-folder


### PR DESCRIPTION
Addresses https://github.com/atlassian/data-center-helm-charts/issues/633

An annotation in the configmap can be a flag for dashboard importer sidecar to import a dashboard into a subdirectory.