### PR TITLE
Add an optional postStart hook

### DIFF
--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -64,6 +64,7 @@ Kubernetes: `>=1.21.x-0`
 | bamboo.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | bamboo.ports.http | int | `8085` | The port on which the Bamboo container listens for HTTP traffic  |
 | bamboo.ports.jms | int | `54663` | JMS port  |
+| bamboo.postStart | object | `{"command":null}` | PostStart is executed immediately after a container is created. However, there is no guarantee that the hook will execute before the container ENTRYPOINT. See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks  |
 | bamboo.readinessProbe.customProbe | object | `{}` | Custom ReadinessProbe to override the default /status httpGet  |
 | bamboo.readinessProbe.enabled | bool | `true` | Whether to apply the readinessProbe check to pod.  |
 | bamboo.readinessProbe.failureThreshold | int | `30` | The number of consecutive failures of the Bamboo container readiness probe before the pod fails readiness checks.  |

--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -246,6 +246,11 @@ spec:
             {{ end }}
             {{- end }}
           lifecycle:
+          {{- if .Values.bamboo.postStart.command }}
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", {{- .Values.bamboo.postStart.command | quote }}]
+          {{- end }}
             preStop:
               exec:
                 command: ["sh", "-c", {{ .Values.bamboo.shutdown.command | quote }}]

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -726,6 +726,13 @@ bamboo:
     #
     command: "/shutdown-wait.sh"
 
+  # -- PostStart is executed immediately after a container is created.
+  # However, there is no guarantee that the hook will execute before the container ENTRYPOINT.
+  # See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+  #
+  postStart:
+    command:
+
   # Pod resource requests
   #
   resources:

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -99,6 +99,7 @@ Kubernetes: `>=1.21.x-0`
 | bitbucket.ports.hazelcast | int | `5701` | The port on which the Hazelcast listens for client traffic  |
 | bitbucket.ports.http | int | `7990` | The port on which the Bitbucket container listens for HTTP traffic  |
 | bitbucket.ports.ssh | int | `7999` | The port on which the Bitbucket SSH service will listen on. Must be within 1024-65535 range  |
+| bitbucket.postStart | object | `{"command":null}` | PostStart is executed immediately after a container is created. However, there is no guarantee that the hook will execute before the container ENTRYPOINT. See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks  |
 | bitbucket.readinessProbe.customProbe | object | `{}` | Custom readinessProbe to override the default /status httpGet  |
 | bitbucket.readinessProbe.enabled | bool | `true` | Whether to apply the readinessProbe check to pod.  |
 | bitbucket.readinessProbe.failureThreshold | int | `60` | The number of consecutive failures of the Bitbucket container readiness probe before the pod fails readiness checks.  |

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -266,6 +266,11 @@ spec:
             {{ end }}
             {{- include "bitbucket.additionalEnvironmentVariables" . | nindent 12 }}
           lifecycle:
+          {{- if .Values.bitbucket.postStart.command }}
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", {{- .Values.bitbucket.postStart.command | quote }}]
+          {{- end }}
             preStop:
               exec:
                 command: ["sh", "-c", {{ .Values.bitbucket.shutdown.command | quote }}]

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -831,6 +831,13 @@ bitbucket:
     #
     command: "/shutdown-wait.sh"
 
+  # -- PostStart is executed immediately after a container is created.
+  # However, there is no guarantee that the hook will execute before the container ENTRYPOINT.
+  # See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+  #
+  postStart:
+    command:
+
   # -- Pod management strategy. Bitbucket Data Center requires the "OrderedReady" value but for Bitbucket Mirrors you
   # can use the "Parallel" option.
   # To learn more, visit https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -62,6 +62,7 @@ Kubernetes: `>=1.21.x-0`
 | confluence.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | confluence.ports.hazelcast | int | `5701` | The port on which the Confluence container listens for Hazelcast traffic  |
 | confluence.ports.http | int | `8090` | The port on which the Confluence container listens for HTTP traffic  |
+| confluence.postStart | object | `{"command":null}` | PostStart is executed immediately after a container is created. However, there is no guarantee that the hook will execute before the container ENTRYPOINT. See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks  |
 | confluence.readinessProbe.customProbe | object | `{}` | Custom readinessProbe to override the default /status httpGet  |
 | confluence.readinessProbe.enabled | bool | `true` | Whether to apply the readinessProbe check to pod.  |
 | confluence.readinessProbe.failureThreshold | int | `6` | The number of consecutive failures of the Confluence container readiness probe before the pod fails readiness checks.  |

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -214,6 +214,11 @@ spec:
                   name: {{ include "common.names.fullname" . }}-jvm-config
             {{- include "confluence.additionalEnvironmentVariables" . | nindent 12 }}
           lifecycle:
+          {{- if .Values.confluence.postStart.command }}
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", {{- .Values.confluence.postStart.command | quote }}]
+          {{- end }}
             preStop:
               exec:
                 command: ["sh", "-c", {{ .Values.confluence.shutdown.command | quote }}]

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -827,6 +827,13 @@ confluence:
     #
     command: "/shutdown-wait.sh"
 
+  # -- PostStart is executed immediately after a container is created.
+  # However, there is no guarantee that the hook will execute before the container ENTRYPOINT.
+  # See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+  #
+  postStart:
+    command:
+
   # -- The Docker entrypoint.py generates application configuration on
   # first start; not all of these files are regenerated on subsequent starts.
   # By default, confluence.cfg.xml is generated only once. Set `forceConfigUpdate` to true

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -51,6 +51,7 @@ Kubernetes: `>=1.21.x-0`
 | crowd.livenessProbe.periodSeconds | int | `5` | How often (in seconds) the Crowd container liveness probe will run  |
 | crowd.livenessProbe.timeoutSeconds | int | `1` | Number of seconds after which the probe times out  |
 | crowd.ports.http | int | `8095` | The port on which the Crowd container listens for HTTP traffic  |
+| crowd.postStart | object | `{"command":null}` | PostStart is executed immediately after a container is created. However, there is no guarantee that the hook will execute before the container ENTRYPOINT. See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks  |
 | crowd.readinessProbe.customProbe | object | `{}` | Custom readinessProbe to override the default /status httpGet  |
 | crowd.readinessProbe.enabled | bool | `true` | Whether to apply the readinessProbe check to pod.  |
 | crowd.readinessProbe.failureThreshold | int | `10` | The number of consecutive failures of the Crowd container readiness probe before the pod fails readiness checks.  |

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -197,6 +197,11 @@ spec:
                   name: {{ include "common.names.fullname" . }}-jvm-config
             {{- include "crowd.additionalEnvironmentVariables" . | nindent 12 }}
           lifecycle:
+          {{- if .Values.crowd.postStart.command }}
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", {{- .Values.crowd.postStart.command | quote }}]
+          {{- end }}
             preStop:
               exec:
                 command: ["sh", "-c", {{ .Values.crowd.shutdown.command | quote }}]

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -284,6 +284,13 @@ crowd:
     #
     command: "/shutdown-wait.sh"
 
+  # -- PostStart is executed immediately after a container is created.
+  # However, there is no guarantee that the hook will execute before the container ENTRYPOINT.
+  # See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+  #
+  postStart:
+    command:
+
   # Crowd Pod resource requests
   #
   resources:

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -87,6 +87,7 @@ Kubernetes: `>=1.21.x-0`
 | jira.ports.ehcache | int | `40001` | Ehcache port  |
 | jira.ports.ehcacheobject | int | `40011` | Ehcache object port  |
 | jira.ports.http | int | `8080` | The port on which the Jira container listens for HTTP traffic  |
+| jira.postStart | object | `{"command":null}` | PostStart is executed immediately after a container is created. However, there is no guarantee that the hook will execute before the container ENTRYPOINT. See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks  |
 | jira.readinessProbe.customProbe | object | `{}` | Custom readinessProbe to override the default /status httpGet  |
 | jira.readinessProbe.enabled | bool | `true` | Whether to apply the readinessProbe check to pod.  |
 | jira.readinessProbe.failureThreshold | int | `10` | The number of consecutive failures of the Jira container readiness probe before the pod fails readiness checks.  |

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -207,6 +207,11 @@ spec:
             {{ end }}
             {{- end }}
           lifecycle:
+          {{- if .Values.jira.postStart.command }}
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", {{- .Values.jira.postStart.command | quote }}]
+          {{- end }}
             preStop:
               exec:
                 command: ["sh", "-c", {{ .Values.jira.shutdown.command | quote }}]

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -640,6 +640,13 @@ jira:
     #
     command: "/shutdown-wait.sh"
 
+  # -- PostStart is executed immediately after a container is created.
+  # However, there is no guarantee that the hook will execute before the container ENTRYPOINT.
+  # See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+  #
+  postStart:
+    command:
+
   # Pod resource requests
   #
   resources:

--- a/src/test/java/test/LifecycleHooksTest.java
+++ b/src/test/java/test/LifecycleHooksTest.java
@@ -1,0 +1,56 @@
+package test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import test.helm.Helm;
+import test.model.Product;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LifecycleHooksTest {
+
+    private Helm helm;
+
+    @BeforeEach
+    void initHelm(TestInfo testInfo) {
+        helm = new Helm(testInfo);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    void default_pre_stop_hook(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of());
+        final var statefulSet = resources.getStatefulSet(product.getHelmReleaseName());
+        assertEquals("sh", statefulSet.getContainer().get("lifecycle").get("preStop").get("exec").get("command").get(0).asText());
+        assertEquals("-c", statefulSet.getContainer().get("lifecycle").get("preStop").get("exec").get("command").get(1).asText());
+        assertEquals("/shutdown-wait.sh", statefulSet.getContainer().get("lifecycle").get("preStop").get("exec").get("command").get(2).asText());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    void custom_pre_stop_hook(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product.name() + ".shutdown.command", "echo hello"
+        ));
+        final var statefulSet = resources.getStatefulSet(product.getHelmReleaseName());
+        assertEquals("sh", statefulSet.getContainer().get("lifecycle").get("preStop").get("exec").get("command").get(0).asText());
+        assertEquals("-c", statefulSet.getContainer().get("lifecycle").get("preStop").get("exec").get("command").get(1).asText());
+        assertEquals("echo hello", statefulSet.getContainer().get("lifecycle").get("preStop").get("exec").get("command").get(2).asText());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    void custom_post_start_hook(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product.name() + ".postStart.command", "echo hello"
+        ));
+        final var statefulSet = resources.getStatefulSet(product.getHelmReleaseName());
+        assertEquals("/bin/sh", statefulSet.getContainer().get("lifecycle").get("postStart").get("exec").get("command").get(0).asText());
+        assertEquals("-c", statefulSet.getContainer().get("lifecycle").get("postStart").get("exec").get("command").get(1).asText());
+        assertEquals("echo hello", statefulSet.getContainer().get("lifecycle").get("postStart").get("exec").get("command").get(2).asText());
+    }
+}

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -127,6 +127,8 @@ data:
       ports:
         http: 8085
         jms: 54663
+      postStart:
+        command: null
       readinessProbe:
         customProbe: {}
         enabled: true

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -196,6 +196,8 @@ data:
         hazelcast: 5701
         http: 7990
         ssh: 7999
+      postStart:
+        command: null
       readinessProbe:
         customProbe: {}
         enabled: true

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -127,6 +127,8 @@ data:
       ports:
         hazelcast: 5701
         http: 8090
+      postStart:
+        command: null
       readinessProbe:
         customProbe: {}
         enabled: true

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -115,6 +115,8 @@ data:
         timeoutSeconds: 1
       ports:
         http: 8095
+      postStart:
+        command: null
       readinessProbe:
         customProbe: {}
         enabled: true

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -156,6 +156,8 @@ data:
         ehcache: 40001
         ehcacheobject: 40011
         http: 8080
+      postStart:
+        command: null
       readinessProbe:
         customProbe: {}
         enabled: true


### PR DESCRIPTION
Resolves https://github.com/atlassian/data-center-helm-charts/issues/529

More info on lifecycle hooks: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
