### PR TITLE
Add defaultMode to additionalConfigMaps

### DIFF
--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -261,6 +261,9 @@ spec:
         - name: {{ .fileName | replace "_" "-" | replace "." "-" }}
           configMap:
             name: {{ include "common.names.fullname" $ }}-{{ $key.name }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+            {{- end }}
             items:
               - key: {{ .fileName }}
                 path: {{ .fileName }}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -1063,6 +1063,7 @@ additionalConfigMaps: []
 #    keys:
 #      - fileName: hello.properties
 #        mountPath: /opt/atlassian/jira/atlassian-jira/WEB-INF/classes
+#        defaultMode:
 #        content: |
 #          foo=bar
 #          hello=world

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -269,6 +269,9 @@ spec:
         - name: {{ .fileName | replace "_" "-" | replace "." "-" }}
           configMap:
             name: {{ include "common.names.fullname" $ }}-{{ $key.name }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+            {{- end }}
             items:
               - key: {{ .fileName }}
                 path: {{ .fileName }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -1352,6 +1352,7 @@ additionalConfigMaps: []
 #    keys:
 #      - fileName: hello.properties
 #        mountPath: /opt/atlassian/jira/atlassian-jira/WEB-INF/classes
+#        defaultMode:
 #        content: |
 #          foo=bar
 #          hello=world

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -229,6 +229,9 @@ spec:
         - name: {{ .fileName | replace "_" "-" | replace "." "-" }}
           configMap:
             name: {{ include "common.names.fullname" $ }}-{{ $key.name }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+            {{- end }}
             items:
               - key: {{ .fileName }}
                 path: {{ .fileName }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -1364,6 +1364,7 @@ additionalConfigMaps: []
 #    keys:
 #      - fileName: hello.properties
 #        mountPath: /opt/atlassian/jira/atlassian-jira/WEB-INF/classes
+#        defaultMode:
 #        content: |
 #          foo=bar
 #          hello=world

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -212,6 +212,9 @@ spec:
         - name: {{ .fileName | replace "_" "-" | replace "." "-" }}
           configMap:
             name: {{ include "common.names.fullname" $ }}-{{ $key.name }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+            {{- end }}
             items:
               - key: {{ .fileName }}
                 path: {{ .fileName }}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -783,6 +783,7 @@ additionalConfigMaps: []
 #    keys:
 #      - fileName: hello.properties
 #        mountPath: /opt/atlassian/jira/atlassian-jira/WEB-INF/classes
+#        defaultMode:
 #        content: |
 #          foo=bar
 #          hello=world

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -222,6 +222,9 @@ spec:
         - name: {{ .fileName | replace "_" "-" | replace "." "-" }}
           configMap:
             name: {{ include "common.names.fullname" $ }}-{{ $key.name }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+            {{- end }}
             items:
               - key: {{ .fileName }}
                 path: {{ .fileName }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -848,7 +848,7 @@ monitoring:
     #
     dashboardLabels: {}
       # grafana_dashboard: dc_monitoring
-    
+
     # -- Annotations added to Grafana dashboards ConfigMaps. See: https://github.com/kiwigrid/k8s-sidecar#usage
     #
     dashboardAnnotations: {}
@@ -1037,11 +1037,13 @@ additionalConfigMaps: []
 #    keys:
 #      - fileName: hello.properties
 #        mountPath: /opt/atlassian/jira/atlassian-jira/WEB-INF/classes
+#        defaultMode:
 #        content: |
 #          foo=bar
 #          hello=world
 #      - fileName: hello.xml
 #        mountPath: /opt/atlassian/jira/atlassian-jira/WEB-INF/classes
+#        defaultMode:
 #        content: |
 #          <xml>
 #          </xml>


### PR DESCRIPTION
We may want to make mounted files executable, so control over defaultMode will help. Other uses cases - security requirements that may enforce certain default modes.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
