### PR TITLE
Quote int in session vars

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -622,11 +622,11 @@ volumeClaimTemplates:
 {{- define "confluence.sessionVars"}}
 {{- if .Values.confluence.session.timeout }}
 - name: ATL_CONFLUENCE_SESSION_TIMEOUT
-  value: {{ .Values.confluence.session.timeout | quote }}
+  value: {{ .Values.confluence.session.timeout | int | quote }}
 {{- end }}
 {{- if .Values.confluence.session.autologinCookieAge }}
 - name: ATL_AUTOLOGIN_COOKIE_AGE
-  value: {{ .Values.confluence.session.autologinCookieAge | quote }}
+  value: {{ .Values.confluence.session.autologinCookieAge | int | quote }}
 {{- end }}
 {{- end }}
 

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -11,11 +11,11 @@
 {{- define "jira.sessionVars"}}
 {{- if .Values.jira.session.timeout }}
 - name: ATL_JIRA_SESSION_TIMEOUT
-  value: {{ .Values.jira.session.timeout | quote }}
+  value: {{ .Values.jira.session.timeout | int | quote }}
 {{- end }}
 {{- if .Values.jira.session.autologinCookieAge }}
 - name: ATL_AUTOLOGIN_COOKIE_AGE
-  value: {{ .Values.jira.session.autologinCookieAge | quote }}
+  value: {{ .Values.jira.session.autologinCookieAge | int| quote }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
If session values are not quotes in values.yaml:

```
confluence: 
  session:
    autologinCookieAge: 1209600
```

The value becomes `1.2096e+06`.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
