### PR TITLE
BDEV-19172: Add support for JDK21

### DIFF
--- a/docs/docs/containers/BAMBOO-AGENT.md
+++ b/docs/docs/containers/BAMBOO-AGENT.md
@@ -12,7 +12,7 @@ To learn more about Bamboo, see: <https://www.atlassian.com/software/bamboo>
 This Docker container makes it easy to get a Bamboo Remote Agent up and running. It is intended to be used as a base to 
 build from, and as such contains limited built-in capabilities:
 
-* JDK 11 (JDK 17 starting from v9.4.0)
+* JDK 11, JDK 17 (from v9.4.0), JDK 21 (from v10.1.0)
 * Git & Git LFS
 * Maven 3
 * Python 3
@@ -117,7 +117,7 @@ This Docker image contains only minimal setup to run a Bamboo agent which might 
 
 Example of extending the agent base image by Maven and Git:
 ```Dockerfile
-FROM atlassian/bamboo-agent-base:8.2.1
+FROM atlassian/bamboo-agent-base:9.2.1
 USER root
 RUN apt-get update && \
     apt-get install maven -y && \
@@ -134,7 +134,7 @@ RUN /bamboo-update-capability.sh "system.git.executable" /usr/bin/git
 * Modify or replace the [Jinja](https://jinja.palletsprojects.com/) templates
   under `config`; _NOTE_: The files must have the `.j2` extensions. However you
   don't have to use template variables if you don't wish.
-* Build the new image with e.g: `docker build --build-arg BAMBOO_VERSION=X.Y.Z --tag my-agent-image .`
+* Build the new image with e.g: `docker build --tag my-bamboo-image --platform linux/amd64,linux/arm64 --build-arg BAMBOO_VERSION=X.Y.Z .`
 * Optionally push to a registry, and deploy.
 
 ## Issue tracker
@@ -142,14 +142,12 @@ RUN /bamboo-update-capability.sh "system.git.executable" /usr/bin/git
 * You can view know issues [here](https://jira.atlassian.com/projects/BAM/issues/filter=allissues).
 * Please contact our support if you encounter any problems with this Dockerfile.
 
-## Supported JDK versions
+## Supported JDK versions and base images
 
-Bamboo agent images are based on JDK 11, and generated from the
-[official Eclipse Temurin OpenJDK Docker images](https://hub.docker.com/_/eclipse-temurin).
-Starting from Bamboo 9.4 images are built on top of JDK 17.
-
-Starting from 9.4 [UBI based](https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6?architecture=amd64) tags are published as well.
-UBI tags are available in 2 formats: `<version>-ubi9` and `<version>-ubi9-jdk17`.
+Bamboo Docker images are based on JDK 11, JDK 17 (from Bamboo 9.4), and JDK 21 (from Bamboo 10.1) and generated from the
+[official Eclipse Temurin OpenJDK Docker images](https://hub.docker.com/_/eclipse-temurin) and
+[Red Hat Universal Base Images](https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6?architecture=amd64).
+Starting in Bamboo 9.4, UBI tags are available in 2 formats: `<version>-ubi9`, `<version>-ubi9-jdk17`, `<version>-ubi9-jdk21`
 
 The Docker images follow the [Atlassian Support end-of-life
 policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html);
@@ -157,7 +155,7 @@ images for unsupported versions of the products remain available but will no lon
 receive updates or fixes.
 
 However, Bamboo is an exception to this. Due to the need to support JDK 11 and
-Kubernetes, we currently only generate new images for Bamboo 8.0 and up. Legacy
+Kubernetes, we currently only generate new images for Bamboo 9.1 and up. Legacy
 builds for JDK 8 are still available in Docker Hub, and building custom images
 is available (see above).
 
@@ -170,9 +168,25 @@ If for some reason you need a different version, see "Building your own image".
 
 ## Migration to UBI
 
-If you have been mounting any files to `${JAVA_HOME}` directory in `eclipse-temurin` based container, `JAVA_HOME` in UBI JDK17 container is set to `/usr/lib/jvm/java-17`.
+If you have been mounting any files to `${JAVA_HOME}` directory in `eclipse-temurin` based container, `JAVA_HOME` in UBI container is set to `/usr/lib/jvm/java-17` (JDK17) and `/usr/lib/jvm/java-21` (JDK21).
 
 Also, if you have been mounting and running any custom scripts in the container, UBI-based images may lack some tools and utilities that are available out of the box in eclipse-temurin tags. If that's the case, see [Building your own image](#building-your-own-image).
+
+## Supported architectures
+
+Currently, the Atlassian Docker images are built for the `linux/amd64` and `linux/arm64` target
+platforms; we do not have other architectures on our roadmap at this
+point. However, the Dockerfiles and support tooling have now had all
+architecture-specific components removed, so if necessary it is possible to
+build images for any platform supported by Docker.
+
+### Building on the target architecture
+
+The simplest method of getting a platform image is to build it on a target
+machine; and specify either `linux/amd64` or `linux/arm64`. See [Building your own image](#building-your-own-image) above.
+
+Note: This method is known to work on Mac M1 and AWS ARM64 machines, but has not
+been extensively tested.
 
 ## Support
 

--- a/docs/docs/containers/BAMBOO-AGENT.md
+++ b/docs/docs/containers/BAMBOO-AGENT.md
@@ -147,7 +147,7 @@ RUN /bamboo-update-capability.sh "system.git.executable" /usr/bin/git
 Bamboo Docker images are based on JDK 11, JDK 17 (from Bamboo 9.4), and JDK 21 (from Bamboo 10.1) and generated from the
 [official Eclipse Temurin OpenJDK Docker images](https://hub.docker.com/_/eclipse-temurin) and
 [Red Hat Universal Base Images](https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6?architecture=amd64).
-Starting in Bamboo 9.4, UBI tags are available in 2 formats: `<version>-ubi9`, `<version>-ubi9-jdk17`, `<version>-ubi9-jdk21`
+Starting in Bamboo 9.4, UBI tags are available in 2 formats: `<version>-ubi9`, `<version>-ubi9-jdk17`, or `<version>-ubi9-jdk21>`
 
 The Docker images follow the [Atlassian Support end-of-life
 policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html);

--- a/docs/docs/containers/BAMBOO.md
+++ b/docs/docs/containers/BAMBOO.md
@@ -112,11 +112,13 @@ see <https://tomcat.apache.org/tomcat-9.0-doc/config/index.html>.
 
 * `ATL_TOMCAT_MGMT_PORT` (default: 8007)
 * `ATL_TOMCAT_MAXTHREADS` (default: 150)
+* `ATL_TOMCAT_MAXHTTPHEADERSIZE` (default: 8192)
 * `ATL_TOMCAT_MINSPARETHREADS` (default: 25)
 * `ATL_TOMCAT_CONNECTIONTIMEOUT` (default: 20000)
 * `ATL_TOMCAT_ENABLELOOKUPS` (default: false)
 * `ATL_TOMCAT_PROTOCOL` (default: HTTP/1.1)
 * `ATL_TOMCAT_ACCEPTCOUNT` (default: 100)
+* `ATL_TOMCAT_URIENCODING` (default: UTF-8)
 
 The standard HTTP connectors (NIO, NIO2 and APR/native) settings
 
@@ -483,22 +485,19 @@ The `latest` tag matches the most recent release of Atlassian Bamboo. Thus
 Alternatively you can use a specific major, major.minor, or major.minor.patch
 version of Bamboo by using a version number tag:
 
-* `atlassian/bamboo:8`
-* `atlassian/bamboo:8.0`
-* `atlassian/bamboo:8.0.1`
+* `atlassian/bamboo:9`
+* `atlassian/bamboo:9.0`
+* `atlassian/bamboo:9.0.1`
 
 All versions from 8.0+ are available. Legacy builds for older versions are
 available but are no longer supported.
 
 ## Supported JDK versions and base images
 
-Bamboo Docker images are JDK 11, and generated from the
-[official Eclipse Temurin OpenJDK Docker images](https://hub.docker.com/_/eclipse-temurin).
-
-Starting from Bamboo 9.4 JDK 17 based images are released as well. Two flavours of JDK 17 images are baked: 
+Bamboo Docker images are based on JDK 11, JDK 17 (from Bamboo 9.4), and JDK 21 (from Bamboo 10.1) and generated from the
 [official Eclipse Temurin OpenJDK Docker images](https://hub.docker.com/_/eclipse-temurin) and 
 [Red Hat Universal Base Images](https://catalog.redhat.com/software/containers/ubi9/openjdk-17/61ee7c26ed74b2ffb22b07f6?architecture=amd64).
-UBI tags are available in 2 formats: `<version>-ubi9` and `<version>-ubi9-jdk17`
+Starting in Bamboo 9.4, UBI tags are available in 2 formats: `<version>-ubi9`, `<version>-ubi9-jdk17`, `<version>-ubi9-jdk21`
 
 The Docker images follow the [Atlassian Support end-of-life
 policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html);
@@ -506,7 +505,7 @@ images for unsupported versions of the products remain available but will no lon
 receive updates or fixes.
 
 However, Bamboo is an exception to this. Due to the need to support JDK 11 and
-Kubernetes, we currently only generate new images for Bamboo 8.0 and up. Legacy
+Kubernetes, we currently only generate new images for Bamboo 9.1 and up. Legacy
 builds for JDK 8 are still available in Docker Hub, and building custom images
 is available (see below).
 
@@ -523,19 +522,19 @@ If for some reason you need a different version, see "Building your own image".
 * Modify or replace the [Jinja](https://jinja.palletsprojects.com/) templates
   under `config`; _NOTE_: The files must have the `.j2` extensions. However, you
   don't have to use template variables if you don't wish.
-* Build the new image with e.g: `docker build --tag my-bamboo-image --build-arg BAMBOO_VERSION=8.x.x .`
+* Build the new image with e.g: `docker build --tag my-bamboo-image --platform linux/amd64,linux/arm64 --build-arg BAMBOO_VERSION=X.Y.Z .`
 * Optionally push to a registry, and deploy.
 
 ## Migration to UBI
 
-If you have been mounting any files to `${JAVA_HOME}` directory in `eclipse-temurin` based container, `JAVA_HOME` in UBI JDK17 container is set to `/usr/lib/jvm/java-17`.
+If you have been mounting any files to `${JAVA_HOME}` directory in `eclipse-temurin` based container, `JAVA_HOME` in UBI container is set to `/usr/lib/jvm/java-17` (JDK17) and `/usr/lib/jvm/java-21` (JDK21).
 
-Also, if you have been mounting and running any custom scripts in the container, UBI-based images may lack some tools and utilities that are available out of the box in eclipse-temurin tags. If that's the case, see "Building your own image".
+Also, if you have been mounting and running any custom scripts in the container, UBI-based images may lack some tools and utilities that are available out of the box in eclipse-temurin tags. If that's the case, see [Building your own image](#building-your-own-image).
 
 ## Supported architectures
 
-Currently, the Atlassian Docker images are built for the `linux/amd64` target
-platform; we do not have other architectures on our roadmap at this
+Currently, the Atlassian Docker images are built for the `linux/amd64` and `linux/arm64` target
+platforms; we do not have other architectures on our roadmap at this
 point. However, the Dockerfiles and support tooling have now had all
 architecture-specific components removed, so if necessary it is possible to
 build images for any platform supported by Docker.
@@ -543,7 +542,7 @@ build images for any platform supported by Docker.
 ### Building on the target architecture
 
 The simplest method of getting a platform image is to build it on a target
-machine; see "Building your own image" above.
+machine; and specify either `linux/amd64` or `linux/arm64`. See [Building your own image](#building-your-own-image) above.
 
 Note: This method is known to work on Mac M1 and AWS ARM64 machines, but has not
 been extensively tested.


### PR DESCRIPTION
## Pull request description

Prepare for Bamboo 10.1.0 - Add support for JDK21

## Checklist
- [-] I have added unit tests
- [-] I have applied the change to all applicable products
- [-] The E2E test has passed (use `e2e` label)
