### PR TITLE
Updated pod labels for all products

### DIFF
--- a/src/main/charts/bamboo/templates/statefulset.yaml
+++ b/src/main/charts/bamboo/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
         {{- include "bamboo.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "common.labels.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.commonLabels" . | nindent 8 }}
         {{- include "bamboo.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "bamboo.serviceAccountName" . }}

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
         {{- end }}
         {{- include "bitbucket.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "common.labels.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.commonLabels" . | nindent 8 }}
         {{- include "bitbucket.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "bitbucket.serviceAccountName" . }}

--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -35,7 +35,7 @@ spec:
         {{- include "confluence.podAnnotations" . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "synchrony.selectorLabels" . | nindent 8 }}
+        {{- include "synchrony.labels" . | nindent 8 }}
         {{- include "confluence.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "confluence.serviceAccountName" . }}

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
         {{- include "confluence.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "common.labels.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.commonLabels" . | nindent 8 }}
         {{- include "confluence.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "confluence.serviceAccountName" . }}

--- a/src/main/charts/crowd/templates/statefulset.yaml
+++ b/src/main/charts/crowd/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
         {{- include "crowd.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "common.labels.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.commonLabels" . | nindent 8 }}
         {{- include "crowd.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "crowd.serviceAccountName" . }}

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
         {{- include "jira.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "common.labels.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.commonLabels" . | nindent 8 }}
         {{- include "jira.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "jira.serviceAccountName" . }}


### PR DESCRIPTION
## Pull request description

Updated labels on all pods under stateful sets to include the same labels on their associated pod workloads.  Previously, the pods only had the selector labels.  With this update, all pods will have the same labels as their parent resource to improve traceability.  Validated the common labels include the selector labels as well so this will only result in a few more labels being added that were previously missing from the associated pod resources.

## Checklist
- [ ] I have added unit tests
- [X ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)

