### PR TITLE
use pointer in aws secrets manager

### DIFF
--- a/docs/docs/containers/BITBUCKET.md
+++ b/docs/docs/containers/BITBUCKET.md
@@ -175,7 +175,7 @@ Starting from Bitbucket `8.13` the `JDBC` password can now be managed via [AWS S
 docker run \
     -e JDBC_DRIVER=org.postgresql.Driver \
     -e JDBC_USER=atlbitbucket \
-    -e JDBC_PASSWORD="{\"region\":\"us-east-1\",\"secretId\":\"mysecret\",\"secretPointer\":\"password\"}" \
+    -e JDBC_PASSWORD="{\"region\":\"us-east-1\",\"secretId\":\"mysecret\",\"secretPointer\":\"/password\"}" \
     -e JDBC_PASSWORD_DECRYPTER_CLASSNAME="com.atlassian.secrets.store.aws.AwsSecretsManagerStore" \
     -e JDBC_URL=jdbc:postgresql://my.database.host:5432/bitbucket \
     -v /data/bitbucket-shared:/var/atlassian/application-data/bitbucket/shared \

--- a/docs/docs/containers/CONFLUENCE.md
+++ b/docs/docs/containers/CONFLUENCE.md
@@ -282,7 +282,7 @@ Example:
 docker run -v /data/your-confluence-home:/var/atlassian/application-data/confluence \
 --name="confluence" -d -p 8090:8090 -p 8091:8091 \
 -e ATL_JDBC_SECRET_CLASS='com.atlassian.secrets.store.aws.AwsSecretsManagerStore' \
--e ATL_JDBC_PASSWORD='{"region": "us-east-1", "secretId": "mysecret", "secretPointer": "password"}' \
+-e ATL_JDBC_PASSWORD='{"region": "us-east-1", "secretId": "mysecret", "secretPointer": "/password"}' \
 -e ATL_CLUSTER_RELATED_VARIABLES='variable-value' \
 atlassian/confluence
 ```

--- a/docs/docs/containers/JIRA.md
+++ b/docs/docs/containers/JIRA.md
@@ -299,7 +299,7 @@ docker run -v jiraVolume:/var/atlassian/application-data/jira --name='jira' -d -
   -e ATL_JDBC_USER='jira' -e ATL_DB_DRIVER='org.postgresql.Driver' \
   -e ATL_DB_TYPE='postgres72' \
   -e ATL_JDBC_SECRET_CLASS='com.atlassian.secrets.store.aws.AwsSecretsManagerStore' \
-  -e ATL_JDBC_PASSWORD='{"region": "us-east-1", "secretId": "mysecret", "secretPointer": "password"}' \
+  -e ATL_JDBC_PASSWORD='{"region": "us-east-1", "secretId": "mysecret", "secretPointer": "/password"}' \
   -e ATL_FORCE_CFG_UPDATE='true' atlassian/jira-software
 ```
 


### PR DESCRIPTION
## Pull request description

minor change, if the json structure is used for the aws secrets-manager secrets we should prepend `secretPointer` with a slash

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
