### PR TITLE
Encourage ATL_DB_TYPE=oracle instead of oracle12c

### DIFF
--- a/docs/docs/containers/BAMBOO.md
+++ b/docs/docs/containers/BAMBOO.md
@@ -379,7 +379,7 @@ The following variables are all must all be supplied if using this feature:
    * `h2` - for evaluation needs only
    * `mssql`
    * `mysql`
-   * `oracle12c`
+   * `oracle`
    * `postgresql`
 
 ???+ note "MySQL or Oracle JDBC drivers" 


### PR DESCRIPTION
## Pull request description

Use generic oracle as a DB Type instead of a hardcoded oracle12c

## Checklist
- [-] I have added unit tests
- [-] I have applied the change to all applicable products
- [-] The E2E test has passed (use `e2e` label)
