### PR TITLE
Add quote to podAnnotation templating

### DIFF
--- a/src/main/charts/bamboo-agent/templates/_helpers.tpl
+++ b/src/main/charts/bamboo-agent/templates/_helpers.tpl
@@ -57,7 +57,7 @@ Define pod annotations here to allow template overrides when used as a sub chart
 */}}
 {{- define "agent.podAnnotations" -}}
 {{- range $key, $value := .Values.podAnnotations }}
-{{ $key }}: {{ tpl $value $ }}
+{{ $key }}: {{ tpl $value $ | quote }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/bamboo/templates/_helpers.tpl
+++ b/src/main/charts/bamboo/templates/_helpers.tpl
@@ -122,7 +122,7 @@ Define pod annotations here to allow template overrides when used as a sub chart
 */}}
 {{- define "bamboo.podAnnotations" -}}
 {{- range $key, $value := .Values.podAnnotations }}
-{{ $key }}: {{ tpl $value $ }}
+{{ $key }}: {{ tpl $value $ | quote }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -130,7 +130,7 @@ Define pod annotations here to allow template overrides when used as a sub chart
 */}}
 {{- define "bitbucket.podAnnotations" -}}
 {{- range $key, $value := .Values.podAnnotations }}
-{{ $key }}: {{ tpl $value $ }}
+{{ $key }}: {{ tpl $value $ | quote }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -277,7 +277,7 @@ Define pod annotations here to allow template overrides when used as a sub chart
 */}}
 {{- define "confluence.podAnnotations" -}}
 {{- range $key, $value := .Values.podAnnotations }}
-{{ $key }}: {{ tpl $value $ }}
+{{ $key }}: {{ tpl $value $ | quote }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/crowd/templates/_helpers.tpl
+++ b/src/main/charts/crowd/templates/_helpers.tpl
@@ -122,7 +122,7 @@ Define pod annotations here to allow template overrides when used as a sub chart
 */}}
 {{- define "crowd.podAnnotations" -}}
 {{- range $key, $value := .Values.podAnnotations }}
-{{ $key }}: {{ tpl $value $ }}
+{{ $key }}: {{ tpl $value $ | quote }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -122,7 +122,7 @@ Define pod annotations here to allow template overrides when used as a sub chart
 */}}
 {{- define "jira.podAnnotations" -}}
 {{- range $key, $value := .Values.podAnnotations }}
-{{ $key }}: {{ tpl $value $ }}
+{{ $key }}: {{ tpl $value $ | quote }}
 {{- end }}
 {{- end }}
 

--- a/src/test/config/kind/common-values.yaml
+++ b/src/test/config/kind/common-values.yaml
@@ -44,6 +44,11 @@ volumes:
       # this is the default storageclass name created when deploying the provisioner
       storageClassName: nfs-client
 
+podAnnotations:
+  annotation: "{{ \"podOfTucuxis\" | upper }}"
+  quote: "true"
+  normal: annotation-comes-here
+
 # KinD is deployed with custom settings, namely extraPortMappings for ports 80 and 443
 # to make sure ingress traffic is available at http://localhost
 ingress:

--- a/src/test/java/test/PodAnnotationsTest.java
+++ b/src/test/java/test/PodAnnotationsTest.java
@@ -25,7 +25,9 @@ class PodAnnotationsTest {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "podAnnotations.podAnnotation1", "podOfHumpbacks",
                 "podAnnotations.podAnnotation2", "podOfOrcas",
-                "podAnnotations.podAnnotation3", "'{{ \"podOfTucuxis\" | b64enc }}'"
+                "podAnnotations.podAnnotation3", "'{{ \"podOfTucuxis\" | b64enc }}'",
+                "podAnnotations.podAnnotation4", "'{{ \"podOfTucuxis\" | upper }}'"
+
         ));
 
         final var annotations = resources.getStatefulSet(product.getHelmReleaseName()).getPodMetadata().get("annotations");
@@ -33,7 +35,8 @@ class PodAnnotationsTest {
         assertThat(annotations).isObject(Map.of(
                 "podAnnotation1", "podOfHumpbacks",
                 "podAnnotation2", "podOfOrcas",
-                "podAnnotation3", b64enc("podOfTucuxis")
+                "podAnnotation3", "'" + b64enc("podOfTucuxis") + "'",
+                "podAnnotation4", "'PODOFTUCUXIS'"
         ));
     }
 
@@ -43,7 +46,8 @@ class PodAnnotationsTest {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 "podAnnotations.podAnnotation1", "podOfHumpbacks",
                 "podAnnotations.podAnnotation2", "podOfOrcas",
-                "podAnnotations.podAnnotation3", "'{{ \"podOfTucuxis\" | b64enc }}'"
+                "podAnnotations.podAnnotation3", "'{{ \"podOfTucuxis\" | b64enc }}'",
+                "podAnnotations.podAnnotation4", "'{{ \"podOfTucuxis\" | upper }}'"
         ));
 
         final var annotations = resources.getDeployment(product.getHelmReleaseName()).getPodMetadata().get("annotations");
@@ -51,7 +55,8 @@ class PodAnnotationsTest {
         assertThat(annotations).isObject(Map.of(
                 "podAnnotation1", "podOfHumpbacks",
                 "podAnnotation2", "podOfOrcas",
-                "podAnnotation3", b64enc("podOfTucuxis")
+                "podAnnotation3", "'" + b64enc("podOfTucuxis") + "'",
+                "podAnnotation4", "'PODOFTUCUXIS'"
         ));
     }
 


### PR DESCRIPTION
A fixup to https://github.com/atlassian/data-center-helm-charts/pull/662

When "true" is the value of the annotation, helm install fails because k8s expects a string. Add `| quote` to make sure it's a string. Also, add an additional templating case - uppercase + add podAnnotations for KinD tests.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
