### PR TITLE
Use the same helm docs version in prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Helm Docs
         uses: envoy/install-helm-docs@v1.0.0
         with:
-          version: 1.11.0
+          version: 1.12.0
 
       - name: Generate changelog and Chart annotations
         run: |


### PR DESCRIPTION
Otherwise the [workflow that raises PRs to bump tls version](https://github.com/atlassian/data-center-helm-charts/pull/913/files#diff-764356ebbc71f9a9756adc30f2f9bde2b1d2f2ca6232bfa28dfdc42605ad08b8L75) updates helm docs comment :) 
