### PR TITLE
Fix config-jvm template to avoid wrong new line

### DIFF
--- a/src/main/charts/confluence/templates/config-jvm.yaml
+++ b/src/main/charts/confluence/templates/config-jvm.yaml
@@ -22,8 +22,8 @@ data:
     {{- if .Values.confluence.additionalCertificates.secretName }}
     -Djavax.net.ssl.trustStore=/var/ssl/cacerts
     {{- end }}
-    {{ include "common.jmx.javaagent" . | indent 4 | trim }}
-    {{ include "confluence.sysprop.s3Config" . | indent 4 | trim }}
+    {{- include "common.jmx.javaagent" . | indent 4 -}}
+    {{- include "confluence.sysprop.s3Config" . | indent 4 }}
   max_heap: {{ .Values.confluence.resources.jvm.maxHeap }}
   min_heap: {{ .Values.confluence.resources.jvm.minHeap }}
   reserved_code_cache: {{ .Values.confluence.resources.jvm.reservedCodeCache }}


### PR DESCRIPTION
## Pull request description

When the S3 bucket properties are provided the config map generated by the `config-jvm` template adds new lines that will break the application startup.
> Same behavior should be noticed when setting the `exposeJmxMetrics` attribute to true

```
data:
  additional_jvm_args: >-
    -Dconfluence.cluster.hazelcast.listenPort=5701
    -Dsynchrony.btf.disabled=true
    -Dsynchrony.by.default.enable.collab.editing.if.manually.managed=true
    -Dconfluence.clusterNodeName.useHostname=true
    -Datlassian.logging.cloud.enabled=false
    -XX:ActiveProcessorCount=2
    -Daws.webIdentityTokenFile=/var/run/secrets/eks.amazonaws.com/serviceaccount/token

    -Dconfluence.filestore.attachments.s3.bucket.name=MY_BUCKET_NAME
    -Dconfluence.filestore.attachments.s3.bucket.region=eu-west-1
```

This PR should fix this behavior resulting in no extra line breaks added to the rendered manifest:

```
data:
  additional_jvm_args: >-
    -Dconfluence.cluster.hazelcast.listenPort=5701
    -Dsynchrony.btf.disabled=true
    -Dsynchrony.by.default.enable.collab.editing.if.manually.managed=true
    -Dconfluence.clusterNodeName.useHostname=true
    -Datlassian.logging.cloud.enabled=false
    -XX:ActiveProcessorCount=2
    -Daws.webIdentityTokenFile=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
    -Dconfluence.filestore.attachments.s3.bucket.name=MY_BUCKET_NAME
    -Dconfluence.filestore.attachments.s3.bucket.region=eu-west-1
```

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
