### PR TITLE
Fix e2e and microshift jobs

### DIFF
--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Install the latest Terraform
         run: |
           # check existing version
-          terraform -version
+          terraform -version || true
           # download the latest
           URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
           curl -s -o /tmp/terraform.zip ${URL}

--- a/.github/workflows/openshift.yaml
+++ b/.github/workflows/openshift.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Install required virtualization software
         run: |
           sudo apt-get update
-          sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system
+          sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system virtiofsd
           sudo usermod -a -G libvirt $USER
 
       - name: Free up disk


### PR DESCRIPTION
GitHub has updated ubuntu-latest (now noble) which has broken e2e workflow (Terraform isn't bundled now so checking tf version fails) and MicroShift (missing virtiofsd package which makes it impossible to start a MicroShift VM - [failed build](https://github.com/atlassian/data-center-helm-charts/actions/runs/11309767388/job/31454134143#step:10:150)).