### PR TITLE
Make StuckThreadDetectionValve threshold configurable

### DIFF
--- a/docs/docs/containers/BAMBOO.md
+++ b/docs/docs/containers/BAMBOO.md
@@ -119,6 +119,7 @@ see <https://tomcat.apache.org/tomcat-9.0-doc/config/index.html>.
 * `ATL_TOMCAT_MINSPARETHREADS` (default: 25)
 * `ATL_TOMCAT_PROTOCOL` (default: HTTP/1.1)
 * `ATL_TOMCAT_URIENCODING` (default: UTF-8)
+* `ATL_TOMCAT_STUCKTHREADDETECTIONVALVE_THRESHOLD` (default: 60)
 
 The standard HTTP connectors (NIO, NIO2 and APR/native) settings
 

--- a/docs/docs/containers/CONFLUENCE.md
+++ b/docs/docs/containers/CONFLUENCE.md
@@ -174,6 +174,7 @@ see <https://tomcat.apache.org/tomcat-7.0-doc/config/index.html>.
 * `ATL_TOMCAT_DEBUG` (default: 0)
 * `ATL_TOMCAT_URIENCODING` (default: UTF-8)
 * `ATL_TOMCAT_MAXHTTPHEADERSIZE` (default: 8192)
+* `ATL_TOMCAT_STUCKTHREADDETECTIONVALVE_THRESHOLD` (default: 60)
 
 ### Access Log Settings
 

--- a/docs/docs/containers/JIRA.md
+++ b/docs/docs/containers/JIRA.md
@@ -167,6 +167,7 @@ see https://tomcat.apache.org/tomcat-7.0-doc/config/index.html.
 * `ATL_TOMCAT_PROTOCOL` (default: HTTP/1.1)
 * `ATL_TOMCAT_ACCEPTCOUNT` (default: 10)
 * `ATL_TOMCAT_MAXHTTPHEADERSIZE` (default: 8192)
+* `ATL_TOMCAT_STUCKTHREADDETECTIONVALVE_THRESHOLD` (default: 120)
 
 ### Access Log Settings
 

--- a/src/main/charts/bamboo/templates/configmap-server-config.yaml
+++ b/src/main/charts/bamboo/templates/configmap-server-config.yaml
@@ -136,7 +136,7 @@ data:
               <Manager pathname=""/>
               <JarScanner scanManifest="false"/>
               <Valve className="org.apache.catalina.valves.StuckThreadDetectionValve"
-                     threshold="120" />
+                     threshold="{{ .Values.bamboo.tomcatConfig.stuckThreadDetectionValveThreshold | default "120" }}" />
             </Context>
 
           </Host>

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -887,6 +887,7 @@ bamboo:
     proxyInternalIps:
     trustedProxies:
     requestAttributesEnabled:
+    stuckThreadDetectionValveThreshold: "120"
 
     # -- Custom server.xml to be mounted into /opt/atlassian/bamboo/conf
     #

--- a/src/main/charts/confluence/templates/configmap-server-config.yaml
+++ b/src/main/charts/confluence/templates/configmap-server-config.yaml
@@ -48,7 +48,7 @@ data:
               <!-- Logging configuration for Confluence is specified in confluence/WEB-INF/classes/log4j.properties -->
               <Manager pathname=""/>
               <Valve className="org.apache.catalina.valves.StuckThreadDetectionValve"
-                     threshold="60"/>
+                     threshold="{{ .Values.confluence.tomcatConfig.stuckThreadDetectionValveThreshold | default "60" }}" />
             {{ if .Values.confluence.accessLog.enabled }}
               <Valve className="org.apache.catalina.valves.AccessLogValve"
                      requestAttributesEnabled="true"

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -950,6 +950,8 @@ confluence:
     maxHttpHeaderSize: "8192"
     proxyInternalIps:
     trustedProxies:
+    stuckThreadDetectionValveThreshold: "60"
+
 
     # -- Custom server.xml to be mounted into /opt/atlassian/confluence/conf
     #

--- a/src/main/charts/jira/templates/configmap-server-config.yaml
+++ b/src/main/charts/jira/templates/configmap-server-config.yaml
@@ -64,7 +64,7 @@ data:
               <Manager pathname=""/>
               <JarScanner scanManifest="false"/>
               <Valve className="org.apache.catalina.valves.StuckThreadDetectionValve"
-                     threshold="120" />
+                     threshold="{{ .Values.jira.tomcatConfig.stuckThreadDetectionValveThreshold | default "120" }}" />
             </Context>
 
           </Host>

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -814,6 +814,7 @@ jira:
     # proxyPort is set depending on ingress.https value (80 if http, 443 if https)
     proxyPort:
     maxHttpHeaderSize: "8192"
+    stuckThreadDetectionValveThreshold: "120"
 
     # -- Custom server.xml to be mounted into /opt/atlassian/jira/conf
     #

--- a/src/test/java/test/ServerConfigTest.java
+++ b/src/test/java/test/ServerConfigTest.java
@@ -117,6 +117,7 @@ class ServerConfigTest {
         assertThat(serverConfigMap.getConfigMapData().path("server.xml")).hasTextContaining("maxHttpHeaderSize=\"9876\"");
         assertThat(serverConfigMap.getConfigMapData().path("server.xml")).hasTextContaining("proxyPort=\"443\"");
         assertThat(serverConfigMap.getConfigMapData().path("server.xml")).hasTextContaining("proxyName=\"" + String.format("%s.com", product.name()));
+
     }
     void use_custom_server_xml(Product product, String generatedByHelm, String restrictedSCC) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(

--- a/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo-agent/output.yaml
@@ -46,7 +46,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 02b54bb93db33521006ce64a308ac08baa09c581900e2b24bbbdee9f7f72e563
+        checksum/config-jvm: ec64ad63ec48fc0498be8475d86de385f725182b09e2e8e9eb80ebb116eb701f
       labels:
         app.kubernetes.io/name: bamboo-agent
         app.kubernetes.io/instance: unittest-bamboo-agent

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -217,6 +217,7 @@ data:
         sslEnabled: null
         sslPass: null
         sslProtocol: null
+        stuckThreadDetectionValveThreshold: "120"
         trustedProxies: null
         truststoreFile: null
         truststorePass: null
@@ -449,7 +450,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 98059bbd35cde5327af60086608c41b3273f26540cb6d109abc8df2260af5125
+        checksum/config-jvm: 7460e3943ee4989d91e6a16da3c1c7936d89e71ca30ac590b34cb96523e181b5
       labels:
         helm.sh/chart: bamboo-1.22.0
         app.kubernetes.io/name: bamboo

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -593,7 +593,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 212c67fcc63a0a749a09427c27e16f9c0ea93adc91f75194f4029d78a6a7fd6e
+        checksum/config-jvm: fa5fb52d5acfd16b972384b7b11c61f2e04db1a9ea250eafbff680ec8470461d
       labels:
         app.kubernetes.io/name: bitbucket-mesh
         app.kubernetes.io/instance: unittest-bitbucket
@@ -714,7 +714,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 7dc0984e043eee12affbe932d19a86cd52839fc66969529b2d67d61519df2d09
+        checksum/config-jvm: f3cd6f92a07ad448d350991df65ec9d7e4094ae184f68c2616c9f28bf4816437
       labels:
         helm.sh/chart: bitbucket-1.22.0
         app.kubernetes.io/name: bitbucket

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -197,6 +197,7 @@ data:
         redirectPort: "8443"
         scheme: null
         secure: null
+        stuckThreadDetectionValveThreshold: "60"
         trustedProxies: null
         uriEncoding: UTF-8
       topologySpreadConstraints: []

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -374,7 +374,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-jvm: 6efec411869b484c4625fd845cff88bd9b4be4731527776c8584ba5ef9442612
+        checksum/config-jvm: 847a2c91335ed3c042bff96afea37bf8739cf11e65ba4ddf272cad9f195f8aa7
       labels:
         helm.sh/chart: crowd-1.22.0
         app.kubernetes.io/name: crowd

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -235,6 +235,7 @@ data:
         redirectPort: "8443"
         scheme: null
         secure: null
+        stuckThreadDetectionValveThreshold: "120"
       topologySpreadConstraints: []
       useHelmReleaseNameAsContainerName: false
     monitoring:


### PR DESCRIPTION
Follow up to https://bitbucket.org/atlassian-docker/docker-atlassian-jira/pull-requests/155 in case container is run as non root and server.xml can't be generated in runtime.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
