### PR TITLE
possiblity to add annotations to the StatefulSets, which might be use…

### DIFF
--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.bamboo.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.updateStrategy }}
   {{- with .Values.updateStrategy }}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -942,6 +942,10 @@ bamboo:
   #
   additionalVolumeMounts: []
 
+  # -- Defines additional annotations to the Bamboo StateFulSet. This might be required when deploying using a GitOps approach
+  additionalAnnotations: {}
+  #  argocd.argoproj.io/sync-wave: "10"
+  
   # -- Defines any additional environment variables to be passed to the Bamboo
   # container. See https://hub.docker.com/r/atlassian/bamboo for
   # supported variables.

--- a/src/main/charts/bitbucket/templates/statefulset-mesh.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset-mesh.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "common.names.fullname" . }}-mesh
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.bitbucket.mesh.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.updateStrategy }}
   {{- with .Values.updateStrategy }}

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.bitbucket.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.updateStrategy }}
   {{- with .Values.updateStrategy }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -1075,6 +1075,10 @@ bitbucket:
     #   key: keystore.jks
     #   mountPath: /var/ssl
 
+    # -- Defines additional annotations to the Bitbucket Mesh StateFulSet. This might be required when deploying using a GitOps approach
+    additionalAnnotations: {}
+    #  argocd.argoproj.io/sync-wave: "10"
+
     # -- Standard K8s node-selectors that will be applied to all Bitbucket Mesh pods
     #
     nodeSelector: {}
@@ -1208,6 +1212,10 @@ bitbucket:
   #    resources:
   #      requests:
   #        storage: 1Gi
+
+  # -- Defines additional annotations to the Bitbucket StateFulSet. This might be required when deploying using a GitOps approach
+  additionalAnnotations: {}
+  #  argocd.argoproj.io/sync-wave: "10"
 
   # -- Defines topology spread constraints for Bitbucket pods. See details:
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/

--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "synchrony.fullname" . }}
   labels:
     {{- include "synchrony.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.synchrony.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.updateStrategy }}
   {{- with .Values.updateStrategy }}

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.confluence.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.updateStrategy }}
   {{- with .Values.updateStrategy }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -1029,6 +1029,10 @@ confluence:
   #      requests:
   #        storage: 1Gi
 
+  # -- Defines additional annotations to the Confluence StateFulSet. This might be required when deploying using a GitOps approach
+  additionalAnnotations: {}
+  #  argocd.argoproj.io/sync-wave: "10"
+
   # -- Defines topology spread constraints for Confluence pods. See details:
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   #
@@ -1346,6 +1350,10 @@ synchrony:
   # 'volumes.additionalSynchrony'.
   #
   additionalVolumeMounts: []
+
+  # -- Defines additional annotations to the Synchrony StateFulSet. This might be required when deploying using a GitOps approach
+  additionalAnnotations: 
+  #  argocd.argoproj.io/sync-wave: "10"
 
   # -- Defines any additional ports for the Synchrony container.
   #

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.crowd.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.updateStrategy }}
   {{- with .Values.updateStrategy }}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -436,6 +436,10 @@ crowd:
   #      requests:
   #        storage: 1Gi
 
+  # -- Defines additional annotations to the Bamboo StateFulSet. This might be required when deploying using a GitOps approach
+  additionalAnnotations: {}
+  #  argocd.argoproj.io/sync-wave: "10"
+
   # -- Defines topology spread constraints for Crowd pods. See details:
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   #

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels.commonLabels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.jira.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.updateStrategy }}
   {{- with .Values.updateStrategy }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -845,6 +845,10 @@ jira:
   #
   additionalEnvironmentVariables: []
 
+  # -- Defines additional annotations to the Jira StateFulSet. This might be required when deploying using a GitOps approach
+  additionalAnnotations: {}
+  #  argocd.argoproj.io/sync-wave: "10"
+
   # -- Defines any additional ports for the Jira container.
   #
   additionalPorts: []

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -19,9 +19,10 @@ metadata:
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   additional_jvm_args: >-
     -XX:ActiveProcessorCount=2
@@ -37,9 +38,10 @@ metadata:
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   jmx-config.yaml: |
     rules:
@@ -65,9 +67,10 @@ metadata:
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   values.yaml: |
     additionalConfigMaps: []
@@ -90,6 +93,8 @@ data:
       accessLog:
         localHomeSubPath: log
         mountPath: /opt/atlassian/bamboo/logs
+      additionalAnnotations:
+        argocd.argoproj.io/sync-wave: "10"
       additionalBundledPlugins: []
       additionalCertificates:
         customCmd: null
@@ -363,9 +368,10 @@ metadata:
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -376,7 +382,7 @@ spec:
       name: jms
   selector:
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
 ---
 # Source: bamboo/templates/service-jmx.yaml
 apiVersion: v1
@@ -386,9 +392,10 @@ metadata:
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -399,7 +406,7 @@ spec:
       name: jmx
   selector:
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
 ---
 # Source: bamboo/templates/service.yaml
 apiVersion: v1
@@ -409,9 +416,10 @@ metadata:
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -423,7 +431,7 @@ spec:
       name: http
   selector:
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
 ---
 # Source: bamboo/templates/statefulset.yaml
 apiVersion: apps/v1
@@ -433,23 +441,29 @@ metadata:
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
+  
   replicas: 1
   serviceName: unittest-bamboo
   selector:
     matchLabels:
       app.kubernetes.io/name: bamboo
-      app.kubernetes.io/instance: unittest-bamboo
+      app.kubernetes.io/instance: unittest
   template:
     metadata:
       annotations:
-        checksum/config-jvm: e742d2253278aa23591596b959247bb63f0b8c32a3bb9a411cd0f5d2946fe5ab
+        checksum/config-jvm: c20cda5d27651a02b12ee52b1320646b6d879a07861242ef79cb795be243c5e4
+        
       labels:
         app.kubernetes.io/name: bamboo
-        app.kubernetes.io/instance: unittest-bamboo
+        app.kubernetes.io/instance: unittest
+        
     spec:
       serviceAccountName: unittest-bamboo
       terminationGracePeriodSeconds: 30
@@ -459,8 +473,10 @@ spec:
           - bar.local
           ip: 127.0.0.1
       securityContext:
+        
         fsGroup: 2005
       initContainers:
+        
         - name: nfs-permission-fixer
           image: alpine:latest
           imagePullPolicy: IfNotPresent
@@ -470,6 +486,7 @@ spec:
             - name: shared-home
               mountPath: "/shared-home"
           command: ["sh", "-c", "(chgrp 2005 /shared-home; chmod g+w /shared-home)"]
+        
         - name: fetch-jmx-exporter
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
@@ -484,14 +501,23 @@ spec:
           image: "atlassian/bamboo:9.6.4"
           imagePullPolicy: IfNotPresent
           env:
+            
             - name: ATL_TOMCAT_SCHEME
               value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
+            
             - name: ATL_BASE_URL
               value: "http://localhost:8085/"
+            
             - name: ATL_TOMCAT_PORT
               value: "8085"
+            
+            
+            
+            
+            
+            
             - name: SET_PERMISSIONS
               value: "true"
             - name: BAMBOO_SHARED_HOME
@@ -511,18 +537,26 @@ spec:
                 configMapKeyRef:
                   key: max_heap
                   name: unittest-bamboo-jvm-config
+            
             - name: ATL_CLIENT_BROKER_URL
               value: "tcp://testBroker:1234"
+            
+            
             - name: SECURITY_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: agentTestSecret
                   key: agentTestKey
+            
+            
+            
             - name: ATL_LICENSE
               valueFrom:
                 secretKeyRef:
                   name: licenseTestSecret
                   key: licenseTestKey
+            
+            
             - name: ATL_ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -543,12 +577,16 @@ spec:
                 secretKeyRef:
                   name: adminTestSecret
                   key: adminEmailTestKey
+            
+            
             - name: ATL_IMPORT_OPTION
               value: clean
             - name: ATL_IMPORT_PATH
               value: 
+            
             - name: ATL_BAMBOO_ENABLE_UNATTENDED_SETUP
               value: "true"
+            
           ports:
             - name: http
               containerPort: 8085
@@ -556,9 +594,11 @@ spec:
             - name: jms
               containerPort: 54663
               protocol: TCP
+            
             - name: jmx
               containerPort: 9999
               protocol: TCP
+            
           readinessProbe:
             httpGet:
               port: 8085
@@ -572,6 +612,7 @@ spec:
               cpu: "2"
               memory: 2G
           volumeMounts:
+            
             - name: local-home
               mountPath: "/var/atlassian/application-data/bamboo"
             - name: local-home
@@ -581,21 +622,39 @@ spec:
               mountPath: "/var/atlassian/application-data/shared-home"
             - name: helm-values
               mountPath: /opt/atlassian/helm
+            
             - name: jmx-config
               mountPath: /opt/atlassian/jmx
+            
+            
+            
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "/shutdown-wait.sh"]
+        
+        
+        
       priorityClassName: high
       volumes:
+        
+        
+        
         - name: local-home
+        
           emptyDir: {}
         - name: shared-home
+        
           emptyDir: {}
         - name: helm-values
           configMap:
             name: unittest-bamboo-helm-values
+        
+        
+        
+        
+        
+        
         - name: jmx-config
           configMap:
             name: unittest-bamboo-jmx-config
@@ -608,12 +667,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -652,12 +713,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: bamboo-1.20.1
     app.kubernetes.io/name: bamboo
-    app.kubernetes.io/instance: unittest-bamboo
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.6.4"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -680,6 +743,8 @@ spec:
           ls -l /shared-home/permissions-test
           rm /shared-home/permissions-test
   volumes:
+    
     - name: shared-home
+    
       emptyDir: {}
   restartPolicy: Never

--- a/src/test/resources/expected_helm_output/bamboo/values.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/values.yaml
@@ -30,6 +30,8 @@ bamboo:
   jmsService:
     enabled: true
 
+  additionalAnnotations:
+    argocd.argoproj.io/sync-wave: "10"
 
 priorityClassName: "high"
 additionalHosts:

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -19,9 +19,10 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   additional_jvm_args: >-
     -XX:ActiveProcessorCount=1
@@ -37,9 +38,10 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   additional_jvm_args: >-
     -XX:ActiveProcessorCount=2
@@ -56,9 +58,10 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   jmx-config.yaml: |
     rules:
@@ -78,9 +81,10 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   values.yaml: |
     additionalConfigMaps: []
@@ -100,6 +104,8 @@ data:
       helmValues:
         enabled: true
     bitbucket:
+      additionalAnnotations:
+        argocd.argoproj.io/sync-wave: "10"
       additionalBundledPlugins: []
       additionalCertificates:
         customCmd: null
@@ -143,6 +149,8 @@ data:
         periodSeconds: 5
         timeoutSeconds: 1
       mesh:
+        additionalAnnotations:
+          argocd.argoproj.io/sync-wave: "10"
         additionalCertificates:
           customCmd: null
           initContainer:
@@ -325,27 +333,236 @@ data:
         scrapeIntervalSeconds: 30
     nodeSelector: {}
     opensearch:
+      antiAffinity: soft
+      antiAffinityTopologyKey: kubernetes.io/hostname
       baseUrl: null
+      clusterName: opensearch-cluster
+      config:
+        opensearch.yml: |
+          cluster.name: opensearch-cluster
+    
+          # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+          network.host: 0.0.0.0
+    
+          # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+          # Implicitly done if ".singleNode" is set to "true".
+          # discovery.type: single-node
+    
+          # Start OpenSearch Security Demo Configuration
+          # WARNING: revise all the lines below before you go into production
+          plugins:
+            security:
+              ssl:
+                transport:
+                  pemcert_filepath: esnode.pem
+                  pemkey_filepath: esnode-key.pem
+                  pemtrustedcas_filepath: root-ca.pem
+                  enforce_hostname_verification: false
+                http:
+                  enabled: true
+                  pemcert_filepath: esnode.pem
+                  pemkey_filepath: esnode-key.pem
+                  pemtrustedcas_filepath: root-ca.pem
+              allow_unsafe_democertificates: true
+              allow_default_init_securityindex: true
+              authcz:
+                admin_dn:
+                  - CN=kirk,OU=client,O=client,L=test,C=de
+              audit.type: internal_opensearch
+              enable_snapshot_restore_privilege: true
+              check_snapshot_restore_write_privileges: true
+              restapi:
+                roles_enabled: ["all_access", "security_rest_api_access"]
+              system_indices:
+                enabled: true
+                indices:
+                  [
+                    ".opendistro-alerting-config",
+                    ".opendistro-alerting-alert*",
+                    ".opendistro-anomaly-results*",
+                    ".opendistro-anomaly-detector*",
+                    ".opendistro-anomaly-checkpoints",
+                    ".opendistro-anomaly-detection-state",
+                    ".opendistro-reports-*",
+                    ".opendistro-notifications-*",
+                    ".opendistro-notebooks",
+                    ".opendistro-asynchronous-search-response*",
+                  ]
+          ######## End OpenSearch Security Demo Configuration ########
       credentials:
         passwordSecretKey: password
         secretName: null
         usernameSecretKey: username
+      customAntiAffinity: {}
+      enableServiceLinks: true
       envFrom:
       - secretRef:
           name: opensearch-initial-password
+      extraContainers: []
       extraEnvs:
       - name: plugins.security.ssl.http.enabled
         value: "false"
+      extraInitContainers: []
+      extraObjects: []
+      extraVolumeMounts: []
+      extraVolumes: []
+      fsGroup: ""
+      fullnameOverride: ""
+      global:
+        dockerRegistry: ""
+      hostAliases: []
+      httpHostPort: ""
+      httpPort: 9200
+      image:
+        pullPolicy: IfNotPresent
+        repository: opensearchproject/opensearch
+        tag: ""
+      imagePullSecrets: []
+      ingress:
+        annotations: {}
+        enabled: false
+        hosts:
+        - chart-example.local
+        ingressLabels: {}
+        path: /
+        tls: []
+      initResources: {}
       install: false
+      keystore: []
+      labels: {}
+      lifecycle: {}
+      livenessProbe: {}
+      majorVersion: ""
+      masterService: opensearch-cluster-master
+      masterTerminationFix: false
+      maxUnavailable: 1
+      metricsPort: 9600
+      nameOverride: ""
+      networkHost: 0.0.0.0
+      networkPolicy:
+        create: false
+        http:
+          enabled: false
+      nodeAffinity: {}
+      nodeGroup: master
+      nodeSelector: {}
+      openSearchAnnotations: {}
+      opensearchHome: /usr/share/opensearch
+      opensearchJavaOpts: -Xmx512M -Xms512M
+      opensearchLifecycle: {}
       persistence:
+        accessModes:
+        - ReadWriteOnce
+        annotations: {}
+        enableInitChown: true
+        enabled: true
+        labels:
+          enabled: false
         size: 10Gi
+      plugins:
+        enabled: false
+        installList: []
+      podAffinity: {}
+      podAnnotations: {}
+      podManagementPolicy: Parallel
+      podSecurityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      podSecurityPolicy:
+        create: false
+        name: ""
+        spec:
+          fsGroup:
+            rule: RunAsAny
+          privileged: true
+          runAsUser:
+            rule: RunAsAny
+          seLinux:
+            rule: RunAsAny
+          supplementalGroups:
+            rule: RunAsAny
+          volumes:
+          - secret
+          - configMap
+          - persistentVolumeClaim
+          - emptyDir
+      priorityClassName: ""
+      protocol: https
+      rbac:
+        automountServiceAccountToken: false
+        create: false
+        serviceAccountAnnotations: {}
+        serviceAccountName: ""
+      readinessProbe:
+        failureThreshold: 3
+        periodSeconds: 5
+        tcpSocket:
+          port: 9200
+        timeoutSeconds: 3
+      replicas: 3
       resources:
         requests:
           cpu: 1
           memory: 1Gi
+      roles:
+      - master
+      - ingest
+      - data
+      - remote_cluster_client
+      schedulerName: ""
+      secretMounts: []
       securityConfig:
-        internalUsersSecret: null
+        actionGroupsSecret: null
+        config:
+          data: {}
+          dataComplete: true
+          securityConfigSecret: ""
+        configSecret: null
+        enabled: true
+        path: /usr/share/opensearch/config/opensearch-security
+        rolesMappingSecret: null
+        rolesSecret: null
+        tenantsSecret: null
+      securityContext:
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        runAsUser: 1000
+      service:
+        annotations: {}
+        externalTrafficPolicy: ""
+        headless:
+          annotations: {}
+        httpPortName: http
+        labels: {}
+        labelsHeadless: {}
+        loadBalancerIP: ""
+        loadBalancerSourceRanges: []
+        metricsPortName: metrics
+        nodePort: ""
+        transportPortName: transport
+        type: ClusterIP
+      sidecarResources: {}
       singleNode: true
+      startupProbe:
+        failureThreshold: 30
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        tcpSocket:
+          port: 9200
+        timeoutSeconds: 3
+      sysctl:
+        enabled: false
+      sysctlInit:
+        enabled: false
+      sysctlVmMaxMapCount: 262144
+      terminationGracePeriod: 120
+      tolerations: []
+      topologySpreadConstraints: []
+      transportHostPort: ""
+      transportPort: 9300
+      updateStrategy: RollingUpdate
     openshift:
       runWithRestrictedSCC: false
     ordinals:
@@ -437,9 +654,10 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -453,7 +671,7 @@ spec:
       name: jmx-mesh-sidecar
   selector:
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
 ---
 # Source: bitbucket/templates/service-mesh.yaml
 apiVersion: v1
@@ -463,9 +681,10 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -489,9 +708,10 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -515,9 +735,10 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -541,9 +762,10 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -563,7 +785,7 @@ spec:
       name: hazelcast
   selector:
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
 ---
 # Source: bitbucket/templates/statefulset-mesh.yaml
 apiVersion: apps/v1
@@ -573,24 +795,30 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
+  
   replicas: 3
   podManagementPolicy: OrderedReady
   serviceName: unittest-bitbucket-mesh
   selector:
     matchLabels:
       app.kubernetes.io/name: bitbucket-mesh
-      app.kubernetes.io/instance: unittest-bitbucket
+      app.kubernetes.io/instance: unittest
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 181b3e6cefd7ac8f0db885749fc9ff0807fac4112d79b112676977cdac8a8970
+        checksum/config-jvm: 6b22d35fb8cb28aee54e09f4589b71955901f654a0343f137f66ba53a0cbc0c2
+        
       labels:
         app.kubernetes.io/name: bitbucket-mesh
-        app.kubernetes.io/instance: unittest-bitbucket
+        app.kubernetes.io/instance: unittest
+        
     spec:
       serviceAccountName: unittest-bitbucket
       terminationGracePeriodSeconds: 35
@@ -600,6 +828,7 @@ spec:
           - bar.local
           ip: 127.0.0.1
       initContainers:
+        
         - name: fetch-jmx-exporter
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
@@ -617,6 +846,7 @@ spec:
             - name: mesh
               containerPort: 7777
               protocol: TCP
+            
             - name: jmx
               containerPort: 9999
               protocol: TCP
@@ -629,6 +859,7 @@ spec:
           volumeMounts:
             - name: mesh-home
               mountPath: "/var/atlassian/application-data/mesh"
+            
             - name: jmx-config
               mountPath: /opt/atlassian/jmx
           resources:
@@ -666,15 +897,27 @@ spec:
                   name: unittest-bitbucket-jvm-config-mesh
             - name: JMX_ENABLED
               value: "true"
+            
+            
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "/shutdown-wait.sh"]
+        
+        
       priorityClassName: high
       volumes:
+        
+        
+        
+        
+        
+        
         - name: jmx-config
           configMap:
             name: unittest-bitbucket-jmx-config
+  
+  
   volumeClaimTemplates:
   - metadata:
       name: mesh-home
@@ -692,24 +935,30 @@ metadata:
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
+  
   replicas: 1
   podManagementPolicy: OrderedReady
   serviceName: unittest-bitbucket
   selector:
     matchLabels:
       app.kubernetes.io/name: bitbucket
-      app.kubernetes.io/instance: unittest-bitbucket
+      app.kubernetes.io/instance: unittest
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 5afa854bf2e6923ea0fdd790b78f94f108f6bd8352de4bd53bae0ef176b4f6ec
+        checksum/config-jvm: cb2f643ba170fa5de2048da422b71bd00d00bfe8082f9427b5a9934d586e2cef
+        
       labels:
         app.kubernetes.io/name: bitbucket
-        app.kubernetes.io/instance: unittest-bitbucket
+        app.kubernetes.io/instance: unittest
+        
     spec:
       serviceAccountName: unittest-bitbucket
       terminationGracePeriodSeconds: 35
@@ -719,8 +968,12 @@ spec:
           - bar.local
           ip: 127.0.0.1
       securityContext:
+        
+        
         fsGroup: 2003
       initContainers:
+        
+        
         - name: fetch-jmx-exporter
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
@@ -744,6 +997,8 @@ spec:
             - name: hazelcast
               containerPort: 5701
               protocol: TCP
+            
+            
             - name: jmx
               containerPort: 9999
               protocol: TCP
@@ -758,10 +1013,15 @@ spec:
           volumeMounts:
             - name: local-home
               mountPath: "/var/atlassian/application-data/bitbucket"
+            
             - name: helm-values
               mountPath: /opt/atlassian/helm
+            
+            
             - name: jmx-config
               mountPath: /opt/atlassian/jmx
+            
+            
           resources:
             requests:
               cpu: "2"
@@ -773,18 +1033,33 @@ spec:
                   fieldPath: metadata.name
             - name: JAVA_OPTS
               value: "-Dcluster.node.name=$(KUBE_POD_NAME)"
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
             - name: PLUGIN_SSH_PORT
               value: "7999"
+            
             - name: SERVER_CONTEXT_PATH
               value: "/"
             - name: SERVER_PORT
               value: "7990"
+            
             - name: SERVER_SCHEME
               value: "https"
             - name: SERVER_SECURE
               value: "true"
+            
             - name: SET_PERMISSIONS
               value: "true"
+            
             - name: JVM_MINIMUM_MEMORY
               valueFrom:
                 configMapKeyRef:
@@ -804,17 +1079,33 @@ spec:
               value: "default"
             - name: JMX_ENABLED
               value: "true"
+            
+            
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "/shutdown-wait.sh"]
+        
+        
+        
       priorityClassName: high
       volumes:
+        
+        
+        
         - name: local-home
+        
           emptyDir: {}
+        
         - name: helm-values
           configMap:
             name: unittest-bitbucket-helm-values
+        
+        
+        
+        
+        
+        
         - name: jmx-config
           configMap:
             name: unittest-bitbucket-jmx-config
@@ -827,12 +1118,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -859,12 +1152,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: bitbucket-1.20.1
     app.kubernetes.io/name: bitbucket
-    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.19.6"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -888,6 +1183,9 @@ spec:
           ls -l /shared-home/permissions-test
           rm /shared-home/permissions-test
   volumes:
+    
+    
     - name: local-home
+    
       emptyDir: {}
   restartPolicy: Never

--- a/src/test/resources/expected_helm_output/bitbucket/values.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/values.yaml
@@ -9,6 +9,12 @@ bitbucket:
     enabled: true
     priorityClassName: "high"
 
+    additionalAnnotations:
+      argocd.argoproj.io/sync-wave: "10"
+
+  additionalAnnotations:
+    argocd.argoproj.io/sync-wave: "10"
+
 priorityClassName: "high"
 additionalHosts:
   - ip: "127.0.0.1"

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -19,9 +19,10 @@ metadata:
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   additional_jvm_args: >-
     -Dconfluence.cluster.hazelcast.listenPort=5701
@@ -43,9 +44,10 @@ metadata:
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   jmx-config.yaml: |
     rules:
@@ -65,9 +67,10 @@ metadata:
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   values.yaml: |
     additionalConfigMaps: []
@@ -92,6 +95,8 @@ data:
         enabled: true
         localHomeSubPath: logs
         mountPath: /opt/atlassian/confluence/logs
+      additionalAnnotations:
+        argocd.argoproj.io/sync-wave: "10"
       additionalBundledPlugins: []
       additionalCertificates:
         customCmd: null
@@ -266,24 +271,236 @@ data:
         scrapeIntervalSeconds: 30
     nodeSelector: {}
     opensearch:
+      antiAffinity: soft
+      antiAffinityTopologyKey: kubernetes.io/hostname
+      clusterName: opensearch-cluster
+      config:
+        opensearch.yml: |
+          cluster.name: opensearch-cluster
+    
+          # Bind to all interfaces because we don't know what IP address Docker will assign to us.
+          network.host: 0.0.0.0
+    
+          # Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+          # Implicitly done if ".singleNode" is set to "true".
+          # discovery.type: single-node
+    
+          # Start OpenSearch Security Demo Configuration
+          # WARNING: revise all the lines below before you go into production
+          plugins:
+            security:
+              ssl:
+                transport:
+                  pemcert_filepath: esnode.pem
+                  pemkey_filepath: esnode-key.pem
+                  pemtrustedcas_filepath: root-ca.pem
+                  enforce_hostname_verification: false
+                http:
+                  enabled: true
+                  pemcert_filepath: esnode.pem
+                  pemkey_filepath: esnode-key.pem
+                  pemtrustedcas_filepath: root-ca.pem
+              allow_unsafe_democertificates: true
+              allow_default_init_securityindex: true
+              authcz:
+                admin_dn:
+                  - CN=kirk,OU=client,O=client,L=test,C=de
+              audit.type: internal_opensearch
+              enable_snapshot_restore_privilege: true
+              check_snapshot_restore_write_privileges: true
+              restapi:
+                roles_enabled: ["all_access", "security_rest_api_access"]
+              system_indices:
+                enabled: true
+                indices:
+                  [
+                    ".opendistro-alerting-config",
+                    ".opendistro-alerting-alert*",
+                    ".opendistro-anomaly-results*",
+                    ".opendistro-anomaly-detector*",
+                    ".opendistro-anomaly-checkpoints",
+                    ".opendistro-anomaly-detection-state",
+                    ".opendistro-reports-*",
+                    ".opendistro-notifications-*",
+                    ".opendistro-notebooks",
+                    ".opendistro-asynchronous-search-response*",
+                  ]
+          ######## End OpenSearch Security Demo Configuration ########
       credentials:
         createSecret: true
         existingSecretRef:
           name: null
+      customAntiAffinity: {}
+      enableServiceLinks: true
       enabled: false
       envFrom:
       - secretRef:
           name: opensearch-initial-password
+      extraContainers: []
       extraEnvs:
       - name: plugins.security.ssl.http.enabled
         value: "false"
+      extraInitContainers: []
+      extraObjects: []
+      extraVolumeMounts: []
+      extraVolumes: []
+      fsGroup: ""
+      fullnameOverride: ""
+      global:
+        dockerRegistry: ""
+      hostAliases: []
+      httpHostPort: ""
+      httpPort: 9200
+      image:
+        pullPolicy: IfNotPresent
+        repository: opensearchproject/opensearch
+        tag: ""
+      imagePullSecrets: []
+      ingress:
+        annotations: {}
+        enabled: false
+        hosts:
+        - chart-example.local
+        ingressLabels: {}
+        path: /
+        tls: []
+      initResources: {}
+      keystore: []
+      labels: {}
+      lifecycle: {}
+      livenessProbe: {}
+      majorVersion: ""
+      masterService: opensearch-cluster-master
+      masterTerminationFix: false
+      maxUnavailable: 1
+      metricsPort: 9600
+      nameOverride: ""
+      networkHost: 0.0.0.0
+      networkPolicy:
+        create: false
+        http:
+          enabled: false
+      nodeAffinity: {}
+      nodeGroup: master
+      nodeSelector: {}
+      openSearchAnnotations: {}
+      opensearchHome: /usr/share/opensearch
+      opensearchJavaOpts: -Xmx512M -Xms512M
+      opensearchLifecycle: {}
       persistence:
+        accessModes:
+        - ReadWriteOnce
+        annotations: {}
+        enableInitChown: true
+        enabled: true
+        labels:
+          enabled: false
         size: 10Gi
+      plugins:
+        enabled: false
+        installList: []
+      podAffinity: {}
+      podAnnotations: {}
+      podManagementPolicy: Parallel
+      podSecurityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      podSecurityPolicy:
+        create: false
+        name: ""
+        spec:
+          fsGroup:
+            rule: RunAsAny
+          privileged: true
+          runAsUser:
+            rule: RunAsAny
+          seLinux:
+            rule: RunAsAny
+          supplementalGroups:
+            rule: RunAsAny
+          volumes:
+          - secret
+          - configMap
+          - persistentVolumeClaim
+          - emptyDir
+      priorityClassName: ""
+      protocol: https
+      rbac:
+        automountServiceAccountToken: false
+        create: false
+        serviceAccountAnnotations: {}
+        serviceAccountName: ""
+      readinessProbe:
+        failureThreshold: 3
+        periodSeconds: 5
+        tcpSocket:
+          port: 9200
+        timeoutSeconds: 3
+      replicas: 3
       resources:
         requests:
           cpu: 1
           memory: 1Gi
+      roles:
+      - master
+      - ingest
+      - data
+      - remote_cluster_client
+      schedulerName: ""
+      secretMounts: []
+      securityConfig:
+        actionGroupsSecret: null
+        config:
+          data: {}
+          dataComplete: true
+          securityConfigSecret: ""
+        configSecret: null
+        enabled: true
+        internalUsersSecret: null
+        path: /usr/share/opensearch/config/opensearch-security
+        rolesMappingSecret: null
+        rolesSecret: null
+        tenantsSecret: null
+      securityContext:
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        runAsUser: 1000
+      service:
+        annotations: {}
+        externalTrafficPolicy: ""
+        headless:
+          annotations: {}
+        httpPortName: http
+        labels: {}
+        labelsHeadless: {}
+        loadBalancerIP: ""
+        loadBalancerSourceRanges: []
+        metricsPortName: metrics
+        nodePort: ""
+        transportPortName: transport
+        type: ClusterIP
+      sidecarResources: {}
       singleNode: true
+      startupProbe:
+        failureThreshold: 30
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        tcpSocket:
+          port: 9200
+        timeoutSeconds: 3
+      sysctl:
+        enabled: false
+      sysctlInit:
+        enabled: false
+      sysctlVmMaxMapCount: 262144
+      terminationGracePeriod: 120
+      tolerations: []
+      topologySpreadConstraints: []
+      transportHostPort: ""
+      transportPort: 9300
+      updateStrategy: RollingUpdate
     openshift:
       runWithRestrictedSCC: false
     ordinals:
@@ -317,6 +534,8 @@ data:
       roleBinding:
         create: true
     synchrony:
+      additionalAnnotations:
+        argocd.argoproj.io/sync-wave: "10"
       additionalCertificates:
         customCmd: null
         initContainer:
@@ -432,6 +651,7 @@ data:
   # we just add every JAR in the Confluence lib directory.
   start-synchrony.sh: |
     #!/usr/bin/env bash
+
     java \
        -Xms1g \
        -Xmx2g \
@@ -451,9 +671,10 @@ metadata:
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -464,7 +685,7 @@ spec:
       name: jmx
   selector:
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
 ---
 # Source: confluence/templates/service-synchrony.yaml
 apiVersion: v1
@@ -474,10 +695,12 @@ metadata:
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence-synchrony
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
+
 spec:
   type: ClusterIP
   ports:
@@ -491,7 +714,7 @@ spec:
       name: hazelcast
   selector:
     app.kubernetes.io/name: confluence-synchrony
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
 ---
 # Source: confluence/templates/service.yaml
 apiVersion: v1
@@ -501,9 +724,10 @@ metadata:
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -519,7 +743,7 @@ spec:
       name: hazelcast
   selector:
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
 ---
 # Source: confluence/templates/statefulset-synchrony.yaml
 apiVersion: apps/v1
@@ -529,27 +753,34 @@ metadata:
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence-synchrony
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
+  
   replicas: 1
   serviceName: unittest-confluence-synchrony
   selector:
     matchLabels:
       app.kubernetes.io/name: confluence-synchrony
-      app.kubernetes.io/instance: unittest-confluence
+      app.kubernetes.io/instance: unittest
   template:
     metadata:
       annotations:
         checksum/config-jvm: 5c7e4f3183d49bd4e8c82a29b06246e551e4120042495652f1f9b27a0599a882
+        
       labels:
         app.kubernetes.io/name: confluence-synchrony
-        app.kubernetes.io/instance: unittest-confluence
+        app.kubernetes.io/instance: unittest
+        
     spec:
       serviceAccountName: unittest-confluence
       terminationGracePeriodSeconds: 25
       securityContext:
+        
         fsGroup: 2002
       hostAliases:
         - hostnames:
@@ -561,8 +792,12 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["/scripts/start-synchrony.sh"]
           volumeMounts:
+            
             - name: synchrony-home
               mountPath: "/var/atlassian/application-data/confluence"
+            
+            
+            
             - mountPath: /scripts
               name: entrypoint-script
           ports:
@@ -572,6 +807,7 @@ spec:
             - name: hazelcast
               containerPort: 5701
               protocol: TCP
+            
           readinessProbe:
             httpGet:
               port: 8091
@@ -591,14 +827,25 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: SYNCHRONY_SERVICE_URL
+            
               value: "https:///synchrony"
+            
+            
+            
+            
+            
+            
       priorityClassName: high
       volumes:
         - name: entrypoint-script
           configMap:
             name: unittest-confluence-synchrony-entrypoint
             defaultMode: 484
+        
+        
+        
         - name: synchrony-home
+        
           emptyDir: {}
 ---
 # Source: confluence/templates/statefulset.yaml
@@ -609,33 +856,42 @@ metadata:
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
+  
   replicas: 1
   serviceName: unittest-confluence
   selector:
     matchLabels:
       app.kubernetes.io/name: confluence
-      app.kubernetes.io/instance: unittest-confluence
+      app.kubernetes.io/instance: unittest
   template:
     metadata:
       annotations:
-        checksum/config-jvm: f3e06517d2f5a9ad3f17140e443aeec6e7cef638abd89a4718bd90923eb9a37c
+        checksum/config-jvm: df71540edb868775b41d7f668bcae6e690acabf04b6224223d8dc9cdfb730286
+        
       labels:
         app.kubernetes.io/name: confluence
-        app.kubernetes.io/instance: unittest-confluence
+        app.kubernetes.io/instance: unittest
+        
     spec:
       serviceAccountName: unittest-confluence
       terminationGracePeriodSeconds: 25
       securityContext:
+        
+        
         fsGroup: 2002
       hostAliases:
         - hostnames:
           - test.example.com
           ip: 192.168.1.1
       initContainers:
+        
         - name: nfs-permission-fixer
           image: alpine:latest
           imagePullPolicy: IfNotPresent
@@ -645,6 +901,7 @@ spec:
             - name: shared-home
               mountPath: "/shared-home"
           command: ["sh", "-c", "(chgrp 2002 /shared-home; chmod g+w /shared-home)"]
+        
         - name: fetch-jmx-exporter
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
@@ -665,9 +922,11 @@ spec:
             - name: hazelcast
               containerPort: 5701
               protocol: TCP
+            
             - name: jmx
               containerPort: 9999
               protocol: TCP
+            
           readinessProbe:
             httpGet:
               port: 8090
@@ -681,6 +940,7 @@ spec:
               cpu: "2"
               memory: 2G
           volumeMounts:
+            
             - name: local-home
               mountPath: "/var/atlassian/application-data/confluence"
             - name: local-home
@@ -690,15 +950,24 @@ spec:
               mountPath: "/var/atlassian/application-data/shared-home"
             - name: helm-values
               mountPath: /opt/atlassian/helm
+            
+            
             - name: jmx-config
               mountPath: /opt/atlassian/jmx
+            
+            
+            
           env:
+            
             - name: ATL_TOMCAT_SCHEME
               value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
+            
+            
             - name: ATL_TOMCAT_PORT
               value: "8090"
+            
             - name: ATL_TOMCAT_ACCESS_LOG
               value: "true"
             - name: UMASK
@@ -712,6 +981,14 @@ spec:
                 configMapKeyRef:
                   key: additional_jvm_args
                   name: unittest-confluence-jvm-config
+            
+            
+            
+            
+            
+            
+            
+            
             - name: JVM_MINIMUM_MEMORY
               valueFrom:
                 configMapKeyRef:
@@ -727,19 +1004,34 @@ spec:
                 configMapKeyRef:
                   key: reserved_code_cache
                   name: unittest-confluence-jvm-config
+            
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "/shutdown-wait.sh"]
+        
+        
+        
       priorityClassName: high
       volumes:
+        
+        
+        
         - name: local-home
+        
           emptyDir: {}
         - name: shared-home
+        
           emptyDir: {}
         - name: helm-values
           configMap:
             name: unittest-confluence-helm-values
+        
+        
+        
+        
+        
+        
         - name: jmx-config
           configMap:
             name: unittest-confluence-jmx-config
@@ -752,12 +1044,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -783,12 +1077,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: confluence-1.20.1
     app.kubernetes.io/name: confluence
-    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "8.5.12"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -811,6 +1107,8 @@ spec:
           ls -l /shared-home/permissions-test
           rm /shared-home/permissions-test
   volumes:
+    
     - name: shared-home
+    
       emptyDir: {}
   restartPolicy: Never

--- a/src/test/resources/expected_helm_output/confluence/values.yaml
+++ b/src/test/resources/expected_helm_output/confluence/values.yaml
@@ -7,6 +7,9 @@ volumes:
 synchrony:
   enabled: true
 
+  additionalAnnotations:
+    argocd.argoproj.io/sync-wave: "10"
+
 additionalHosts:
 - ip: "192.168.1.1"
   hostnames:
@@ -20,3 +23,7 @@ monitoring:
 atlassianAnalyticsAndSupport:
   analytics:
     enabled: false
+
+confluence:
+  additionalAnnotations:
+    argocd.argoproj.io/sync-wave: "10"

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     helm.sh/chart: crowd-1.20.1
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "6.0.0"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -19,9 +19,10 @@ metadata:
   labels:
     helm.sh/chart: crowd-1.20.1
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "6.0.0"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   additional_jvm_args: >-
     -Dcluster.node.name=${KUBE_POD_NAME}
@@ -39,9 +40,10 @@ metadata:
   labels:
     helm.sh/chart: crowd-1.20.1
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "6.0.0"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   jmx-config.yaml: |
     rules:
@@ -67,9 +69,10 @@ metadata:
   labels:
     helm.sh/chart: crowd-1.20.1
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "6.0.0"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   values.yaml: |
     additionalConfigMaps: []
@@ -95,6 +98,8 @@ data:
         enabled: true
         localHomeSubPath: logs
         mountPath: /opt/atlassian/crowd/apache-tomcat/logs
+      additionalAnnotations:
+        argocd.argoproj.io/sync-wave: "10"
       additionalBundledPlugins: []
       additionalCertificates:
         customCmd: null
@@ -310,9 +315,10 @@ metadata:
   labels:
     helm.sh/chart: crowd-1.20.1
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "6.0.0"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -323,7 +329,7 @@ spec:
       name: jmx
   selector:
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
 ---
 # Source: crowd/templates/service.yaml
 apiVersion: v1
@@ -333,9 +339,10 @@ metadata:
   labels:
     helm.sh/chart: crowd-1.20.1
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "6.0.0"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -347,7 +354,7 @@ spec:
       name: http
   selector:
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
 ---
 # Source: crowd/templates/statefulset.yaml
 apiVersion: apps/v1
@@ -357,23 +364,29 @@ metadata:
   labels:
     helm.sh/chart: crowd-1.20.1
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "6.0.0"
     app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
+  
   replicas: 1
   serviceName: unittest-crowd
   selector:
     matchLabels:
       app.kubernetes.io/name: crowd
-      app.kubernetes.io/instance: unittest-crowd
+      app.kubernetes.io/instance: unittest
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 1e200c10a1739dfe1fe0f298124d0a7337946a7f7e85ec04b7ca69f56ff470c5
+        checksum/config-jvm: a4a4b599d87b9564bf85bc48a2f1e0c3bacdbeba7fd62436bb85ca63b27df266
+        
       labels:
         app.kubernetes.io/name: crowd
-        app.kubernetes.io/instance: unittest-crowd
+        app.kubernetes.io/instance: unittest
+        
     spec:
       serviceAccountName: unittest-crowd
       terminationGracePeriodSeconds: 30
@@ -383,8 +396,11 @@ spec:
           - bar.local
           ip: 127.0.0.1
       securityContext:
+        
+        
         fsGroup: 2004
       initContainers:
+        
         - name: nfs-permission-fixer
           image: alpine:latest
           imagePullPolicy: IfNotPresent
@@ -394,6 +410,7 @@ spec:
             - name: shared-home
               mountPath: "/shared-home"
           command: ["sh", "-c", "(chgrp 2004 /shared-home; chmod g+w /shared-home)"]
+        
         - name: fetch-jmx-exporter
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
@@ -411,6 +428,8 @@ spec:
             - name: http
               containerPort: 8095
               protocol: TCP
+            
+            
             - name: jmx
               containerPort: 9999
               protocol: TCP
@@ -427,6 +446,7 @@ spec:
               cpu: "2"
               memory: 1G
           volumeMounts:
+            
             - name: local-home
               mountPath: "/var/atlassian/application-data/crowd"
             - name: local-home
@@ -436,19 +456,26 @@ spec:
               mountPath: "/var/atlassian/application-data/crowd/shared"
             - name: helm-values
               mountPath: /opt/atlassian/helm
+            
             - name: jmx-config
               mountPath: /opt/atlassian/jmx
+            
+            
+            
           env:
             - name: KUBE_POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            
             - name: ATL_TOMCAT_SCHEME
               value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
+            
             - name: ATL_TOMCAT_PORT
               value: "8095"
+            
             - name: ATL_TOMCAT_ACCESS_LOG
               value: "true"
             - name: UMASK
@@ -472,19 +499,34 @@ spec:
                 configMapKeyRef:
                   key: max_heap
                   name: unittest-crowd-jvm-config
+            
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "/shutdown-wait.sh"]
+        
+        
+        
       priorityClassName: high
       volumes:
+        
+        
+        
         - name: local-home
+        
           emptyDir: {}
         - name: shared-home
+        
           emptyDir: {}
         - name: helm-values
           configMap:
             name: unittest-crowd-helm-values
+        
+        
+        
+        
+        
+        
         - name: jmx-config
           configMap:
             name: unittest-crowd-jmx-config
@@ -497,12 +539,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: crowd-1.20.1
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "6.0.0"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -528,12 +572,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: crowd-1.20.1
     app.kubernetes.io/name: crowd
-    app.kubernetes.io/instance: unittest-crowd
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "6.0.0"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -556,6 +602,8 @@ spec:
           ls -l /shared-home/permissions-test
           rm /shared-home/permissions-test
   volumes:
+    
     - name: shared-home
+    
       emptyDir: {}
   restartPolicy: Never

--- a/src/test/resources/expected_helm_output/crowd/values.yaml
+++ b/src/test/resources/expected_helm_output/crowd/values.yaml
@@ -19,3 +19,7 @@ monitoring:
 atlassianAnalyticsAndSupport:
   analytics:
     enabled: false
+
+crowd:
+  additionalAnnotations:
+    argocd.argoproj.io/sync-wave: "10"

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     helm.sh/chart: jira-1.20.1
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.12.12"
     app.kubernetes.io/managed-by: Helm
 ---
@@ -19,9 +19,10 @@ metadata:
   labels:
     helm.sh/chart: jira-1.20.1
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.12.12"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   additional_jvm_args: >-
     -Datlassian.logging.cloud.enabled=false
@@ -39,13 +40,15 @@ metadata:
   labels:
     helm.sh/chart: jira-1.20.1
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.12.12"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   jmx-config.yaml: |
     ---
     startDelaySeconds: 0
+
     rules:
       - pattern: '(java.lang)<type=(\w+)><>(\w+):'
         name: java_lang_$2_$3
@@ -54,6 +57,7 @@ data:
       - pattern: 'java.lang<name=G1 (\w+) Generation, type=GarbageCollector><>(\w+)'
         name: java_lang_G1_$1_Generation_$2
       - pattern: '.*'
+
     blacklistObjectNames:
       - 'com.atlassian.jira:connectionpool=connections,connection=*,name=BasicDataSource'
 ---
@@ -65,9 +69,10 @@ metadata:
   labels:
     helm.sh/chart: jira-1.20.1
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.12.12"
     app.kubernetes.io/managed-by: Helm
+    
 data:
   values.yaml: |
     additionalConfigMaps: []
@@ -133,6 +138,8 @@ data:
       accessLog:
         localHomeSubPath: log
         mountPath: /opt/atlassian/jira/logs
+      additionalAnnotations:
+        argocd.argoproj.io/sync-wave: "10"
       additionalBundledPlugins: []
       additionalCertificates:
         customCmd: null
@@ -329,9 +336,10 @@ metadata:
   labels:
     helm.sh/chart: jira-1.20.1
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.12.12"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -342,7 +350,7 @@ spec:
       name: jmx
   selector:
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
 ---
 # Source: jira/templates/service.yaml
 apiVersion: v1
@@ -352,9 +360,10 @@ metadata:
   labels:
     helm.sh/chart: jira-1.20.1
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.12.12"
     app.kubernetes.io/managed-by: Helm
+    
   annotations:
 spec:
   type: ClusterIP
@@ -366,7 +375,7 @@ spec:
       name: http
   selector:
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
 ---
 # Source: jira/templates/statefulset.yaml
 apiVersion: apps/v1
@@ -376,23 +385,29 @@ metadata:
   labels:
     helm.sh/chart: jira-1.20.1
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.12.12"
     app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
+  
   replicas: 1
   serviceName: unittest-jira
   selector:
     matchLabels:
       app.kubernetes.io/name: jira
-      app.kubernetes.io/instance: unittest-jira
+      app.kubernetes.io/instance: unittest
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 38f23038a49bdac882b3e9130fa64b85f26fc2128687538bf138b714b4b5da07
+        checksum/config-jvm: 710c74e821cdf980c68ac01666e46d501fc0168d45c8a6d637b22e7f044e732d
+        
       labels:
         app.kubernetes.io/name: jira
-        app.kubernetes.io/instance: unittest-jira
+        app.kubernetes.io/instance: unittest
+        
     spec:
       serviceAccountName: unittest-jira
       terminationGracePeriodSeconds: 30
@@ -402,8 +417,11 @@ spec:
           - bar.local
           ip: 127.0.0.1
       securityContext:
+        
+        
         fsGroup: 2001
       initContainers:
+        
         - name: nfs-permission-fixer
           image: alpine:latest
           imagePullPolicy: IfNotPresent
@@ -413,6 +431,7 @@ spec:
             - name: shared-home
               mountPath: "/shared-home"
           command: ["sh", "-c", "(chgrp 2001 /shared-home; chmod g+w /shared-home)"]
+        
         - name: fetch-jmx-exporter
           image: bitnami/jmx-exporter:0.18.0
           command: ["cp"]
@@ -427,12 +446,25 @@ spec:
           image: "atlassian/jira-software:9.12.12"
           imagePullPolicy: IfNotPresent
           env:
+            
             - name: ATL_TOMCAT_SCHEME
               value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
+            
+            
             - name: ATL_TOMCAT_PORT
               value: "8080"
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
             - name: SET_PERMISSIONS
               value: "true"
             - name: JIRA_SHARED_HOME
@@ -457,6 +489,7 @@ spec:
                 configMapKeyRef:
                   key: reserved_code_cache
                   name: unittest-jira-jvm-config
+            
           ports:
             - name: http
               containerPort: 8080
@@ -467,6 +500,8 @@ spec:
             - name: ehcacheobject
               containerPort: 40011
               protocol: TCP
+            
+            
             - name: jmx
               containerPort: 9999
               protocol: TCP
@@ -483,6 +518,7 @@ spec:
               cpu: "2"
               memory: 2G
           volumeMounts:
+            
             - name: local-home
               mountPath: "/var/atlassian/application-data/jira"
             - name: local-home
@@ -492,21 +528,39 @@ spec:
               mountPath: "/var/atlassian/application-data/shared-home"
             - name: helm-values
               mountPath: /opt/atlassian/helm
+            
             - name: jmx-config
               mountPath: /opt/atlassian/jmx
+            
+            
+            
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "/shutdown-wait.sh"]
+        
+        
+        
       priorityClassName: high
       volumes:
+        
+        
+        
         - name: local-home
+        
           emptyDir: {}
         - name: shared-home
+        
           emptyDir: {}
         - name: helm-values
           configMap:
             name: unittest-jira-helm-values
+        
+        
+        
+        
+        
+        
         - name: jmx-config
           configMap:
             name: unittest-jira-jmx-config
@@ -519,12 +573,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: jira-1.20.1
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.12.12"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -551,12 +607,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    
   labels:
     helm.sh/chart: jira-1.20.1
     app.kubernetes.io/name: jira
-    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/instance: unittest
     app.kubernetes.io/version: "9.12.12"
     app.kubernetes.io/managed-by: Helm
+    
 spec:
   containers:
     - name: test
@@ -579,6 +637,8 @@ spec:
           ls -l /shared-home/permissions-test
           rm /shared-home/permissions-test
   volumes:
+    
     - name: shared-home
+    
       emptyDir: {}
   restartPolicy: Never

--- a/src/test/resources/expected_helm_output/jira/values.yaml
+++ b/src/test/resources/expected_helm_output/jira/values.yaml
@@ -18,3 +18,7 @@ monitoring:
 atlassianAnalyticsAndSupport:
   analytics:
     enabled: false
+
+jira:
+  additionalAnnotations:
+    argocd.argoproj.io/sync-wave: "10"


### PR DESCRIPTION
## Pull request description

I have added annotations to the StatefulSets of Bamboo, Jira, Confluence, Crowd and BitBucket. 
This is especially useful, for a deployment using GitOps approach. 

For example: Sync waves can be added: 
  annotations:
    argocd.argoproj.io/sync-wave: "10"

## Checklist
- [ x] I have added unit tests
- [ x] I have applied the change to all applicable products
- [ x] The E2E test has passed (use `e2e` label)