### PR TITLE
Make KinD api port configurable, add overrides for agent deployment

### DIFF
--- a/src/test/config/kind/common-values.yaml
+++ b/src/test/config/kind/common-values.yaml
@@ -37,6 +37,9 @@ DC_APP_REPLACEME:
   additionalEnvironmentVariables:
     - name: PLUGIN_SSH_BASEURL
       value: ssh://bitbucket.172.17.0.1.nip.io:2222
+      # this is for Bamboo to use the right login url
+    - name: BUILD_NUMBER
+      value: "100100"
   
   # non existing props will be ignored, so it's safe to set them for all products
   # these extra sys properties are mostly for the functional tests

--- a/src/test/config/kind/kind-config.yml
+++ b/src/test/config/kind/kind-config.yml
@@ -1,5 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "127.0.0.1"
+  apiServerPort: 6443
 nodes:
 - role: control-plane
   # this is required due to weird nginx controller behavior where it needs to redirect smth to

--- a/src/test/scripts/kind/configure_kind.sh
+++ b/src/test/scripts/kind/configure_kind.sh
@@ -17,7 +17,7 @@ echo "[INFO]: Deploy Nginx ingress controller"
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 kubectl wait --for=condition=ready pod \
         --selector=app.kubernetes.io/component=controller \
-        --timeout=180s \
+        --timeout=300s \
         -n ingress-nginx
 
 # this is for local runs, because existing nfs server images does not run on arm64 platforms

--- a/src/test/scripts/kind/deploy_app.sh
+++ b/src/test/scripts/kind/deploy_app.sh
@@ -124,7 +124,9 @@ deploy_app() {
                  --set agent.resources.container.requests.cpu=20m \
                  --set agent.resources.container.requests.memory=10Mi \
                 ${OPENSHIFT_VALUES} \
-                 --wait --timeout=180s --debug
+                ${AGENT_OVERRIDES} \
+                --wait --timeout=180s \
+                --debug
   fi
 
   # Deploy Bitbucket Mirror in KinD only. MicroShift can't handle too many pods/processes


### PR DESCRIPTION
A few improvements to KinD config to make it possible to run Bamboo func tests.