### PR TITLE
Make liveness probe configurable

### DIFF
--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -56,6 +56,7 @@ Kubernetes: `>=1.21.x-0`
 | bamboo.license | object | `{"secretKey":"license","secretName":null}` | The Bamboo DC license that should be used. If supplied here the license configuration will be skipped in the setup wizard.  |
 | bamboo.license.secretKey | string | `"license"` | The key (default 'licenseKey') in the Secret used to store the license information  |
 | bamboo.license.secretName | string | `nil` | The secret that contains the license information  |
+| bamboo.livenessProbe.customProbe | object | `{}` | Custom livenessProbe to override the default tcpSocket probe  |
 | bamboo.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | bamboo.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Bamboo container liveness probe before the pod fails liveness checks.  |
 | bamboo.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |

--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -206,13 +206,19 @@ spec:
           {{- end }}
           {{- if .Values.bamboo.livenessProbe.enabled }}
           livenessProbe:
+          {{- if .Values.bamboo.livenessProbe.customProbe}}
+          {{- with .Values.bamboo.livenessProbe.customProbe }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
             tcpSocket:
               port: {{ .Values.bamboo.ports.http }}
             initialDelaySeconds: {{ .Values.bamboo.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.bamboo.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.bamboo.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.bamboo.livenessProbe.failureThreshold }}
-          {{ end }}
+          {{- end }}
+          {{- end }}
           {{- with .Values.bamboo.containerSecurityContext}}
           securityContext:
           {{- toYaml . | nindent 12}}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -690,6 +690,10 @@ bamboo:
     #
     failureThreshold: 12
 
+    # -- Custom livenessProbe to override the default tcpSocket probe
+    #
+    customProbe: {}
+
   # Bamboo log configuration
   #
   accessLog:

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -57,6 +57,7 @@ Kubernetes: `>=1.21.x-0`
 | bitbucket.hazelcastService.type | string | `"ClusterIP"` | The type of the Hazelcast K8s service to use for Bitbucket  |
 | bitbucket.license.secretKey | string | `"license-key"` | The key in the K8s Secret that contains the Bitbucket license key  |
 | bitbucket.license.secretName | string | `nil` | The name of the K8s Secret that contains the Bitbucket license key. If specified, then the license will be automatically populated during Bitbucket setup. Otherwise, it will need to be provided via the browser after initial startup. An Example of creating a K8s secret for the license below: 'kubectl create secret generic <secret-name> --from-literal=license-key=<license> https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets  |
+| bitbucket.livenessProbe.customProbe | object | `{}` | Custom livenessProbe to override the default tcpSocket probe  |
 | bitbucket.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | bitbucket.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Bitbucket container liveness probe before the pod fails liveness checks.  |
 | bitbucket.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -128,13 +128,19 @@ spec:
           {{- end }}
           {{- if .Values.bitbucket.livenessProbe.enabled }}
           livenessProbe:
+          {{- if .Values.bitbucket.livenessProbe.customProbe}}
+          {{- with .Values.bitbucket.livenessProbe.customProbe }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
             tcpSocket:
               port: {{ .Values.bitbucket.ports.http }}
             initialDelaySeconds: {{ .Values.bitbucket.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.bitbucket.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.bitbucket.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.bitbucket.livenessProbe.failureThreshold }}
-          {{ end }}
+          {{- end }}
+          {{- end }}
           {{- with .Values.bitbucket.containerSecurityContext}}
           securityContext:
             {{- toYaml . | nindent 12}}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -779,6 +779,10 @@ bitbucket:
     #
     failureThreshold: 12
 
+    # -- Custom livenessProbe to override the default tcpSocket probe
+    #
+    customProbe: {}
+
   # Elasticsearch config
   #
   elasticSearch:

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -54,6 +54,7 @@ Kubernetes: `>=1.21.x-0`
 | confluence.jvmDebug.enabled | bool | `false` | Set to 'true' for remote debugging. Confluence JVM will be started with debugging port 5005 open. |
 | confluence.license.secretKey | string | `"license-key"` | The key in the K8s Secret that contains the Confluence license key  |
 | confluence.license.secretName | string | `nil` | The name of the K8s Secret that contains the Confluence license key. If specified, then the license will be automatically populated during Confluence setup. Otherwise, it will need to be provided via the browser after initial startup. An Example of creating a K8s secret for the license below: 'kubectl create secret generic <secret-name> --from-literal=license-key=<license> https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets  |
+| confluence.livenessProbe.customProbe | object | `{}` | Custom livenessProbe to override the default tcpSocket probe  |
 | confluence.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | confluence.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Confluence container liveness probe before the pod fails liveness checks.  |
 | confluence.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -117,13 +117,19 @@ spec:
           {{- end }}
           {{- if .Values.confluence.livenessProbe.enabled }}
           livenessProbe:
+          {{- if .Values.confluence.livenessProbe.customProbe}}
+          {{- with .Values.confluence.livenessProbe.customProbe }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
             tcpSocket:
               port: {{ .Values.confluence.ports.http }}
             initialDelaySeconds: {{ .Values.confluence.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.confluence.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.confluence.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.confluence.livenessProbe.failureThreshold }}
-          {{ end }}
+          {{- end }}
+          {{- end }}
           {{- with .Values.confluence.containerSecurityContext}}
           securityContext:
           {{- toYaml . | nindent 12}}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -706,6 +706,10 @@ confluence:
     #
     failureThreshold: 12
 
+    # -- Custom livenessProbe to override the default tcpSocket probe
+    #
+    customProbe: {}
+
   # Confluence log configuration
   #
   accessLog:

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -44,6 +44,7 @@ Kubernetes: `>=1.21.x-0`
 | crowd.additionalVolumeClaimTemplates | list | `[]` | Defines additional volumeClaimTemplates that should be applied to the Crowd pod. Note that this will not create any corresponding volume mounts; those needs to be defined in crowd.additionalVolumeMounts  |
 | crowd.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Crowd container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
 | crowd.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. https://kubernetes.io/docs/tasks/configure-pod-container/security-context/  |
+| crowd.livenessProbe.customProbe | object | `{}` | Custom livenessProbe to override the default tcpSocket probe  |
 | crowd.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | crowd.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Crowd container liveness probe before the pod fails liveness checks.  |
 | crowd.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -114,13 +114,19 @@ spec:
           {{- end }}
           {{- if .Values.crowd.livenessProbe.enabled }}
           livenessProbe:
+          {{- if .Values.crowd.livenessProbe.customProbe}}
+          {{- with .Values.crowd.livenessProbe.customProbe }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
             tcpSocket:
               port: {{ .Values.crowd.ports.http }}
             initialDelaySeconds: {{ .Values.crowd.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.crowd.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.crowd.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.crowd.livenessProbe.failureThreshold }}
-          {{ end }}
+          {{- end }}
+          {{- end }}
           {{- with .Values.crowd.containerSecurityContext}}
           securityContext:
           {{- toYaml . | nindent 12}}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -244,6 +244,10 @@ crowd:
     #
     failureThreshold: 12
 
+    # -- Custom livenessProbe to override the default tcpSocket probe
+    #
+    customProbe: {}
+
   # Crowd log configuration
   #
   accessLog:

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -78,6 +78,7 @@ Kubernetes: `>=1.21.x-0`
 | jira.clustering.enabled | bool | `false` | Set to 'true' if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes.  |
 | jira.containerSecurityContext | object | `{}` | Standard K8s field that holds security configurations that will be applied to a container. https://kubernetes.io/docs/tasks/configure-pod-container/security-context/  |
 | jira.forceConfigUpdate | bool | `false` | The Docker entrypoint.py generates application configuration on first start; not all of these files are regenerated on subsequent starts. By default, dbconfig.xml is generated only once. Set `forceConfigUpdate` to true to change this behavior.  |
+| jira.livenessProbe.customProbe | object | `{}` | Custom livenessProbe to override the default tcpSocket probe  |
 | jira.livenessProbe.enabled | bool | `false` | Whether to apply the livenessProbe check to pod.  |
 | jira.livenessProbe.failureThreshold | int | `12` | The number of consecutive failures of the Jira container liveness probe before the pod fails liveness checks.  |
 | jira.livenessProbe.initialDelaySeconds | int | `60` | Time to wait before starting the first probe  |

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -167,13 +167,19 @@ spec:
           {{- end }}
           {{- if .Values.jira.livenessProbe.enabled }}
           livenessProbe:
+            {{- if .Values.jira.livenessProbe.customProbe}}
+            {{- with .Values.jira.livenessProbe.customProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- else }}
             tcpSocket:
               port: {{ .Values.jira.ports.http }}
             initialDelaySeconds: {{ .Values.jira.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.jira.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.jira.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.jira.livenessProbe.failureThreshold }}
-          {{ end }}
+          {{- end }}
+          {{- end }}
           {{- with .Values.jira.containerSecurityContext}}
           securityContext:
           {{- toYaml . | nindent 12}}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -576,6 +576,10 @@ jira:
     #
     failureThreshold: 12
 
+    # -- Custom livenessProbe to override the default tcpSocket probe
+    #
+    customProbe: {}
+
   # Jira log configuration
   #
   accessLog:

--- a/src/test/java/test/ReadinessLivenessProbesTest.java
+++ b/src/test/java/test/ReadinessLivenessProbesTest.java
@@ -76,6 +76,28 @@ public class ReadinessLivenessProbesTest {
 
     @ParameterizedTest
     @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    void test_liveness_probe_custom_probe(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".livenessProbe.enabled", "true",
+                product + ".livenessProbe.customProbe.tcpSocket.port", "9999",
+                product + ".livenessProbe.customProbe.periodSeconds", "3333",
+                product + ".livenessProbe.customProbe.failureThreshold", "3333",
+                product + ".livenessProbe.customProbe.timeoutSeconds", "4444",
+                product + ".livenessProbe.customProbe.foo", "bar"));
+
+        assertEquals("9999", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("tcpSocket").get("port").asText());
+        assertEquals("3333", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("periodSeconds").asText());
+        assertEquals("3333", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("failureThreshold").asText());
+        assertEquals("4444", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("timeoutSeconds").asText());
+        assertEquals("bar", resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("livenessProbe").get("foo").asText());
+    }
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
     void test_readiness_probe_overrides(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
                 product + ".readinessProbe.initialDelaySeconds", "2222",

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -118,6 +118,7 @@ data:
         secretKey: licenseTestKey
         secretName: licenseTestSecret
       livenessProbe:
+        customProbe: {}
         enabled: false
         failureThreshold: 12
         initialDelaySeconds: 60

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -133,6 +133,7 @@ data:
         secretKey: license-key
         secretName: null
       livenessProbe:
+        customProbe: {}
         enabled: false
         failureThreshold: 12
         initialDelaySeconds: 60

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -118,6 +118,7 @@ data:
         secretKey: license-key
         secretName: null
       livenessProbe:
+        customProbe: {}
         enabled: false
         failureThreshold: 12
         initialDelaySeconds: 60

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -107,6 +107,7 @@ data:
       additionalVolumeMounts: []
       containerSecurityContext: {}
       livenessProbe:
+        customProbe: {}
         enabled: false
         failureThreshold: 12
         initialDelaySeconds: 60

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -146,6 +146,7 @@ data:
       containerSecurityContext: {}
       forceConfigUpdate: false
       livenessProbe:
+        customProbe: {}
         enabled: false
         failureThreshold: 12
         initialDelaySeconds: 60


### PR DESCRIPTION
In certain scenarios being able to override liveness probe can help restart pods that are stuck in `not ready` status for some time. The default tcpSocket probe just checks if the server listens on port but not if the application is ready.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
