### PR TITLE
Update common dependency version

### DIFF
--- a/src/main/charts/bamboo-agent/Chart.lock
+++ b/src/main/charts/bamboo-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.6
+  version: 1.2.7
 digest: sha256:d5d71e640fd11f06ce6a7f380063611619b8ccfc678ed90093c096f3a63dd5db
 generated: "2024-01-30T06:19:23.741497+11:00"

--- a/src/main/charts/bamboo-agent/Chart.yaml
+++ b/src/main/charts/bamboo-agent/Chart.yaml
@@ -23,5 +23,5 @@ annotations:
     - "Update appVersions for DC apps (#869)"
 dependencies:
 - name: common
-  version: 1.2.6
+  version: 1.2.7
   repository: https://atlassian.github.io/data-center-helm-charts

--- a/src/main/charts/bamboo/Chart.lock
+++ b/src/main/charts/bamboo/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.6
+  version: 1.2.7
 digest: sha256:d5d71e640fd11f06ce6a7f380063611619b8ccfc678ed90093c096f3a63dd5db
 generated: "2024-01-30T06:19:10.886419+11:00"

--- a/src/main/charts/bamboo/Chart.yaml
+++ b/src/main/charts/bamboo/Chart.yaml
@@ -23,5 +23,5 @@ annotations:
     - "Update appVersions for DC apps (#869)"
 dependencies:
 - name: common
-  version: 1.2.6
+  version: 1.2.7
   repository: https://atlassian.github.io/data-center-helm-charts

--- a/src/main/charts/bitbucket/Chart.lock
+++ b/src/main/charts/bitbucket/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.6
+  version: 1.2.7
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
   version: 2.19.0

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -24,7 +24,7 @@ annotations:
 
 dependencies:
 - name: common
-  version: 1.2.6
+  version: 1.2.7
   repository: https://atlassian.github.io/data-center-helm-charts
 - name: opensearch
   version: 2.19.0

--- a/src/main/charts/confluence/Chart.lock
+++ b/src/main/charts/confluence/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.6
+  version: 1.2.7
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
   version: 2.19.0

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -24,7 +24,7 @@ annotations:
 
 dependencies:
 - name: common
-  version: 1.2.6
+  version: 1.2.7
   repository: https://atlassian.github.io/data-center-helm-charts
 - name: opensearch
   version: 2.19.0

--- a/src/main/charts/crowd/Chart.lock
+++ b/src/main/charts/crowd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.6
+  version: 1.2.7
 digest: sha256:d5d71e640fd11f06ce6a7f380063611619b8ccfc678ed90093c096f3a63dd5db
 generated: "2024-01-30T06:18:58.225309+11:00"

--- a/src/main/charts/crowd/Chart.yaml
+++ b/src/main/charts/crowd/Chart.yaml
@@ -24,5 +24,5 @@ annotations:
 
 dependencies:
 - name: common
-  version: 1.2.6
+  version: 1.2.7
   repository: https://atlassian.github.io/data-center-helm-charts

--- a/src/main/charts/jira/Chart.lock
+++ b/src/main/charts/jira/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://atlassian.github.io/data-center-helm-charts
-  version: 1.2.6
+  version: 1.2.7
 digest: sha256:d5d71e640fd11f06ce6a7f380063611619b8ccfc678ed90093c096f3a63dd5db
 generated: "2024-01-30T06:20:05.010578+11:00"

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -25,5 +25,5 @@ annotations:
 
 dependencies:
 - name: common
-  version: 1.2.6
+  version: 1.2.7
   repository: https://atlassian.github.io/data-center-helm-charts


### PR DESCRIPTION
Prepare to release the next version. [Common 1.2.7 has been released](https://github.com/atlassian/data-center-helm-charts/releases/tag/common-1.2.7).