### PR TITLE
Added synchrony.service.url option

### DIFF
--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -240,6 +240,7 @@ Kubernetes: `>=1.21.x-0`
 | synchrony.service.nodePort | string | `nil` | Only applicable if service.type is NodePort. NodePort for Synchrony service  |
 | synchrony.service.port | int | `80` | The port on which the Synchrony K8s Service will listen  |
 | synchrony.service.type | string | `"ClusterIP"` | The type of K8s service to use for Synchrony  |
+| synchrony.service.url | string | `nil` | Complete URL of Synchrony Service (i.e. https://public.mydomain.com/synchrony). If left empty, it is calculated from ingress.https and ingress.host  |
 | synchrony.setPermissions | bool | `true` | Boolean to define whether to set synchrony home directory permissions on startup of Synchrony container. Set to 'false' to disable this behaviour.  |
 | synchrony.shutdown.terminationGracePeriodSeconds | int | `25` | The termination grace period for pods during shutdown. This should be set to the Synchrony internal grace period (default 20 seconds), plus a small buffer to allow the JVM to fully terminate. |
 | synchrony.tolerations | list | `[]` | Standard K8s tolerations that will be applied to all Synchrony pods  |

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -204,8 +204,11 @@ Pod labels
 {{- $synchronyIngressPath = regexReplaceAll $sanitizePathRegex .Values.synchrony.ingress.path "" }}
 {{- end }}
 {{- if .Values.synchrony.enabled -}}
-    {{- if .Values.ingress.https -}}-Dsynchrony.service.url=https://{{ .Values.ingress.host }}/{{ $synchronyIngressPath }}/v1
-    {{- else }}-Dsynchrony.service.url=http://{{ .Values.ingress.host }}/{{ $synchronyIngressPath }}/v1
+    {{- if .Values.synchrony.service.url -}}-Dsynchrony.service.url={{ .Values.synchrony.service.url }}/v1
+    {{- else -}}
+        {{- if .Values.ingress.https -}}-Dsynchrony.service.url=https://{{ .Values.ingress.host }}/{{ $synchronyIngressPath }}/v1
+        {{- else }}-Dsynchrony.service.url=http://{{ .Values.ingress.host }}/{{ $synchronyIngressPath }}/v1
+        {{- end }}    
     {{- end }}
 {{- else -}}
 -Dsynchrony.btf.disabled=true

--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -127,12 +127,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: SYNCHRONY_SERVICE_URL
-            {{ if .Values.ingress.https }}
-              value: "https://{{ .Values.ingress.host }}/synchrony"
+            - name: SYNCHRONY_SERVICE_URL 
+            {{ if .Values.synchrony.service.url }}
+              value: "{{ .Values.synchrony.service.url }}"
             {{ else }}
-              value: "http://{{ .Values.ingress.host }}/synchrony"
-            {{- end }}
+              {{ if .Values.ingress.https }}
+                value: "https://{{ .Values.ingress.host }}/synchrony"
+              {{ else }}
+                value: "http://{{ .Values.ingress.host }}/synchrony"
+              {{- end }}
+            {{ end }}
             {{- include "synchrony.databaseEnvVars" . | nindent 12 }}
             {{- include "synchrony.clusteringEnvVars" . | nindent 12 }}
       {{- if .Values.synchrony.nodeSelector }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -1257,6 +1257,9 @@ synchrony:
     #
     annotations: {}
 
+    # -- Complete URL of Synchrony Service (i.e. https://public.mydomain.com/synchrony). If left empty, it is calculated from ingress.https and ingress.host
+    url:
+
   # -- If 'synchrony.ingress.path' is defined, a dedicated Synchrony ingress object is created.
   # This is useful if you need to deploy multiple instances of Confluence with Synchrony enabled
   # using the same Ingress hostname and different synchrony paths

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -387,6 +387,7 @@ data:
         nodePort: null
         port: 80
         type: ClusterIP
+        url: null
       setPermissions: true
       shutdown:
         terminationGracePeriodSeconds: 25


### PR DESCRIPTION
## New option for Synchrony service URL

This resolves issue #964 Check issue for more details

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
