### PR TITLE
Include shared home for synchrony when additional libs are defined

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -482,6 +482,9 @@ For each additional plugin declared, generate a volume mount that injects that l
 {{ if not .Values.volumes.synchronyHome.persistentVolumeClaim.create }}
 {{ include "synchrony.volumes.synchronyHome" . }}
 {{- end }}
+{{- if .Values.synchrony.additionalLibraries }}
+{{ include "confluence.volumes.sharedHome" . }}
+{{- end }}
 {{- with .Values.volumes.additionalSynchrony }}
 {{- toYaml . | nindent 0 }}
 {{- end }}


### PR DESCRIPTION
Addresses https://github.com/atlassian/data-center-helm-charts/issues/775

When additionalLibraries are defined, subDir volumeMount depends on a shared-home volume

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
