### PR TITLE
Removed unused Confluence shared home volume from Synchrony volume.

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -479,7 +479,6 @@ For each additional plugin declared, generate a volume mount that injects that l
 {{ if not .Values.volumes.synchronyHome.persistentVolumeClaim.create }}
 {{ include "synchrony.volumes.synchronyHome" . }}
 {{- end }}
-{{ include "confluence.volumes.sharedHome" . }}
 {{- with .Values.volumes.additionalSynchrony }}
 {{- toYaml . | nindent 0 }}
 {{- end }}


### PR DESCRIPTION
## Pull request description

This PR fixes https://github.com/atlassian/data-center-helm-charts/issues/745 to remove unused Confluence shared home volume from Synchrony volume.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
