### PR TITLE
CLIP-1916: Update actions/upload-artifact version

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload test log files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: e2e-test-artifacts
           path: tf/test/e2etest/artifacts/


### PR DESCRIPTION
## Pull request description

`actions/upload-artifact@v2` is deprecated and caused e2e test to fail. This PR updated this action to a newer version that's used in the repo. 

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
