### PR TITLE
Make it possible to declare additional ingress paths

### DIFF
--- a/src/main/charts/bamboo-agent/README.md
+++ b/src/main/charts/bamboo-agent/README.md
@@ -1,6 +1,6 @@
 # bamboo-agent
 
-![Version: 1.22.7](https://img.shields.io/badge/Version-1.22.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.2.3](https://img.shields.io/badge/AppVersion-10.2.3-informational?style=flat-square)
+![Version: 1.22.8](https://img.shields.io/badge/Version-1.22.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.2.3](https://img.shields.io/badge/AppVersion-10.2.3-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center remote agents on Kubernetes
 

--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -1,6 +1,6 @@
 # bamboo
 
-![Version: 1.22.7](https://img.shields.io/badge/Version-1.22.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.2.3](https://img.shields.io/badge/AppVersion-10.2.3-informational?style=flat-square)
+![Version: 1.22.8](https://img.shields.io/badge/Version-1.22.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.2.3](https://img.shields.io/badge/AppVersion-10.2.3-informational?style=flat-square)
 
 A chart for installing Bamboo Data Center on Kubernetes
 
@@ -137,6 +137,7 @@ Kubernetes: `>=1.21.x-0`
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy  |
 | image.repository | string | `"atlassian/bamboo"` | The Bamboo Docker image to use https://hub.docker.com/r/atlassian/bamboo  |
 | image.tag | string | `""` | The docker image tag to be used - defaults to the Chart appVersion  |
+| ingress.additionalPaths | list | `[]` | Additional paths to be added to the Ingress resource to point to different backend services  |
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress Resource. If using an ingress-nginx controller be sure that the annotations you add here are compatible with those already defined in the 'ingess.yaml' template  |
 | ingress.className | string | `"nginx"` | The class name used by the ingress controller if it's being used.  Please follow documenation of your ingress controller. If the cluster contains multiple ingress controllers, this setting allows you to control which of them is used for Atlassian application traffic.  |
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a pre-provisioned Ingress Controller being available.  |

--- a/src/main/charts/bamboo/templates/ingress.yaml
+++ b/src/main/charts/bamboo/templates/ingress.yaml
@@ -38,4 +38,13 @@ spec:
                 name: {{ include "common.names.fullname" $ }}
                 port:
                   number: {{ $.Values.bamboo.service.port }}
+         {{- range $path := .Values.ingress.additionalPaths }}
+          - path: {{ $path.path }}
+            pathType: {{ $path.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $path.service }}
+                port:
+                  number: {{ $path.portNumber }}
+         {{- end }}
 {{ end }}

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -448,6 +448,14 @@ ingress:
   #
   tlsSecretName:
 
+  # -- Additional paths to be added to the Ingress resource to point to different backend services
+  #
+  additionalPaths: []
+    #- path: /static-content
+    #  pathType: Prefix
+    #  service: static-content-svc
+    #  portNumber: 80
+
 # Bamboo configuration
 #
 bamboo:

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -1,6 +1,6 @@
 # bitbucket
 
-![Version: 1.22.7](https://img.shields.io/badge/Version-1.22.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.4.5](https://img.shields.io/badge/AppVersion-9.4.5-informational?style=flat-square)
+![Version: 1.22.8](https://img.shields.io/badge/Version-1.22.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.4.5](https://img.shields.io/badge/AppVersion-9.4.5-informational?style=flat-square)
 
 A chart for installing Bitbucket Data Center on Kubernetes
 
@@ -180,6 +180,7 @@ Kubernetes: `>=1.21.x-0`
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy  |
 | image.repository | string | `"atlassian/bitbucket"` | The Bitbucket Docker image to use https://hub.docker.com/r/atlassian/bitbucket  |
 | image.tag | string | `""` | The docker image tag to be used - defaults to the Chart appVersion  |
+| ingress.additionalPaths | list | `[]` | Additional paths to be added to the Ingress resource to point to different backend services  |
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress Resource. If using an ingress-nginx controller be sure that the annotations you add here are compatible with those already defined in the 'ingess.yaml' template  |
 | ingress.className | string | `"nginx"` | The class name used by the ingress controller if it's being used.  Please follow documentation of your ingress controller. If the cluster contains multiple ingress controllers, this setting allows you to control which of them is used for Atlassian application traffic.  |
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a pre-provisioned Ingress Controller being available.  |

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -38,4 +38,13 @@ spec:
                 name: {{ include "common.names.fullname" $ }}
                 port:
                   number: {{ $.Values.bitbucket.service.port }}
+         {{- range $path := .Values.ingress.additionalPaths }}
+          - path: {{ $path.path }}
+            pathType: {{ $path.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $path.service }}
+                port:
+                  number: {{ $path.portNumber }}
+         {{- end }}
 {{ end }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -523,6 +523,14 @@ ingress:
   #
   tlsSecretName:
 
+  # -- Additional paths to be added to the Ingress resource to point to different backend services
+  #
+  additionalPaths: []
+    #- path: /static-content
+    #  pathType: Prefix
+    #  service: static-content-svc
+    #  portNumber: 80
+
 # Bitbucket configuration
 #
 bitbucket:

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -1,6 +1,6 @@
 # confluence
 
-![Version: 1.22.7](https://img.shields.io/badge/Version-1.22.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.2.3](https://img.shields.io/badge/AppVersion-9.2.3-informational?style=flat-square)
+![Version: 1.22.8](https://img.shields.io/badge/Version-1.22.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.2.3](https://img.shields.io/badge/AppVersion-9.2.3-informational?style=flat-square)
 
 A chart for installing Confluence Data Center on Kubernetes
 
@@ -133,6 +133,7 @@ Kubernetes: `>=1.21.x-0`
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy  |
 | image.repository | string | `"atlassian/confluence"` | The Confluence Docker image to use https://hub.docker.com/r/atlassian/confluence  |
 | image.tag | string | `""` | The docker image tag to be used - defaults to the Chart appVersion  |
+| ingress.additionalPaths | list | `[]` | Additional paths to be added to the Ingress resource to point to different backend services  |
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress Resource. If using an ingress-nginx controller be sure that the annotations you add here are compatible with those already defined in the 'ingess.yaml' template  |
 | ingress.className | string | `"nginx"` | The class name used by the ingress controller if it's being used.  Please follow documentation of your ingress controller. If the cluster contains multiple ingress controllers, this setting allows you to control which of them is used for Atlassian application traffic.  |
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a pre-provisioned Ingress Controller being available.  |

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -47,4 +47,13 @@ spec:
                 name: {{ include "common.names.fullname" . }}
                 port:
                   number: {{ $.Values.confluence.service.port }}
+         {{- range $path := .Values.ingress.additionalPaths }}
+          - path: {{ $path.path }}
+            pathType: {{ $path.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $path.service }}
+                port:
+                  number: {{ $path.portNumber }}
+         {{- end }}
 {{ end }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -568,6 +568,15 @@ ingress:
   #
   tlsSecretName:
 
+  # -- Additional paths to be added to the Ingress resource to point to different backend services
+  #
+  additionalPaths: []
+    #- path: /static-content
+    #  pathType: Prefix
+    #  service: static-content-svc
+    #  portNumber: 80
+
+
 # Confluence configuration
 #
 confluence:

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -1,6 +1,6 @@
 # crowd
 
-![Version: 1.22.7](https://img.shields.io/badge/Version-1.22.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0](https://img.shields.io/badge/AppVersion-6.3.0-informational?style=flat-square)
+![Version: 1.22.8](https://img.shields.io/badge/Version-1.22.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.3.0](https://img.shields.io/badge/AppVersion-6.3.0-informational?style=flat-square)
 
 A chart for installing Crowd Data Center on Kubernetes
 
@@ -125,6 +125,7 @@ Kubernetes: `>=1.21.x-0`
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy  |
 | image.repository | string | `"atlassian/crowd"` | The Docker Crowd Docker image to use https://hub.docker.com/r/atlassian/crowd  |
 | image.tag | string | `""` | The docker image tag to be used. Defaults to appVersion in Chart.yaml  |
+| ingress.additionalPaths | list | `[]` | Additional paths to be added to the Ingress resource to point to different backend services  |
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress Resource. If using an ingress-nginx controller be sure that the annotations you add here are compatible with those already defined in the 'ingess.yaml' template  |
 | ingress.className | string | `"nginx"` | The class name used by the ingress controller if it's being used.  Please follow documentation of your ingress controller. If the cluster contains multiple ingress controllers, this setting allows you to control which of them is used for Atlassian application traffic.  |
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a pre-provisioned Ingress Controller being available.  |

--- a/src/main/charts/crowd/templates/ingress.yaml
+++ b/src/main/charts/crowd/templates/ingress.yaml
@@ -38,4 +38,13 @@ spec:
                 name: {{ include "common.names.fullname" . }}
                 port:
                   number: {{ $.Values.crowd.service.port }}
+         {{- range $path := .Values.ingress.additionalPaths }}
+          - path: {{ $path.path }}
+            pathType: {{ $path.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $path.service }}
+                port:
+                  number: {{ $path.portNumber }}
+         {{- end }}
 {{ end }}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -597,6 +597,15 @@ ingress:
   #
   tlsSecretName:
 
+  # -- Additional paths to be added to the Ingress resource to point to different backend services
+  #
+  additionalPaths: []
+    #- path: /static-content
+    #  pathType: Prefix
+    #  service: static-content-svc
+    #  portNumber: 80
+
+
 # Fluentd configuration
 #
 # Crowd log collection and aggregation can be enabled using Fluentd. This config

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -1,6 +1,6 @@
 # jira
 
-![Version: 1.22.7](https://img.shields.io/badge/Version-1.22.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.5](https://img.shields.io/badge/AppVersion-10.3.5-informational?style=flat-square)
+![Version: 1.22.8](https://img.shields.io/badge/Version-1.22.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.5](https://img.shields.io/badge/AppVersion-10.3.5-informational?style=flat-square)
 
 A chart for installing Jira Data Center on Kubernetes
 
@@ -54,6 +54,7 @@ Kubernetes: `>=1.21.x-0`
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy  |
 | image.repository | string | `"atlassian/jira-software"` | The Jira Docker image to use https://hub.docker.com/r/atlassian/jira-software  |
 | image.tag | string | `""` | The docker image tag to be used - defaults to the Chart appVersion  |
+| ingress.additionalPaths | list | `[]` | Additional paths to be added to the Ingress resource to point to different backend services  |
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress Resource. If using an ingress-nginx controller be sure that the annotations you add here are compatible with those already defined in the 'ingess.yaml' template  |
 | ingress.className | string | `"nginx"` | The class name used by the ingress controller if it's being used.  Please follow documentation of your ingress controller. If the cluster contains multiple ingress controllers, this setting allows you to control which of them is used for Atlassian application traffic.  |
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a pre-provisioned Ingress Controller being available.  |

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -38,4 +38,13 @@ spec:
                 name: {{ include "common.names.fullname" $ }}
                 port:
                   number: {{ $.Values.jira.service.port }}
+         {{- range $path := .Values.ingress.additionalPaths }}
+          - path: {{ $path.path }}
+            pathType: {{ $path.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $path.service }}
+                port:
+                  number: {{ $path.portNumber }}
+         {{- end }}
 {{ end }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -457,6 +457,15 @@ ingress:
   # https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   #
   tlsSecretName:
+  
+  # -- Additional paths to be added to the Ingress resource to point to different backend services
+  #
+  additionalPaths: []
+    #- path: /static-content
+    #  pathType: Prefix
+    #  service: static-content-svc
+    #  portNumber: 80
+  
 
 # Jira configuration
 #

--- a/src/test/resources/expected_helm_output/bamboo/output.yaml
+++ b/src/test/resources/expected_helm_output/bamboo/output.yaml
@@ -257,6 +257,7 @@ data:
       repository: atlassian/bamboo
       tag: ""
     ingress:
+      additionalPaths: []
       annotations: {}
       className: nginx
       create: false

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -298,6 +298,7 @@ data:
       repository: atlassian/bitbucket
       tag: ""
     ingress:
+      additionalPaths: []
       annotations: {}
       className: nginx
       create: false

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -246,6 +246,7 @@ data:
       repository: atlassian/confluence
       tag: ""
     ingress:
+      additionalPaths: []
       annotations: {}
       className: nginx
       create: false

--- a/src/test/resources/expected_helm_output/crowd/output.yaml
+++ b/src/test/resources/expected_helm_output/crowd/output.yaml
@@ -203,6 +203,7 @@ data:
       repository: atlassian/crowd
       tag: ""
     ingress:
+      additionalPaths: []
       annotations: {}
       className: nginx
       create: false

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -115,6 +115,7 @@ data:
       repository: atlassian/jira-software
       tag: ""
     ingress:
+      additionalPaths: []
       annotations: {}
       className: nginx
       create: false


### PR DESCRIPTION
Addresses https://github.com/atlassian/data-center-helm-charts/issues/920

This PR makes it possible to declare additional ingress paths. Example:

```
ingress:
  additionalPaths:
    - path: /static-content
      pathType: Prefix
      service: static-content-svc
      portNumber: 80
```

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
