### PR TITLE
fix access logs mount naming

### DIFF
--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -152,7 +152,7 @@ on Tomcat's logs directory. THis ensures that Tomcat+Jira logs get captured in t
 {{ define "jira.volumeMounts" }}
 - name: local-home
   mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
-- name: local-home
+- name: local-home-logs
   mountPath: {{ .Values.jira.accessLog.mountPath | quote }}
   subPath: {{ .Values.jira.accessLog.localHomeSubPath | quote }}
 - name: shared-home


### PR DESCRIPTION
## Logs mounts naming

problem happen with config

```yaml
localHome:
    persistentVolumeClaim:
      create: true
```
Into the pod mounts other volume 
```bash
$ df
/dev/sdg   <> <> <>   1% /opt/atlassian/jira/logs ```  