### PR TITLE
Fix broken links in the documentation

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -23,7 +23,7 @@ Use the charts to install and operate Data Center products within a Kubernetes c
     **Certain product limitations listed below:**
 
     * **Jira** currently has [limitations with scaling](troubleshooting/LIMITATIONS.md#jira-and-horizontal-scaling).
-    * **Bamboo** has a number of limitations, [particularly with deployment and clustering](troubleshooting/LIMITATIONS/#deployment).
+    * **Bamboo** has a number of limitations, [particularly with deployment and clustering](troubleshooting/LIMITATIONS.md#deployment).
     
     Read more about these [product and platform limitations](troubleshooting/LIMITATIONS.md).
 

--- a/docs/docs/examples/EXAMPLES.md
+++ b/docs/docs/examples/EXAMPLES.md
@@ -56,7 +56,7 @@ See examples of provisioning Kubernetes clusters on cloud-based providers:
 * See an example of [how to deploy an EFK stack to Kubernetes](logging/efk/EFK.md)
 
 ### :simple-prometheus: Prometheus Monitoring
-* See an example of [how to monitor DC products with Prometheus](monitoring/PROMETHEUS.md)
+* See an example of [how to monitor DC products with Prometheus](../userguide/monitoring/PROMETHEUS.md)
 
 ### :material-checkbox-multiple-marked-outline: Customization
 * See an example of [External libraries and plugins](external_libraries/EXTERNAL_LIBS.md)

--- a/docs/docs/examples/logging/efk/EFK.md
+++ b/docs/docs/examples/logging/efk/EFK.md
@@ -67,7 +67,7 @@ fluentd:
 Fluentd tries to parse and send the data to Elasticsearch, but since it's not installed the data is lost. At this point you have logged data in the installed Elasticsearch, and you should install Kibana to complete the EFK stack deployment:
 
 ### 3. Install Kibana
-With the same version that was used for installing [Elasticsearch](../../elasticsearch/BITBUCKET_ELASTICSEARCH.md), use the `imageTag` property to install Kibana:
+With the same version that was used for installing [Elasticsearch](../../bitbucket/BITBUCKET_ELASTICSEARCH.md), use the `imageTag` property to install Kibana:
 
 ```shell
 helm install kibana --namespace <namespace> --set imageTag="7.9.3" elastic/kibana

--- a/docs/docs/platforms/PLATFORMS.md
+++ b/docs/docs/platforms/PLATFORMS.md
@@ -5,7 +5,7 @@
 
     If you have followed our documentation on how to configure the Helm charts, and you're using correctly created components, we will then provide support if you encounter an error with installation after running the `helm install` command. 
 
-    Read more about [what we support and what we don’t](troubleshooting/SUPPORT_BOUNDARIES.md). 
+    Read more about [what we support and what we don’t](../troubleshooting/SUPPORT_BOUNDARIES.md). 
 
 Using our Helm charts on different platforms:
 

--- a/docs/docs/troubleshooting/LIMITATIONS.md
+++ b/docs/docs/troubleshooting/LIMITATIONS.md
@@ -17,7 +17,7 @@ At present there are issues relating to index replication with Jira when immedia
   
     Please note that Jira is actively being worked on to address these issues in the coming releases.
       
-Although these issues are Jira specific, they are exasperated on account of the significantly reduced startup times for Jira when running in a Kubernetes cluster. As such these issues can have an impact on horizontal scaling if [you don't take the correct approach](../../userguide/resource_management/RESOURCE_SCALING/#scaling-jira-safely).
+Although these issues are Jira specific, they are exasperated on account of the significantly reduced startup times for Jira when running in a Kubernetes cluster. As such these issues can have an impact on horizontal scaling if [you don't take the correct approach](../userguide/resource_management/RESOURCE_SCALING.md#scaling-jira-safely).
 
 ## Bamboo
 There are a number of known limitations relating to Bamboo Data Center, these are documented below.

--- a/docs/docs/userguide/INSTALLATION.md
+++ b/docs/docs/userguide/INSTALLATION.md
@@ -27,7 +27,7 @@ helm show values atlassian-data-center/<product> > values.yaml
 
 !!!warning "Bamboo deployments"
 
-    If deploying Bamboo, be sure to read about the current limitations relating to [Bamboo deployments and values.yaml](../../troubleshooting/LIMITATIONS/#deployment)
+    If deploying Bamboo, be sure to read about the current limitations relating to [Bamboo deployments and values.yaml](../troubleshooting/LIMITATIONS.md#deployment)
 
 ## 3. Configure database
 

--- a/docs/docs/userguide/OPERATION.md
+++ b/docs/docs/userguide/OPERATION.md
@@ -71,7 +71,7 @@ Go to `http://localhost:9999/metrics` in your local browser to verify metrics av
 
 ### Scrape Metrics With Prometheus
 
-See: [Prometheus Monitoring](../examples/monitoring/PROMETHEUS.md)
+See: [Prometheus Monitoring](monitoring/PROMETHEUS.md)
 
 
 ## Managing resources

--- a/docs/docs/userguide/monitoring/PROMETHEUS.md
+++ b/docs/docs/userguide/monitoring/PROMETHEUS.md
@@ -55,7 +55,7 @@ helm install prometheus-stack prometheus-community/kube-prometheus-stack
 
 ## 2. Expose JMX metrics
 
-Follow [these instructions](../../../userguide/OPERATION/#expose-jmx-metrics) for details on how to enable and expose `JMX` for your product via a dedicated `Service`. 
+Follow [these instructions](../OPERATION.md#expose-jmx-metrics) for details on how to enable and expose `JMX` for your product via a dedicated `Service`. 
 
 
 ## 3. Create a ServiceMonitor

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -32,8 +32,8 @@ plugins:
         remove_comments: true
 markdown_extensions:
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.superfences


### PR DESCRIPTION
## Pull request description

When testing other PR I found out that we have quite a lot of broken links in the docs. I went through them and fixed them (they were reporting 404).