### PR TITLE
Decouple server and jmx svc annotations

### DIFF
--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -139,6 +139,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.jmxServiceAnnotations | object | `{}` | Annotations added to the jmx service  |
 | monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
 | monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
 | monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |

--- a/src/main/charts/bamboo/templates/service-jmx.yaml
+++ b/src/main/charts/bamboo/templates/service-jmx.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
   {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-  {{- with .Values.bamboo.service.annotations }}
+  {{- with .Values.monitoring.jmxServiceAnnotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -833,6 +833,10 @@ monitoring:
   #
   exposeJmxMetrics: false
 
+  # -- Annotations added to the jmx service
+  #
+  jmxServiceAnnotations: {}
+
   # -- Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar
   # to shared home and provide an absolute path in jmxExporterCustomJarLocation
   #

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -171,6 +171,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.jmxServiceAnnotations | object | `{}` | Annotations added to the jmx service  |
 | monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
 | monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
 | monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |

--- a/src/main/charts/bitbucket/templates/service-jmx.yaml
+++ b/src/main/charts/bitbucket/templates/service-jmx.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
   {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-  {{- with .Values.bitbucket.service.annotations }}
+  {{- with .Values.monitoring.jmxServiceAnnotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -1106,6 +1106,10 @@ monitoring:
   #
   exposeJmxMetrics: false
 
+  # -- Annotations added to the jmx service
+  #
+  jmxServiceAnnotations: {}
+
   # -- Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar
   # to shared home and provide an absolute path in jmxExporterCustomJarLocation
   #

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -134,6 +134,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.jmxServiceAnnotations | object | `{}` | Annotations added to the jmx service  |
 | monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
 | monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
 | monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |

--- a/src/main/charts/confluence/templates/service-jmx.yaml
+++ b/src/main/charts/confluence/templates/service-jmx.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
   {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-  {{- with .Values.confluence.service.annotations }}
+  {{- with .Values.monitoring.jmxServiceAnnotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -937,6 +937,10 @@ monitoring:
   #
   exposeJmxMetrics: false
 
+  # -- Annotations added to the jmx service
+  #
+  jmxServiceAnnotations: {}
+
   # -- Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar
   # to shared home and provide an absolute path in jmxExporterCustomJarLocation
   #

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -113,6 +113,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.jmxServiceAnnotations | object | `{}` | Annotations added to the jmx service  |
 | monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
 | monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
 | monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |

--- a/src/main/charts/crowd/templates/service-jmx.yaml
+++ b/src/main/charts/crowd/templates/service-jmx.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
   {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-  {{- with .Values.crowd.service.annotations }}
+  {{- with .Values.monitoring.jmxServiceAnnotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -809,6 +809,10 @@ monitoring:
   #
   exposeJmxMetrics: false
 
+  # -- Annotations added to the jmx service
+  #
+  jmxServiceAnnotations: {}
+
   # -- Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar
   # to shared home and provide an absolute path in jmxExporterCustomJarLocation
   #

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -130,6 +130,7 @@ Kubernetes: `>=1.21.x-0`
 | monitoring.jmxExporterImageTag | string | `"0.18.0"` | Image tag to be used to pull jmxExporterImageRepo  |
 | monitoring.jmxExporterPort | int | `9999` | Port number on which metrics will be available  |
 | monitoring.jmxExporterPortType | string | `"ClusterIP"` | JMX exporter port type  |
+| monitoring.jmxServiceAnnotations | object | `{}` | Annotations added to the jmx service  |
 | monitoring.serviceMonitor.create | bool | `false` | Create ServiceMonitor to start scraping metrics. ServiceMonitor CRD needs to be created in advance.  |
 | monitoring.serviceMonitor.prometheusLabelSelector | object | `{}` | ServiceMonitorSelector of the prometheus instance.  |
 | monitoring.serviceMonitor.scrapeIntervalSeconds | int | `30` | Scrape interval for the JMX service.  |

--- a/src/main/charts/jira/templates/service-jmx.yaml
+++ b/src/main/charts/jira/templates/service-jmx.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
   {{- include "common.labels.commonLabels" . | nindent 4 }}
   annotations:
-  {{- with .Values.jira.service.annotations }}
+  {{- with .Values.monitoring.jmxServiceAnnotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -798,6 +798,10 @@ monitoring:
   # -- Expose JMX metrics with jmx_exporter https://github.com/prometheus/jmx_exporter
   #
   exposeJmxMetrics: false
+  
+  # -- Annotations added to the jmx service
+  #
+  jmxServiceAnnotations: {}
 
   # -- Fetch jmx_exporter jar from the image. If set to false make sure to manually copy the jar
   # to shared home and provide an absolute path in jmxExporterCustomJarLocation

--- a/src/test/java/test/JmxMetricsTest.java
+++ b/src/test/java/test/JmxMetricsTest.java
@@ -134,7 +134,8 @@ class JmxMetricsTest {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "monitoring.exposeJmxMetrics", "true",
                 "monitoring.jmxExporterPort", "9000",
-                "monitoring.jmxExporterPortType", "NodePort"
+                "monitoring.jmxExporterPortType", "NodePort",
+                "monitoring.jmxServiceAnnotations.foo", "bar"
         ));
 
         final var service = resources.get(Kind.Service, Service.class, product.getHelmReleaseName()+"-jmx");
@@ -143,6 +144,9 @@ class JmxMetricsTest {
                 .hasTextEqualTo("NodePort");
         VavrAssertions.assertThat(service.getPort("jmx"))
                 .hasValueSatisfying(node -> assertThat(node.path("port")).hasValueEqualTo(9000));
+        assertThat(service.getAnnotations()).isObject(Map.of(
+                "foo", "bar"
+        ));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
In certain scenarios it is necessary to have a different set of annotations for the main (server) svc and the jmx service. This PR introduces `monitoring.jmxServiceAnnotations` and a unit test case for it.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
