### PR TITLE
Allow setting subPath for local-home volumes

### DIFF
--- a/src/main/charts/bamboo/templates/_helpers.tpl
+++ b/src/main/charts/bamboo/templates/_helpers.tpl
@@ -162,6 +162,9 @@ on Tomcat's logs directory. THis ensures that Tomcat+Bamboo logs get captured in
 {{ define "bamboo.volumeMounts" }}
 - name: local-home
   mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
+  {{- if .Values.volumes.localHome.subPath }}
+  subPath: {{ .Values.volumes.localHome.subPath | quote }}
+  {{- end }}
 - name: local-home
   mountPath: {{ .Values.bamboo.accessLog.mountPath | quote }}
   subPath: {{ .Values.bamboo.accessLog.localHomeSubPath | quote }}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -237,6 +237,11 @@ volumes:
     #
     mountPath: "/var/atlassian/application-data/bamboo"
 
+    # -- Specifies the sub-directory of the local-home volume that will be mounted in to the
+    # Bamboo container.
+    #
+    subPath:
+
   # A volume for 'shared-home' is required by Bamboo to effectively operate in multi-node
   # environment
   # https://confluence.atlassian.com/bamboo/bamboo-data-center-requirements-1063170547.html#BambooDataCenterrequirements-Sharedfilesystem

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -183,6 +183,9 @@ spec:
           volumeMounts:
             - name: local-home
               mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
+              {{- if .Values.volumes.localHome.subPath }}
+              subPath: {{ .Values.volumes.localHome.subPath | quote }}
+              {{- end }}
             {{/* jmxExporter is saved to shared home but mirrors don't have one, so we need at least emptyDir */}}
             {{- if or .Values.volumes.sharedHome.persistentVolumeClaim.create .Values.volumes.sharedHome.customVolume
                (and (eq .Values.bitbucket.applicationMode "mirror") .Values.monitoring.exposeJmxMetrics) }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -279,6 +279,11 @@ volumes:
     #
     mountPath: "/var/atlassian/application-data/bitbucket"
 
+    # -- Specifies the sub-directory of the local-home volume that will be mounted in to the
+    # Bitbucket container.
+    #
+    subPath:
+
   # An NFS volume for 'shared-home' is required by Bitbucket to effectively operate in multi-node
   # environment.
   #

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -270,6 +270,9 @@ on Tomcat's logs directory. THis ensures that Tomcat+Confluence logs get capture
 {{ define "confluence.volumeMounts" }}
 - name: local-home
   mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
+  {{- if .Values.volumes.localHome.subPath }}
+  subPath: {{ .Values.volumes.localHome.subPath | quote }}
+  {{- end }}
 - name: local-home
   mountPath: {{ .Values.confluence.accessLog.mountPath | quote }}
   subPath: {{ .Values.confluence.accessLog.localHomeSubPath | quote }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -280,6 +280,11 @@ volumes:
     #
     mountPath: "/var/atlassian/application-data/confluence"
 
+    # -- Specifies the sub-directory of the local-home volume that will be mounted in to the
+    # Confluence container.
+    #
+    subPath:
+
   # A volume for 'shared-home' is required by Confluence to effectively operate in multi-node
   # environment
   # https://confluence.atlassian.com/doc/set-up-a-confluence-data-center-cluster-982322030.html#SetupaConfluenceDataCentercluster-Setupandconfigureyourcluster

--- a/src/main/charts/crowd/templates/_helpers.tpl
+++ b/src/main/charts/crowd/templates/_helpers.tpl
@@ -135,6 +135,9 @@ on Tomcat's logs directory. THis ensures that Tomcat+Crowd logs get captured in 
 {{ define "crowd.volumeMounts" }}
 - name: local-home
   mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
+  {{- if .Values.volumes.localHome.subPath }}
+  subPath: {{ .Values.volumes.localHome.subPath | quote }}
+  {{- end }}
 - name: local-home
   mountPath: {{ .Values.crowd.accessLog.mountPath | quote }}
   subPath: {{ .Values.crowd.accessLog.localHomeSubPath | quote }}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -756,6 +756,11 @@ volumes:
     #
     mountPath: "/var/atlassian/application-data/crowd"
 
+    # -- Specifies the sub-directory of the local-home volume that will be mounted in to the
+    # Crowd container.
+    #
+    subPath:
+
   # A volume for 'shared-home' is required by Crowd to effectively operate in multi-node
   # environment
   # https://crowd.atlassian.com/doc/set-up-a-crowd-data-center-cluster-982322030.html#SetupaCrowdDataCentercluster-Setupandconfigureyourcluster

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -152,6 +152,9 @@ on Tomcat's logs directory. THis ensures that Tomcat+Jira logs get captured in t
 {{ define "jira.volumeMounts" }}
 - name: local-home
   mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
+  {{- if .Values.volumes.localHome.subPath }}
+  subPath: {{ .Values.volumes.localHome.subPath | quote }}
+  {{- end }}
 - name: local-home
   mountPath: {{ .Values.jira.accessLog.mountPath | quote }}
   subPath: {{ .Values.jira.accessLog.localHomeSubPath | quote }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -248,6 +248,11 @@ volumes:
     #
     mountPath: "/var/atlassian/application-data/jira"
 
+    # -- Specifies the sub-directory of the local-home volume that will be mounted in to the
+    # Jira container.
+    #
+    subPath:
+
   # A volume for 'shared-home' is required by Jira to effectively operate in multi-node
   # environment
   # https://confluence.atlassian.com/adminjiraserver/set-up-a-jira-data-center-cluster-993929600.html

--- a/src/test/java/test/VolumesTest.java
+++ b/src/test/java/test/VolumesTest.java
@@ -114,7 +114,8 @@ class VolumesTest {
                 "volumes.localHome.persistentVolumeClaim.create", "true",
                 "volumes.localHome.persistentVolumeClaim.storageClassName", "foo",
                 "volumes.localHome.persistentVolumeClaim.resources.requests.storage", "2Gi",
-                "volumes.localHome.mountPath", "/foo/bar"));
+                "volumes.localHome.mountPath", "/foo/bar",
+                "volumes.localHome.subPath", "sub"));
 
         final var statefulSet = resources.getStatefulSet(product.getHelmReleaseName());
 
@@ -127,6 +128,7 @@ class VolumesTest {
         final var mount = statefulSet.getContainer().getVolumeMount("local-home");
         assertThat(mount.get("name")).hasTextEqualTo("local-home");
         assertThat(mount.get("mountPath")).hasTextEqualTo("/foo/bar");
+        assertThat(mount.get("subPath")).hasTextEqualTo("sub");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Pull request description

Should be useful for reusing existing PVs with specific structure.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
