### PR TITLE
BSERV-19054 Re-enable plugin upload for test Helm chart

### DIFF
--- a/src/test/config/bitbucket/values.yaml
+++ b/src/test/config/bitbucket/values.yaml
@@ -26,6 +26,7 @@ bitbucket:
     secretName: bitbucket-sysadmin-credentials
   additionalJvmArgs:
     - -Dfeature.getting.started.page=false
+    - -Dupm.plugin.upload.enabled=true
     - -XX:ActiveProcessorCount=2
   resources:
     container:


### PR DESCRIPTION
Modern Bitbucket no longer permits plugin upload via UPM by default. This is however useful for testing and in test and development environments we've re-enabled the functionality, for example when the product is run in dev-mode, or started with AMPS. The same should be done for the test helm charts.

## Pull request description

_Provide description for the PR_

## Checklist
- [N/A] I have added unit tests
- [X] I have applied the change to all applicable products
- [X] The E2E test has passed (use `e2e` label)
