### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -12,7 +12,7 @@ Use the charts to install and operate Data Center products within a Kubernetes c
 ## Support disclaimer
 
 !!! warning "Support Disclaimer"
-    Helm is a Kubernetes package manager that orchestrates the provisioning of applications onto existing Kubernetes infrastructure. The requirements for this infrastructure are described in [Prerequisites](../userguide/PREREQUISITES.md). The Kubernetes cluster remains your responsibility; we do not provide direct support for Kubernetes or the underlying hardware it runs on.
+    Helm is a Kubernetes package manager that orchestrates the provisioning of applications onto existing Kubernetes infrastructure. The requirements for this infrastructure are described in [Prerequisites](userguide/PREREQUISITES.md). The Kubernetes cluster remains your responsibility; we do not provide direct support for Kubernetes or the underlying hardware it runs on.
 
     If you have followed our documentation on how to configure the Helm charts, and you're using correctly created components, we will then provide support if you encounter an error with installation after running the `helm install` command. 
 


### PR DESCRIPTION
Just fixing a broken link in docs. Readme is on the same level with userguide.