### PR TITLE
Pin ubuntu version

### DIFF
--- a/.github/workflows/documentation-build.yaml
+++ b/.github/workflows/documentation-build.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/documentation-deploy.yaml
+++ b/.github/workflows/documentation-deploy.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/e2e-tf-deployment.yaml
+++ b/.github/workflows/e2e-tf-deployment.yaml
@@ -20,7 +20,7 @@ jobs:
   test:
     if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     name: Deploy Infrastructure and Run E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   kind-testing:
     if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # See: https://github.com/kubernetes-sigs/kind/tags
       KIND_VERSION: "v0.23.0"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/openshift.yaml
+++ b/.github/workflows/openshift.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   microshift:
     if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       DC_APP: ${{inputs.dc_app}}
       LICENSE: ${{ secrets[format('{0}_LICENSE', inputs.dc_app)] }}

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -9,7 +9,7 @@ jobs:
   prepare-release:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/process-dashboard-test.yaml
+++ b/.github/workflows/process-dashboard-test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-process-dashboard-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release-unit-tests.yaml
+++ b/.github/workflows/release-unit-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-release-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sync-grafana-dashboards.yaml
+++ b/.github/workflows/sync-grafana-dashboards.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync_dashboards:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/update-lts-tags.yaml
+++ b/.github/workflows/update-lts-tags.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lts_check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Weird things happening. 2 days ago ubuntu-latest was [24.04.1](https://github.com/atlassian/data-center-helm-charts/actions/runs/11338544151/job/31531929333#step:1:4) and now it is [22.04.05](https://github.com/atlassian/data-center-helm-charts/actions/runs/11377587673/job/31651979744#step:1:4). It'll be better to pin the version to 24 (noble) since upgrade to noble has already bitten us (missing packages, different package names etc)
