### PR TITLE
Update documentation related to Bitbucket shared home requirements

### DIFF
--- a/docs/docs/examples/storage/STORAGE.md
+++ b/docs/docs/examples/storage/STORAGE.md
@@ -1,7 +1,7 @@
 # Shared storage
 Atlassian's Data Center products require a shared storage solution to effectively operate in multi-node environment. The specifics of how this shared storage is created is site-dependent, we do however provide examples on how shared storage can be created below.
 
-!!!tip "Due to the high requirements on performance for IO operations, Bitbucket needs a dedicated NFS server providing persistence for a shared home. See [NFS](nfs/NFS.md) example for details"
+!!!tip "In case you are not using [Bitbucket Mesh](../bitbucket/BITBUCKET_MESH.md) nodes, Bitbucket requires a **dedicated NFS server** providing persistence for a shared home due to requirements for high IO throughput. See [NFS](nfs/NFS.md) example for details"
 
 ## AWS EFS
 Jira, Confluence and Crowd can all be configured with an EFS-backed shared solution. For details on how this can be set up, see the [AWS EFS example](aws/SHARED_STORAGE.md). 

--- a/docs/docs/examples/storage/nfs/NFS.md
+++ b/docs/docs/examples/storage/nfs/NFS.md
@@ -6,8 +6,12 @@
     The included NFS example is provided as is and should be used as reference a only. Before you proceed we highly recommend that you understand your specific deployment needs and tailor your solution to them.
 
 ## Bitbucket Data Center and NFS
-Due to the high performance requirements on IO operations, Bitbucket needs a dedicated NFS server providing persistence for a shared home. For this reason 
-we don't recommend that you use [cloud managed storage services](https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html#Supportedplatforms-cloudplatformsCloudPlatforms) such as AWS EFS.
+
+When deploying Bitbucket, you have two options how to store git data. You can deploy [Bitbucket Mesh nodes](../bitbucket/BITBUCKET_MESH.md)
+or you can use shared home for your Bitbucket Data Center instance.
+
+Due to the high performance requirements on IO operations, Bitbucket needs a dedicated NFS server providing persistence in case you using the shared home to store git data.
+For this reason we don't recommend that you use [cloud managed storage services](https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html#Supportedplatforms-cloudplatformsCloudPlatforms) such as AWS EFS.
  
 ## NFS provisioning
 The NFS server can be provisioned manually or by using the supplied Helm chart. Details for both approaches can be found below.

--- a/docs/docs/userguide/CONFIGURATION.md
+++ b/docs/docs/userguide/CONFIGURATION.md
@@ -157,7 +157,7 @@ using `PersistentVolumes` is the strongly recommended approach.
 
 ### Volumes examples
 
-1. Bitbucket needs a dedicated NFS server providing persistence for a shared home. Prior to installing the Helm chart, a suitable NFS shared storage solution must be provisioned. The exact details of this resource will be highly site-specific, but you can use this example as a guide: [Implementation of an NFS Server for Bitbucket](../examples/storage/nfs/NFS.md).
+1. Bitbucket needs a dedicated NFS server providing persistence for a shared home if you are not using [Bitbucket Mesh](../examples/bitbucket/BITBUCKET_MESH.md). Prior to installing the Helm chart, a suitable NFS shared storage solution must be provisioned. The exact details of this resource will be highly site-specific, but you can use this example as a guide: [Implementation of an NFS Server for Bitbucket](../examples/storage/nfs/NFS.md).
 2. We have an example detailing how an existing EFS filesystem can be created and consumed using static provisioning: [Shared storage - utilizing AWS EFS-backed filesystem](../examples/storage/aws/SHARED_STORAGE.md).
 3. You can also refer to an example on how a Kubernetes cluster and helm deployment can be configured to utilize AWS EBS backed volumes: [Local storage - utilizing AWS EBS-backed volumes](../examples/storage/aws/LOCAL_STORAGE.md).
 

--- a/docs/docs/userguide/PREREQUISITES.md
+++ b/docs/docs/userguide/PREREQUISITES.md
@@ -75,7 +75,8 @@ Before installing the Data Center Helm charts you need to set up your environmen
 !!! info "Bitbucket shared storage"
     In the case of Bitbucket, the following must be taken into account. 
     
-    * Due to the high-performance requirements on IO operations, Bitbucket needs a dedicated NFS server providing persistence for a shared home. 
+    * Consider deploying [Bitbucket Mesh](../examples/bitbucket/BITBUCKET_MESH.md) nodes to relex performance requirements on the shared home. 
+    * Due to the high-performance requirements on IO operations, Bitbucket needs a dedicated NFS server providing persistence for a shared home if not using Bitbucket Mesh nodes to store git data. 
     * Before choosing [AWS EFS](https://aws.amazon.com/efs/){.external} as the File system, review the prerequisite mentioned on [cloud managed storage services](https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html#Supportedplatforms-cloudplatformsCloudplatforms). We include example for [Bitbucket Mesh](../examples/bitbucket/BITBUCKET_MESH.md).
     * Bitbucket doesn't support other cloud-managed storage service such as [Azure Files](https://docs.microsoft.com/en-us/azure/storage/files/storage-files-introduction){.external}.
     

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -284,8 +284,8 @@ volumes:
     #
     subPath:
 
-  # An NFS volume for 'shared-home' is required by Bitbucket to effectively operate in multi-node
-  # environment.
+  # When storing git data on shared home (i.e. not using Mesh), an NFS volume for 'shared-home'
+  # is required by Bitbucket to effectively operate in multi-node environment.
   #
   # Details on how an NFS should be stood up for Bitbucket can be found here:
   # https://confluence.atlassian.com/bitbucketserver/install-bitbucket-data-center-872139817.html#InstallBitbucketDataCenter-nfs


### PR DESCRIPTION
## Pull request description

Historically we required a dedicated NFS server to store shared home as it contained the `git` data. With the introduction of BB Mesh, this is no longer the case. The documentation updates reflect relaxed requirements in case the Bitbucket Mesh is deployed.
