### PR TITLE
Update affinity definition for tpl usage

### DIFF
--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -201,7 +201,7 @@ spec:
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-      {{- toYaml . | nindent 8 }}
+        {{- tpl . $ | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -1300,8 +1300,32 @@ tolerations: []
 
 # -- Standard K8s affinities that will be applied to all Confluence pods
 #
-affinity: {}
-#  name: <value>
+affinity: {} 
+#affinity example to prohibit schedule of pods in same az and on same host to maximise availability in jira ha
+# affinity: |
+#   podAntiAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       - labelSelector:
+#           matchLabels:
+#             {{- include "common.labels.selectorLabels" . | nindent 10 }}
+#           matchExpressions:
+#             - key: app.kubernetes.io/component
+#               operator: NotIn
+#               values:
+#                 - test
+#         topologyKey: kubernetes.io/hostname
+#     preferredDuringSchedulingIgnoredDuringExecution:
+#       - weight: 100
+#         podAffinityTerm:
+#           labelSelector:
+#             matchLabels:
+#               {{- include "common.labels.selectorLabels" . | nindent 12 }}
+#             matchExpressions:
+#               - key: app.kubernetes.io/component
+#                 operator: NotIn
+#                 values:
+#                   - test
+#           topologyKey: topology.kubernetes.io/zone
 
 # -- Standard K8s schedulerName that will be applied to all Confluence pods.
 # Check Kubernetes documentation on how to configure multiple schedulers:

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -194,7 +194,7 @@ spec:
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-      {{- toYaml . | nindent 8 }}
+        {{- tpl . $ | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -969,8 +969,32 @@ tolerations: []
 
 # -- Standard K8s affinities that will be applied to all Jira pods
 #
-affinity: {}
-#  name: <value>
+affinity: {} 
+#affinity example to prohibit schedule of pods in same az and on same host to maximise availability in jira ha
+# affinity: |
+#   podAntiAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       - labelSelector:
+#           matchLabels:
+#             {{- include "common.labels.selectorLabels" . | nindent 10 }}
+#           matchExpressions:
+#             - key: app.kubernetes.io/component
+#               operator: NotIn
+#               values:
+#                 - test
+#         topologyKey: kubernetes.io/hostname
+#     preferredDuringSchedulingIgnoredDuringExecution:
+#       - weight: 100
+#         podAffinityTerm:
+#           labelSelector:
+#             matchLabels:
+#               {{- include "common.labels.selectorLabels" . | nindent 12 }}
+#             matchExpressions:
+#               - key: app.kubernetes.io/component
+#                 operator: NotIn
+#                 values:
+#                   - test
+#           topologyKey: topology.kubernetes.io/zone
 
 # -- Standard K8s schedulerName that will be applied to all Jira pods.
 # Check Kubernetes documentation on how to configure multiple schedulers:


### PR DESCRIPTION
## Pull request description

This solution cannot utilize the toYaml function due to its dependence on dynamic TPL functionality for passing selector labels to affinity rules.

Using the `tpl` function in Helm instead of `toYaml` can be necessary in certain scenarios due to the specific requirements and limitations of Helm and Kubernetes configurations:

1. **Dynamic Templating**: Helm's `tpl` function allows for dynamic templating, enabling you to generate configurations by interpolating values or variables. This can be useful when you need to create configuration elements programmatically, such as dynamically defining affinity rules or generating labels based on input values.

2. **Parameterization**: Helm is designed to make it easy to parameterize and customize Kubernetes configurations. By using `tpl`, you can incorporate Helm values and templates into your configuration, making it more flexible and adaptable to different environments or use cases.

3. **Complex Logic**: In some cases, you may need to apply complex logic or calculations to generate configuration elements. `tpl` allows you to include Helm-specific functions and expressions within your templates to achieve this, which may not be straightforward or even possible using `toYaml`.

4. **Compatibility**: Helm templates are a Helm-specific way to generate Kubernetes manifests. While `toYaml` can convert Helm templates to YAML, using `tpl` ensures that your templates remain Helm-centric and compatible with Helm's rendering and deployment process.

However, there may still be situations where `toYaml` is useful, such as when you want to convert a Helm chart to plain YAML for debugging, manual inspection, or use outside of Helm. It's important to choose the appropriate tool based on your specific requirements and whether you need the dynamic templating capabilities provided by `tpl` or the YAML conversion offered by `toYaml`.

## Checklist
- [ ] I have added unit tests
- [ X ] I have applied the change to all applicable products
- [ X ] The E2E test has passed (use `e2e` label)
