### PR TITLE
CLIP-1832: Install the latest Terraform on e2e tf deployment runner container

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -45,6 +45,18 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install the latest Terraform
+        run: |
+          # check existing version
+          terraform -version
+          # download the latest
+          URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+          curl -s -o /tmp/terraform.zip ${URL}
+          echo yes | unzip /tmp/terraform.zip -d /usr/local/bin/
+          rm /tmp/terraform.zip          
+          # check the latest version
+          terraform -version
+
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v3.0
         with:


### PR DESCRIPTION
## Pull request description

This PR added a step in e2e tf deployment test to always fetch the latest Terrform version. The intention is to cover the time gap between new Terraform version release and Github Action runner base image update.

It was initially surfaced from a [failed build](https://github.com/atlassian-labs/data-center-terraform/actions/runs/6594472245) in data-center-terraform repo where runner base image had Terraform 1.6.1 where the https://github.com/hashicorp/terraform/issues/34052 was introduced and Terraform crashed during the test. Issue been fixed in Terraform 1.6.2 but runner base image hasn't been updated in a timely manner.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
