### PR TITLE
Fix containers sidebar in docs

### DIFF
--- a/docs/docs/containers/.pages
+++ b/docs/docs/containers/.pages
@@ -1,2 +1,9 @@
 nav:
+    - BAMBOO-AGENT.md
+    - BAMBOO.md
+    - BITBUCKET.md
+    - BITBUCKET-MESH.md
+    - CONFLUENCE.md
+    - CROWD.md
+    - JIRA.md
     - ...


### PR DESCRIPTION
Without references to md files in .pages the sidecar looks like this:
<img width="326" alt="image" src="https://github.com/atlassian/data-center-helm-charts/assets/52448429/c32384de-cc1a-40f6-b4ac-d8de788bab59">

