### PR TITLE
Updating documentation with AWS OpenSearch and Stickiness config details. 

### DIFF
--- a/docs/docs/examples/bitbucket/BITBUCKET_AWS_OPENSEARCH.md
+++ b/docs/docs/examples/bitbucket/BITBUCKET_AWS_OPENSEARCH.md
@@ -1,0 +1,36 @@
+# Configure AWS OpenSearch with Bitbucket
+
+## Configuration Example
+
+```yaml
+bitbucket:
+  # Disable default OpenSearch deployment
+  opensearch:
+    enabled: false
+
+  # Configure AWS OpenSearch connection
+  additionalEnvironmentVariables:
+    - name: SEARCH_ENABLED
+      value: "true"
+    - name: PLUGIN_SEARCH_CONFIG_BASEURL
+      value: "https://your-opensearch-endpoint.region.es.amazonaws.com"
+    - name: PLUGIN_SEARCH_CONFIG_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: aws-opensearch-credentials
+          key: username
+    - name: PLUGIN_SEARCH_CONFIG_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: aws-opensearch-credentials
+          key: password
+```
+
+## Create AWS OpenSearch Credentials Secret
+
+```shell
+kubectl create secret generic aws-opensearch-credentials \
+  --from-literal=username=your-username \
+  --from-literal=password=your-password \
+  -n your-namespace
+``` 

--- a/docs/docs/examples/bitbucket/BITBUCKET_OPENSEARCH.md
+++ b/docs/docs/examples/bitbucket/BITBUCKET_OPENSEARCH.md
@@ -1,30 +1,230 @@
-# Configure OpenSearch with Bitbucket
+!!!info "Helm chart version"
+    OpenSearch sub-chart is supported in Bitbucket Helm chart version 1.20 onwards.
 
-## Deploy OpenSearch Helm Chart
+## Deploy OpenSearch Helm chart with Bitbucket
+
+!!!warning "Support disclaimer"
+    Atlassian does not officially support OpenSearch Helm chart that can be installed with the Bitbucket Helm release. Should you encounter any issues with the deployment, maintenance and upgrades, reach out to the [vendor](https://github.com/opensearch-project/helm-charts/tree/main/charts/opensearch){.external}.
+    Moreover, if you intend to deploy OpenSearch to a critical Kubernetes environment, make sure you follow all the best practices, i.e. deploy a multi node cluster, use taints and tolerations, affinity rules, sufficient resources requests, have DR and backup strategies etc.
+
+To deploy OpenSearch Helm chart and automatically configure Bitbucket to use it as a search platform, set the following in your Helm values file:
+
+```yaml
+opensearch:
+  install: true
+```
+This will:
+
+* auto-generate the initial OpenSearch admin password and create a Kubernetes secret with `OPENSEARCH_INITIAL_ADMIN_PASSWORD` key
+* deploy [OpenSearch Helm chart](https://github.com/opensearch-project/helm-charts/tree/main/charts/opensearch){.external} to the target namespace with the default settings: single node, no SSL, 1Gi memory/1 vCPU resources requests, 10Gi storage request
+* set `PLUGIN_SEARCH_CONFIG_BASEURL` to `http://opensearch-cluster-master:9200` unless overridden in `opensearch.baseUrl`
+* set `PLUGIN_SEARCH_CONFIG_USERNAME` to `admin` (this is the initial admin user created when the OpenSearch cluster starts for the very first time)
+* set `PLUGIN_SEARCH_CONFIG_PASSWORD` to a randomly generated password saved to `opensearch-initial-password` secret
+
+## Create dedicated OpenSearch user
+
+When the Helm chart is installed with the default values, OpenSearch admin user is created with an auto-generated password, and Bitbucket is configured to use these credentials to connect to OpenSearch. If you want to have a more fine-grained control over internal users, you may pre-create a secret with a list of users, their credentials and roles. See [internal_users.yml](https://opensearch.org/docs/latest/security/configuration/yaml/#internal_usersyml){.external} for more details.
+
+### Hash passwords
+
+Passwords in `internal_users.yml` must be hashed. You can use `hash.sh` script bundled with Bitbucket to hash your passwords, for example:
+
+```shell
+docker run atlassian/bitbucket:latest /bin/bash -c "chmod +x /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh && /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh -p mySecureAdminPassword123"
+
+$2y$12$bcUjaXcfutyYwkjp6r/RdePrywC3BmQLKvN77XuuR0PJs0qjBooSv
+```
+If Bitbucket is already up and running in your Kubernetes cluster, you can run exec into the Bitbucket container to hash a password:
+
+```shell
+kubectl exec -ti bitbucket-0 -n atlassian -- /bin/bash -c  "chmod +x /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh && /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh -p mySecureBitbucketPassword123"
+
+$2y$12$x910YF09tcfhNs009vOzWOMy9fswhpsuV5/AiiPwbY4rp5BXKv2tv
+```
+
+### Create internal_users.yml file
+
+This is the minimal `internal_users.yml` file with an admin and a dedicated bitbucket user. See [internal_users.yml](https://opensearch.org/docs/latest/security/configuration/yaml/#internal_usersyml){.external} to get more details about users, roles and role mappings in OpenSearch.
+
+```yaml
+_meta:
+  type: "internalusers"
+  config_version: 2
+
+admin:
+  hash: "$2y$12$bcUjaXcfutyYwkjp6r/RdePrywC3BmQLKvN77XuuR0PJs0qjBooSi"
+  reserved: true
+  backend_roles:
+  - "admin"
+  description: "Demo admin user"
+
+bitbucket:
+  hash: "$2y$12$x910YF09tcfhNs009vOzWOMy9fswhpsuV5/AiiPwbY4rp5BXKv2tu"
+  reserved: true
+  backend_roles:
+    - "admin"
+  description: "Bitbucket admin user"
+```
+
+### Create Kubernetes secret
+
+Create a Kubernetes secret with 3 keys in its data:
+
+!!!warning "internal_users.yml"
+    Make sure there are no typos in `internal_users.yml` filename, otherwise OpenSearch pods can't be created due to a missing key in the secret.
+
+```shell
+kubectl create secret generic opensearch-internal-users \
+      --from-literal=username=bitbucket \
+      --from-literal=password="mySecureBitbucketPassword123" \
+      --from-file=internal_users.yml=/path/to/internal_users.yml \
+      -n atlassian
+```
+
+### Update Helm values
+
+Now that the secret has been created, update your Helm values to point OpenSearch and Bitbucket to `opensearch-internal-users` secret:
+
+```yaml
+opensearch:
+  install: true
+  credentials:
+    secretName: opensearch-internal-users
+    usernameSecretKey: username
+    passwordSecretKey: password
+  securityConfig:
+    internalUsersSecret: opensearch-internal-users
+```
+
+If necessary, you can create 2 separate secrets - one for the `internal_users.yml` only, and one with the actual non-hashed OpenSearch credentials that Bitbucket will use.
+
+## Override OpenSearch Helm chart values
+
+You can configure your OpenSearch cluster and the deployment options by overriding any values that the [Helm chart](https://github.com/opensearch-project/helm-charts/blob/main/charts/opensearch/values.yaml){.external} exposes. OpenSearch values must be nested under `opensearch` stanza in your Helm values file, for example:
+
+```yaml
+opensearch:
+  singleNode: false
+  replicas: 5
+  config:
+    opensearch.yml: |
+      cluster.name: custom-cluster
+```
+
+## Enable SSL with Custom Certificates 
+
+By default, OpenSearch starts with the SSL http plugin disabled, meaning the cluster is accessible via HTTP at http://opensearch-cluster-master:9200. The OpenSearch service is not exposed through a LoadBalancer or Ingress unless the default configurations are explicitly overridden. Bitbucket communicates with the OpenSearch cluster using the service name within the internal Kubernetes network. This setup uses the Kubernetes DNS to resolve the service name to the appropriate cluster IP address.
+
+To enable SSL in OpenSearch and start the service on a secure port, you need to:
+* Enable SSL HTTPS in Helm values.
+* Create Kubernetes secrets with `ca`, `certificate` and `key`, and pass them to OpenSearch.
+* Add `ca.crt` to Java trust store in Bitbucket containers if the custom certificate is not signed by a public authority.
+
+Below is an **example** (not the recommended way) of how to generate a CA certificate, a server certificate, and a corresponding private key for securing communications with OpenSearch:
+
+```shell
+openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -subj "/C=US/ST=CA/L=LA/O=MyCompany Name/CN=opensearch-cluster-master" -keyout ca.key -out ca.crt
+openssl req -new -newkey rsa:2048 -nodes -keyout opensearch-cluster-master.key -subj "/C=US/ST=CA/L=LA/O=MyCompany Name/CN=opensearch-cluster-master" -out opensearch-cluster-master.csr
+openssl x509 -req -days 365 -in opensearch-cluster-master.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out opensearch-cluster-master.crt
+```
+
+It is important to generate the certificate for `opensearch-cluster-master` CN because this is the actual OpenSearch service/host name in the target namespace.
+
+Once done, create 3 Kubernetes secrets:
+
+```shell
+kubectl create secret generic opensearch-ssl-ca -n atlassian --from-file=root-ca.pem=ca.crt
+kubectl create secret generic opensearch-ssl-key -n atlassian --from-file=esnode-key.pem=opensearch-cluster-master.key
+kubectl create secret generic opensearch-ssl-cert -n atlassian --from-file=esnode.pem=opensearch-cluster-master.crt
+```
+
+Enable ssl http plugin, override the default ca, certificate and key, as well as provide additional volume mounts in Bitbucket Helm values file:
+
+```yaml
+opensearch:
+  extraEnvs:
+    - name: plugins.security.ssl.http.enabled
+      value: "true"
+    - name: plugins.security.ssl.transport.pemkey_filepath
+      value: "esnode-key.pem"
+    - name: plugins.security.ssl.transport.pemcert_filepath
+      value: "esnode.pem"
+    - name: plugins.security.ssl.transport.pemtrustedcas_filepath
+      value: "root-ca.pem"
+  secretMounts:
+  - name: opensearch-ssl-cert
+    secretName: opensearch-ssl-cert
+    path: /usr/share/opensearch/config/esnode.pem
+    subPath: esnode.pem
+  - name: opensearch-ssl-key
+    secretName: opensearch-ssl-key
+    path: /usr/share/opensearch/config/esnode-key.pem
+    subPath: esnode-key.pem
+  - name: opensearch-ssl-ca
+    secretName: opensearch-ssl-ca
+    path: /usr/share/opensearch/config/root-ca.pem
+    subPath: root-ca.pem
+```
+When using a self-signed certificate or a certificate not issued/signed by a recognized public certificate authority (CA), it is essential to add the CA certificate to the Java trust store in all Bitbucket containers:
 
 ```yaml
 bitbucket:
-  clustering:
-    enabled: true
-  opensearch:
-    enabled: true
+  additionalCertificates:
+    secretName: opensearch-ssl-ca
+```
+
+Additionally, you need to update the protocol specified in the baseUrl to HTTPS:
+
+```yaml
+bitbucket:
+  additionalCertificates:
+    secretName: opensearch-ssl-ca
+opensearch:
+  baseUrl: https://opensearch-cluster-master:9200
+```
+
+## Enable Ingress
+
+To communicate with the OpenSearch cluster through a fully qualified domain name rather than via Kubernetes internal DNS name, you can enable an Ingress in the OpenSearch Helm chart. Below is an example of how to configure Ingress and update base URL in the Helm values file:
+
+
+```yaml
+opensearch:
+  baseUrl: https://myopensearch.com
+  ingress:
     install: true
 ```
+Important considerations:
+
+* Ensure that the `baseUrl` is set to use HTTPS protocol, which encrypts the data exchanged with the OpenSearch cluster
+* Ensure that the Ingress hostname can be resolved from within the Kubernetes cluster network
+* If the certificate is not signed by a public authority, you will need to add the certificate to Java trust store in Bitbucket containers by defining a secret name in `bitbucket.additionalCertificates.secretName`
 
 ## Use AWS OpenSearch Service
 
+If you're using AWS OpenSearch Service (managed service) instead of deploying your own OpenSearch cluster, configure Bitbucket to connect to your existing AWS OpenSearch domain using environment variables.
+
+### Prerequisites
+
+* Create an AWS OpenSearch Service domain
+* Configure domain access policy to allow your EKS cluster
+* Have the domain endpoint URL and credentials ready
+
+### Configuration
+
 ```yaml
 bitbucket:
   clustering:
     enabled: true
+  # Do not enable the opensearch helm chart
   opensearch:
-    enabled: false  # Disable Helm chart deployment
+    enabled: false
   
   additionalEnvironmentVariables:
     - name: SEARCH_ENABLED
       value: "false"
     - name: PLUGIN_SEARCH_CONFIG_BASEURL
-      value: "https://your-opensearch-endpoint.region.es.amazonaws.com"
+      value: "https://search-your-domain-abc123.us-east-1.es.amazonaws.com"
     - name: PLUGIN_SEARCH_CONFIG_USERNAME
       valueFrom:
         secretKeyRef:
@@ -37,22 +237,68 @@ bitbucket:
           key: password
 ```
 
-## Create Credentials Secret
+### Create AWS OpenSearch Credentials Secret
 
 ```shell
 kubectl create secret generic aws-opensearch-credentials \
-  --from-literal=username=your-username \
-  --from-literal=password=your-password \
+  --from-literal=username=your-master-username \
+  --from-literal=password=your-master-password \
   -n your-namespace
 ```
 
-## Common Issues
+### Using IAM Authentication
 
-**Connection failures**: Verify the OpenSearch endpoint URL and network connectivity from your EKS cluster.
+For domains using IAM authentication, configure IAM roles and omit username/password:
 
-**Authentication errors**: Check credentials and ensure the OpenSearch domain access policy allows your EKS cluster.
+```yaml
+bitbucket:
+  clustering:
+    enabled: true
+  opensearch:
+    enabled: false
+  
+  additionalEnvironmentVariables:
+    - name: SEARCH_ENABLED
+      value: "false"
+    - name: PLUGIN_SEARCH_CONFIG_BASEURL
+      value: "https://search-your-domain-abc123.us-east-1.es.amazonaws.com"
+    # No username/password needed - uses IAM role
+```
 
-**Test connectivity**:
+## Troubleshooting
+
+### Authentication
+
+If you run into auth issues (401 response from OpenSearch), check the following:
+
+* exec into the Bitbucket container and run:
+  ```shell
+  curl -v -u ${PLUGIN_SEARCH_CONFIG_USERNAME}:${PLUGIN_SEARCH_CONFIG_PASSWORD} http://opensearch-cluster-master:9200/_cat/indices?v
+  ```
+  If you get 401, then the user or password passed to the Bitbucket container does not match user or password defined in the `internal_users.yml`
+
+* you can find out where the actual values of `PLUGIN_SEARCH_CONFIG_USERNAME` and `PLUGIN_SEARCH_CONFIG_PASSWORD` environment variables come from by running:
+
+    ```shell
+    kubectl get pod bitbucket-0 -n atlassian -o jsonpath="{.spec.containers[0].env[?(@.name=='PLUGIN_SEARCH_CONFIG_USERNAME')]}"
+    kubectl get pod bitbucket-0 -n atlassian -o jsonpath="{.spec.containers[0].env[?(@.name=='PLUGIN_SEARCH_CONFIG_PASSWORD')]}"
+    ```
+* Make sure that hashed password of the bitbucket user in the `internal_users.yml` file corresponds to the plain text password stored in the Kubernetes secret.
+
+### Networking
+
+The default `opensearch-cluster-master` hostname must be resolved to a Kubernetes service cluster IP, and the request is then forwarded directly to the pod endpoint.
+If you see connection refused/timeout errors, make sure all OpenSearch pods are in a Ready state and the corresponding endpoints have been created:
+
 ```shell
-kubectl exec -ti bitbucket-0 -n atlassian -- curl -u username:password https://your-opensearch-domain/_cluster/health
+kubectl describe pod -n atlassian -l=app.kubernetes.io/component=opensearch-cluster-master
+```
+
+```shell
+kubectl get endpoints -n atlassian
+
+NAME                                 ENDPOINTS                                         AGE
+bitbucket                            10.0.2.31:7999,10.0.2.31:7990,10.0.2.31:5701      113m
+opensearch-cluster-master            10.0.1.170:9200,10.0.1.170:9300                   113m
+opensearch-cluster-master-headless   10.0.1.170:9600,10.0.1.170:9200,10.0.1.170:9300   113m
 ```

--- a/docs/docs/examples/bitbucket/BITBUCKET_OPENSEARCH.md
+++ b/docs/docs/examples/bitbucket/BITBUCKET_OPENSEARCH.md
@@ -1,6 +1,29 @@
 !!!info "Helm chart version"
     OpenSearch sub-chart is supported in Bitbucket Helm chart version 1.20 onwards.
 
+## When to use which OpenSearch configuration
+
+There are two different ways to configure OpenSearch with Bitbucket on Kubernetes:
+
+### 1. Deploy OpenSearch Helm chart (self-managed)
+
+Use the `opensearch` section in your Helm values file when you want to deploy and manage your own OpenSearch cluster within the Kubernetes cluster. This approach:
+
+* Deploys the [OpenSearch Helm chart](https://github.com/opensearch-project/helm-charts/tree/main/charts/opensearch){.external} alongside Bitbucket
+* Automatically configures Bitbucket to connect to the deployed OpenSearch cluster
+* Requires managing the OpenSearch cluster lifecycle (updates, backups, scaling, etc.)
+
+### 2. Use AWS OpenSearch Service (managed service)
+
+Use the `bitbucket.additionalEnvironmentVariables` section when you want to connect to an external AWS OpenSearch Service (managed service). This approach:
+
+* Connects to an existing AWS OpenSearch Service domain
+* Leverages AWS's managed service benefits (automatic backups, updates, scaling, etc.)
+* Requires manual configuration through environment variables
+
+!!!warning "Important: Choose the right configuration method"
+    **Do NOT use the `opensearch` section if you want to connect to AWS OpenSearch Service.** The `opensearch` section is designed to deploy a self-managed OpenSearch cluster within your Kubernetes cluster, not to connect to external services.
+
 ## Deploy OpenSearch Helm chart with Bitbucket
 
 !!!warning "Support disclaimer"
@@ -39,7 +62,7 @@ If Bitbucket is already up and running in your Kubernetes cluster, you can run e
 ```shell
 kubectl exec -ti bitbucket-0 -n atlassian -- /bin/bash -c  "chmod +x /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh && /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh -p mySecureBitbucketPassword123"
 
-$2y$12$x910YF09tcfhNs009vOzWOMy9fswhpsuV5/AiiPwbY4rp5BXKv2tv
+$2y$12$x910YF09tcfhNs009vOzWOMy9fswhpsuV5/AiiPwbY4rp5BXKv2tu
 ```
 
 ### Create internal_users.yml file
@@ -199,6 +222,115 @@ Important considerations:
 * Ensure that the `baseUrl` is set to use HTTPS protocol, which encrypts the data exchanged with the OpenSearch cluster
 * Ensure that the Ingress hostname can be resolved from within the Kubernetes cluster network
 * If the certificate is not signed by a public authority, you will need to add the certificate to Java trust store in Bitbucket containers by defining a secret name in `bitbucket.additionalCertificates.secretName`
+
+## Using AWS OpenSearch Service
+
+If you're running Bitbucket on Amazon EKS and want to use AWS OpenSearch Service (managed service) instead of deploying your own OpenSearch cluster, you need to configure Bitbucket using the `bitbucket.additionalEnvironmentVariables` section.
+
+!!!info "AWS OpenSearch Service benefits"
+    AWS OpenSearch Service provides a fully managed OpenSearch experience with automatic backups, updates, scaling, security, and monitoring. This eliminates the operational overhead of managing your own OpenSearch cluster.
+
+### Prerequisites
+
+Before configuring Bitbucket to use AWS OpenSearch Service:
+
+1. Create an AWS OpenSearch Service domain in the same region as your EKS cluster
+2. Configure the domain's access policy to allow access from your EKS cluster
+3. Note the domain endpoint URL (e.g., `https://search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com`)
+4. Have the username and password for your OpenSearch domain (if using master user authentication)
+
+### Configuration
+
+To configure Bitbucket to use AWS OpenSearch Service, add the following to your Helm values file:
+
+```yaml
+bitbucket:
+  clustering:
+    enabled: true  # Required for OpenSearch integration
+  additionalEnvironmentVariables:
+    - name: SEARCH_ENABLED
+      value: "false"  # Disable internal search
+    - name: PLUGIN_SEARCH_CONFIG_BASEURL
+      value: "https://search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com"
+    - name: PLUGIN_SEARCH_CONFIG_USERNAME
+      value: "master-username"  # Your OpenSearch master username
+    - name: PLUGIN_SEARCH_CONFIG_PASSWORD
+      value: "master-password"  # Your OpenSearch master password
+```
+
+### Using Kubernetes Secrets for Credentials
+
+For better security, store your AWS OpenSearch credentials in a Kubernetes secret instead of hardcoding them in the values file:
+
+```shell
+kubectl create secret generic aws-opensearch-credentials \
+  --from-literal=username="master-username" \
+  --from-literal=password="master-password" \
+  -n atlassian
+```
+
+Then reference the secret in your Helm values:
+
+```yaml
+bitbucket:
+  clustering:
+    enabled: true
+  additionalEnvironmentVariables:
+    - name: SEARCH_ENABLED
+      value: "false"
+    - name: PLUGIN_SEARCH_CONFIG_BASEURL
+      value: "https://search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com"
+    - name: PLUGIN_SEARCH_CONFIG_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: aws-opensearch-credentials
+          key: username
+    - name: PLUGIN_SEARCH_CONFIG_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: aws-opensearch-credentials
+          key: password
+```
+
+### AWS IAM Authentication
+
+If your AWS OpenSearch domain uses IAM authentication instead of master user authentication, you can configure Bitbucket to use IAM roles:
+
+1. Create an IAM policy with the necessary OpenSearch permissions
+2. Attach the policy to your EKS node group role or use IAM Roles for Service Accounts (IRSA)
+3. Configure the environment variables:
+
+```yaml
+bitbucket:
+  clustering:
+    enabled: true
+  additionalEnvironmentVariables:
+    - name: SEARCH_ENABLED
+      value: "false"
+    - name: PLUGIN_SEARCH_CONFIG_BASEURL
+      value: "https://search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com"
+    # When using IAM authentication, username and password are not required
+    # AWS SDK will use the pod's IAM role for authentication
+```
+
+### Important Notes
+
+* **Do not use both configurations**: If you're using AWS OpenSearch Service with `additionalEnvironmentVariables`, ensure that `opensearch.install` is set to `false` (which is the default) and do not configure the `opensearch` section
+* **Clustering must be enabled**: OpenSearch integration requires `bitbucket.clustering.enabled: true`
+* **HTTPS is recommended**: Always use HTTPS endpoints for AWS OpenSearch Service to ensure secure communication
+* **Region considerations**: Ensure your AWS OpenSearch domain is in the same region as your EKS cluster for optimal performance and reduced latency
+
+### Troubleshooting AWS OpenSearch Service
+
+If you encounter issues connecting to AWS OpenSearch Service:
+
+1. **Check the domain endpoint**: Verify the URL is correct and accessible from your EKS cluster
+2. **Verify access policies**: Ensure your EKS cluster has proper access to the OpenSearch domain
+3. **Test connectivity**: Use `kubectl exec` to test connectivity from a Bitbucket pod:
+   ```shell
+   kubectl exec -ti bitbucket-0 -n atlassian -- curl -u username:password https://your-opensearch-domain/_cluster/health
+   ```
+4. **Check CloudWatch logs**: Review AWS OpenSearch Service logs in CloudWatch for authentication or authorization errors
 
 ## Troubleshooting
 

--- a/docs/docs/examples/bitbucket/BITBUCKET_OPENSEARCH.md
+++ b/docs/docs/examples/bitbucket/BITBUCKET_OPENSEARCH.md
@@ -1,285 +1,30 @@
-!!!info "Helm chart version"
-    OpenSearch sub-chart is supported in Bitbucket Helm chart version 1.20 onwards.
+# Configure OpenSearch with Bitbucket
 
-## When to use which OpenSearch configuration
-
-There are two different ways to configure OpenSearch with Bitbucket on Kubernetes:
-
-### 1. Deploy OpenSearch Helm chart (self-managed)
-
-Use the `opensearch` section in your Helm values file when you want to deploy and manage your own OpenSearch cluster within the Kubernetes cluster. This approach:
-
-* Deploys the [OpenSearch Helm chart](https://github.com/opensearch-project/helm-charts/tree/main/charts/opensearch){.external} alongside Bitbucket
-* Automatically configures Bitbucket to connect to the deployed OpenSearch cluster
-* Requires managing the OpenSearch cluster lifecycle (updates, backups, scaling, etc.)
-
-### 2. Use AWS OpenSearch Service (managed service)
-
-Use the `bitbucket.additionalEnvironmentVariables` section when you want to connect to an external AWS OpenSearch Service (managed service). This approach:
-
-* Connects to an existing AWS OpenSearch Service domain
-* Leverages AWS's managed service benefits (automatic backups, updates, scaling, etc.)
-* Requires manual configuration through environment variables
-
-!!!warning "Important: Choose the right configuration method"
-    **Do NOT use the `opensearch` section if you want to connect to AWS OpenSearch Service.** The `opensearch` section is designed to deploy a self-managed OpenSearch cluster within your Kubernetes cluster, not to connect to external services.
-
-## Deploy OpenSearch Helm chart with Bitbucket
-
-!!!warning "Support disclaimer"
-    Atlassian does not officially support OpenSearch Helm chart that can be installed with the Bitbucket Helm release. Should you encounter any issues with the deployment, maintenance and upgrades, reach out to the [vendor](https://github.com/opensearch-project/helm-charts/tree/main/charts/opensearch){.external}.
-    Moreover, if you intend to deploy OpenSearch to a critical Kubernetes environment, make sure you follow all the best practices, i.e. deploy a multi node cluster, use taints and tolerations, affinity rules, sufficient resources requests, have DR and backup strategies etc.
-
-To deploy OpenSearch Helm chart and automatically configure Bitbucket to use it as a search platform, set the following in your Helm values file:
-
-```yaml
-opensearch:
-  install: true
-```
-This will:
-
-* auto-generate the initial OpenSearch admin password and create a Kubernetes secret with `OPENSEARCH_INITIAL_ADMIN_PASSWORD` key
-* deploy [OpenSearch Helm chart](https://github.com/opensearch-project/helm-charts/tree/main/charts/opensearch){.external} to the target namespace with the default settings: single node, no SSL, 1Gi memory/1 vCPU resources requests, 10Gi storage request
-* set `PLUGIN_SEARCH_CONFIG_BASEURL` to `http://opensearch-cluster-master:9200` unless overridden in `opensearch.baseUrl`
-* set `PLUGIN_SEARCH_CONFIG_USERNAME` to `admin` (this is the initial admin user created when the OpenSearch cluster starts for the very first time)
-* set `PLUGIN_SEARCH_CONFIG_PASSWORD` to a randomly generated password saved to `opensearch-initial-password` secret
-
-## Create dedicated OpenSearch user
-
-When the Helm chart is installed with the default values, OpenSearch admin user is created with an auto-generated password, and Bitbucket is configured to use these credentials to connect to OpenSearch. If you want to have a more fine-grained control over internal users, you may pre-create a secret with a list of users, their credentials and roles. See [internal_users.yml](https://opensearch.org/docs/latest/security/configuration/yaml/#internal_usersyml){.external} for more details.
-
-### Hash passwords
-
-Passwords in `internal_users.yml` must be hashed. You can use `hash.sh` script bundled with Bitbucket to hash your passwords, for example:
-
-```shell
-docker run atlassian/bitbucket:latest /bin/bash -c "chmod +x /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh && /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh -p mySecureAdminPassword123"
-
-$2y$12$bcUjaXcfutyYwkjp6r/RdePrywC3BmQLKvN77XuuR0PJs0qjBooSv
-```
-If Bitbucket is already up and running in your Kubernetes cluster, you can run exec into the Bitbucket container to hash a password:
-
-```shell
-kubectl exec -ti bitbucket-0 -n atlassian -- /bin/bash -c  "chmod +x /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh && /opt/atlassian/bitbucket/opensearch/plugins/opensearch-security/tools/hash.sh -p mySecureBitbucketPassword123"
-
-$2y$12$x910YF09tcfhNs009vOzWOMy9fswhpsuV5/AiiPwbY4rp5BXKv2tu
-```
-
-### Create internal_users.yml file
-
-This is the minimal `internal_users.yml` file with an admin and a dedicated bitbucket user. See [internal_users.yml](https://opensearch.org/docs/latest/security/configuration/yaml/#internal_usersyml){.external} to get more details about users, roles and role mappings in OpenSearch.
-
-```yaml
-_meta:
-  type: "internalusers"
-  config_version: 2
-
-admin:
-  hash: "$2y$12$bcUjaXcfutyYwkjp6r/RdePrywC3BmQLKvN77XuuR0PJs0qjBooSi"
-  reserved: true
-  backend_roles:
-  - "admin"
-  description: "Demo admin user"
-
-bitbucket:
-  hash: "$2y$12$x910YF09tcfhNs009vOzWOMy9fswhpsuV5/AiiPwbY4rp5BXKv2tu"
-  reserved: true
-  backend_roles:
-    - "admin"
-  description: "Bitbucket admin user"
-```
-
-### Create Kubernetes secret
-
-Create a Kubernetes secret with 3 keys in its data:
-
-!!!warning "internal_users.yml"
-    Make sure there are no typos in `internal_users.yml` filename, otherwise OpenSearch pods can't be created due to a missing key in the secret.
-
-```shell
-kubectl create secret generic opensearch-internal-users \
-      --from-literal=username=bitbucket \
-      --from-literal=password="mySecureBitbucketPassword123" \
-      --from-file=internal_users.yml=/path/to/internal_users.yml \
-      -n atlassian
-```
-
-### Update Helm values
-
-Now that the secret has been created, update your Helm values to point OpenSearch and Bitbucket to `opensearch-internal-users` secret:
-
-```yaml
-opensearch:
-  install: true
-  credentials:
-    secretName: opensearch-internal-users
-    usernameSecretKey: username
-    passwordSecretKey: password
-  securityConfig:
-    internalUsersSecret: opensearch-internal-users
-```
-
-If necessary, you can create 2 separate secrets - one for the `internal_users.yml` only, and one with the actual non-hashed OpenSearch credentials that Bitbucket will use.
-
-## Override OpenSearch Helm chart values
-
-You can configure your OpenSearch cluster and the deployment options by overriding any values that the [Helm chart](https://github.com/opensearch-project/helm-charts/blob/main/charts/opensearch/values.yaml){.external} exposes. OpenSearch values must be nested under `opensearch` stanza in your Helm values file, for example:
-
-```yaml
-opensearch:
-  singleNode: false
-  replicas: 5
-  config:
-    opensearch.yml: |
-      cluster.name: custom-cluster
-```
-
-## Enable SSL with Custom Certificates 
-
-By default, OpenSearch starts with the SSL http plugin disabled, meaning the cluster is accessible via HTTP at http://opensearch-cluster-master:9200. The OpenSearch service is not exposed through a LoadBalancer or Ingress unless the default configurations are explicitly overridden. Bitbucket communicates with the OpenSearch cluster using the service name within the internal Kubernetes network. This setup uses the Kubernetes DNS to resolve the service name to the appropriate cluster IP address.
-
-To enable SSL in OpenSearch and start the service on a secure port, you need to:
-* Enable SSL HTTPS in Helm values.
-* Create Kubernetes secrets with `ca`, `certificate` and `key`, and pass them to OpenSearch.
-* Add `ca.crt` to Java trust store in Bitbucket containers if the custom certificate is not signed by a public authority.
-
-Below is an **example** (not the recommended way) of how to generate a CA certificate, a server certificate, and a corresponding private key for securing communications with OpenSearch:
-
-```shell
-openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -subj "/C=US/ST=CA/L=LA/O=MyCompany Name/CN=opensearch-cluster-master" -keyout ca.key -out ca.crt
-openssl req -new -newkey rsa:2048 -nodes -keyout opensearch-cluster-master.key -subj "/C=US/ST=CA/L=LA/O=MyCompany Name/CN=opensearch-cluster-master" -out opensearch-cluster-master.csr
-openssl x509 -req -days 365 -in opensearch-cluster-master.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out opensearch-cluster-master.crt
-```
-
-It is important to generate the certificate for `opensearch-cluster-master` CN because this is the actual OpenSearch service/host name in the target namespace.
-
-Once done, create 3 Kubernetes secrets:
-
-```shell
-kubectl create secret generic opensearch-ssl-ca -n atlassian --from-file=root-ca.pem=ca.crt
-kubectl create secret generic opensearch-ssl-key -n atlassian --from-file=esnode-key.pem=opensearch-cluster-master.key
-kubectl create secret generic opensearch-ssl-cert -n atlassian --from-file=esnode.pem=opensearch-cluster-master.crt
-```
-
-Enable ssl http plugin, override the default ca, certificate and key, as well as provide additional volume mounts in Bitbucket Helm values file:
-
-```yaml
-opensearch:
-  extraEnvs:
-    - name: plugins.security.ssl.http.enabled
-      value: "true"
-    - name: plugins.security.ssl.transport.pemkey_filepath
-      value: "esnode-key.pem"
-    - name: plugins.security.ssl.transport.pemcert_filepath
-      value: "esnode.pem"
-    - name: plugins.security.ssl.transport.pemtrustedcas_filepath
-      value: "root-ca.pem"
-  secretMounts:
-  - name: opensearch-ssl-cert
-    secretName: opensearch-ssl-cert
-    path: /usr/share/opensearch/config/esnode.pem
-    subPath: esnode.pem
-  - name: opensearch-ssl-key
-    secretName: opensearch-ssl-key
-    path: /usr/share/opensearch/config/esnode-key.pem
-    subPath: esnode-key.pem
-  - name: opensearch-ssl-ca
-    secretName: opensearch-ssl-ca
-    path: /usr/share/opensearch/config/root-ca.pem
-    subPath: root-ca.pem
-```
-When using a self-signed certificate or a certificate not issued/signed by a recognized public certificate authority (CA), it is essential to add the CA certificate to the Java trust store in all Bitbucket containers:
-
-```yaml
-bitbucket:
-  additionalCertificates:
-    secretName: opensearch-ssl-ca
-```
-
-Additionally, you need to update the protocol specified in the baseUrl to HTTPS:
-
-```yaml
-bitbucket:
-  additionalCertificates:
-    secretName: opensearch-ssl-ca
-opensearch:
-  baseUrl: https://opensearch-cluster-master:9200
-```
-
-## Enable Ingress
-
-To communicate with the OpenSearch cluster through a fully qualified domain name rather than via Kubernetes internal DNS name, you can enable an Ingress in the OpenSearch Helm chart. Below is an example of how to configure Ingress and update base URL in the Helm values file:
-
-
-```yaml
-opensearch:
-  baseUrl: https://myopensearch.com
-  ingress:
-    install: true
-```
-Important considerations:
-
-* Ensure that the `baseUrl` is set to use HTTPS protocol, which encrypts the data exchanged with the OpenSearch cluster
-* Ensure that the Ingress hostname can be resolved from within the Kubernetes cluster network
-* If the certificate is not signed by a public authority, you will need to add the certificate to Java trust store in Bitbucket containers by defining a secret name in `bitbucket.additionalCertificates.secretName`
-
-## Using AWS OpenSearch Service
-
-If you're running Bitbucket on Amazon EKS and want to use AWS OpenSearch Service (managed service) instead of deploying your own OpenSearch cluster, you need to configure Bitbucket using the `bitbucket.additionalEnvironmentVariables` section.
-
-!!!info "AWS OpenSearch Service benefits"
-    AWS OpenSearch Service provides a fully managed OpenSearch experience with automatic backups, updates, scaling, security, and monitoring. This eliminates the operational overhead of managing your own OpenSearch cluster.
-
-### Prerequisites
-
-Before configuring Bitbucket to use AWS OpenSearch Service:
-
-1. Create an AWS OpenSearch Service domain in the same region as your EKS cluster
-2. Configure the domain's access policy to allow access from your EKS cluster
-3. Note the domain endpoint URL (e.g., `https://search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com`)
-4. Have the username and password for your OpenSearch domain (if using master user authentication)
-
-### Configuration
-
-To configure Bitbucket to use AWS OpenSearch Service, add the following to your Helm values file:
-
-```yaml
-bitbucket:
-  clustering:
-    enabled: true  # Required for OpenSearch integration
-  additionalEnvironmentVariables:
-    - name: SEARCH_ENABLED
-      value: "false"  # Disable internal search
-    - name: PLUGIN_SEARCH_CONFIG_BASEURL
-      value: "https://search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com"
-    - name: PLUGIN_SEARCH_CONFIG_USERNAME
-      value: "master-username"  # Your OpenSearch master username
-    - name: PLUGIN_SEARCH_CONFIG_PASSWORD
-      value: "master-password"  # Your OpenSearch master password
-```
-
-### Using Kubernetes Secrets for Credentials
-
-For better security, store your AWS OpenSearch credentials in a Kubernetes secret instead of hardcoding them in the values file:
-
-```shell
-kubectl create secret generic aws-opensearch-credentials \
-  --from-literal=username="master-username" \
-  --from-literal=password="master-password" \
-  -n atlassian
-```
-
-Then reference the secret in your Helm values:
+## Deploy OpenSearch Helm Chart
 
 ```yaml
 bitbucket:
   clustering:
     enabled: true
+  opensearch:
+    enabled: true
+    install: true
+```
+
+## Use AWS OpenSearch Service
+
+```yaml
+bitbucket:
+  clustering:
+    enabled: true
+  opensearch:
+    enabled: false  # Disable Helm chart deployment
+  
   additionalEnvironmentVariables:
     - name: SEARCH_ENABLED
       value: "false"
     - name: PLUGIN_SEARCH_CONFIG_BASEURL
-      value: "https://search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com"
+      value: "https://your-opensearch-endpoint.region.es.amazonaws.com"
     - name: PLUGIN_SEARCH_CONFIG_USERNAME
       valueFrom:
         secretKeyRef:
@@ -292,80 +37,22 @@ bitbucket:
           key: password
 ```
 
-### AWS IAM Authentication
-
-If your AWS OpenSearch domain uses IAM authentication instead of master user authentication, you can configure Bitbucket to use IAM roles:
-
-1. Create an IAM policy with the necessary OpenSearch permissions
-2. Attach the policy to your EKS node group role or use IAM Roles for Service Accounts (IRSA)
-3. Configure the environment variables:
-
-```yaml
-bitbucket:
-  clustering:
-    enabled: true
-  additionalEnvironmentVariables:
-    - name: SEARCH_ENABLED
-      value: "false"
-    - name: PLUGIN_SEARCH_CONFIG_BASEURL
-      value: "https://search-my-domain-abcdefghijklmnop.us-east-1.es.amazonaws.com"
-    # When using IAM authentication, username and password are not required
-    # AWS SDK will use the pod's IAM role for authentication
-```
-
-### Important Notes
-
-* **Do not use both configurations**: If you're using AWS OpenSearch Service with `additionalEnvironmentVariables`, ensure that `opensearch.install` is set to `false` (which is the default) and do not configure the `opensearch` section
-* **Clustering must be enabled**: OpenSearch integration requires `bitbucket.clustering.enabled: true`
-* **HTTPS is recommended**: Always use HTTPS endpoints for AWS OpenSearch Service to ensure secure communication
-* **Region considerations**: Ensure your AWS OpenSearch domain is in the same region as your EKS cluster for optimal performance and reduced latency
-
-### Troubleshooting AWS OpenSearch Service
-
-If you encounter issues connecting to AWS OpenSearch Service:
-
-1. **Check the domain endpoint**: Verify the URL is correct and accessible from your EKS cluster
-2. **Verify access policies**: Ensure your EKS cluster has proper access to the OpenSearch domain
-3. **Test connectivity**: Use `kubectl exec` to test connectivity from a Bitbucket pod:
-   ```shell
-   kubectl exec -ti bitbucket-0 -n atlassian -- curl -u username:password https://your-opensearch-domain/_cluster/health
-   ```
-4. **Check CloudWatch logs**: Review AWS OpenSearch Service logs in CloudWatch for authentication or authorization errors
-
-## Troubleshooting
-
-### Authentication
-
-If you run into auth issues (401 response from OpenSearch), check the following:
-
-* exec into the Bitbucket container and run:
-  ```shell
-  curl -v -u ${PLUGIN_SEARCH_CONFIG_USERNAME}:${PLUGIN_SEARCH_CONFIG_PASSWORD} http://opensearch-cluster-master:9200/_cat/indices?v
-  ```
-  If you get 401, then the user or password passed to the Bitbucket container does not match user or password defined in the `internal_users.yml`
-
-* you can find out where the actual values of `PLUGIN_SEARCH_CONFIG_USERNAME` and `PLUGIN_SEARCH_CONFIG_PASSWORD` environment variables come from by running:
-
-    ```shell
-    kubectl get pod bitbucket-0 -n atlassian -o jsonpath="{.spec.containers[0].env[?(@.name=='PLUGIN_SEARCH_CONFIG_USERNAME')]}"
-    kubectl get pod bitbucket-0 -n atlassian -o jsonpath="{.spec.containers[0].env[?(@.name=='PLUGIN_SEARCH_CONFIG_PASSWORD')]}"
-    ```
-* Make sure that hashed password of the bitbucket user in the `internal_users.yml` file corresponds to the plain text password stored in the Kubernetes secret.
-
-### Networking
-
-The default `opensearch-cluster-master` hostname must be resolved to a Kubernetes service cluster IP, and the request is then forwarded directly to the pod endpoint.
-If you see connection refused/timeout errors, make sure all OpenSearch pods are in a Ready state and the corresponding endpoints have been created:
+## Create Credentials Secret
 
 ```shell
-kubectl describe pod -n atlassian -l=app.kubernetes.io/component=opensearch-cluster-master
+kubectl create secret generic aws-opensearch-credentials \
+  --from-literal=username=your-username \
+  --from-literal=password=your-password \
+  -n your-namespace
 ```
 
-```shell
-kubectl get endpoints -n atlassian
+## Common Issues
 
-NAME                                 ENDPOINTS                                         AGE
-bitbucket                            10.0.2.31:7999,10.0.2.31:7990,10.0.2.31:5701      113m
-opensearch-cluster-master            10.0.1.170:9200,10.0.1.170:9300                   113m
-opensearch-cluster-master-headless   10.0.1.170:9600,10.0.1.170:9200,10.0.1.170:9300   113m
+**Connection failures**: Verify the OpenSearch endpoint URL and network connectivity from your EKS cluster.
+
+**Authentication errors**: Check credentials and ensure the OpenSearch domain access policy allows your EKS cluster.
+
+**Test connectivity**:
+```shell
+kubectl exec -ti bitbucket-0 -n atlassian -- curl -u username:password https://your-opensearch-domain/_cluster/health
 ```

--- a/docs/docs/examples/bitbucket/BITBUCKET_SESSION_AFFINITY.md
+++ b/docs/docs/examples/bitbucket/BITBUCKET_SESSION_AFFINITY.md
@@ -1,36 +1,19 @@
-# Session Stickiness for Bitbucket with NGINX Ingress
+# Configure Session Stickiness with NGINX Ingress
 
-When running Bitbucket Data Center in High Availability (HA) mode with multiple pods, session stickiness ensures that user requests are consistently routed to the same Bitbucket pod throughout their session.
-
-!!!info "Why session stickiness is important for Bitbucket"
-    * **Git operations**: Prevents Git push/pull failures when routed to different pods mid-operation
-    * **User sessions**: Avoids unexpected logouts and session data loss
-    * **Performance**: Maintains repository cache locality for better performance
-
-## Automatic Session Stickiness (Default)
-
-The Bitbucket Helm chart automatically enables session stickiness when using NGINX Ingress Controller:
+## Default Configuration
 
 ```yaml
 ingress:
   create: true
-  nginx: true  # Automatically enables session stickiness
+  nginx: true  # Enables session stickiness automatically
   host: bitbucket.example.com
 
 bitbucket:
   clustering:
-    enabled: true  # Required for HA deployments
+    enabled: true
 ```
 
-This automatically applies these NGINX annotations:
-```yaml
-"nginx.ingress.kubernetes.io/affinity": "cookie"
-"nginx.ingress.kubernetes.io/affinity-mode": "persistent"
-```
-
-## Custom Session Stickiness Configuration
-
-You can customize the session behavior by adding additional annotations:
+## Custom Configuration
 
 ```yaml
 ingress:
@@ -38,16 +21,8 @@ ingress:
   nginx: true
   host: bitbucket.example.com
   annotations:
-    # Custom session cookie name (default: INGRESSCOOKIE)
     "nginx.ingress.kubernetes.io/session-cookie-name": "BITBUCKET-SESSION"
-    # Cookie expiration time in seconds (default: 86400 = 24 hours)
-    "nginx.ingress.kubernetes.io/session-cookie-max-age": "28800"
-    # Whether to change cookie on backend failure (default: false)
-    "nginx.ingress.kubernetes.io/session-cookie-change-on-failure": "true"
-
-bitbucket:
-  clustering:
-    enabled: true
+    "nginx.ingress.kubernetes.io/session-cookie-max-age": "28800"  # 8 hours
 ```
 
 ## Verifying Session Stickiness

--- a/docs/docs/examples/bitbucket/BITBUCKET_SESSION_AFFINITY.md
+++ b/docs/docs/examples/bitbucket/BITBUCKET_SESSION_AFFINITY.md
@@ -1,0 +1,87 @@
+# Session Stickiness for Bitbucket with NGINX Ingress
+
+When running Bitbucket Data Center in High Availability (HA) mode with multiple pods, session stickiness ensures that user requests are consistently routed to the same Bitbucket pod throughout their session.
+
+!!!info "Why session stickiness is important for Bitbucket"
+    * **Git operations**: Prevents Git push/pull failures when routed to different pods mid-operation
+    * **User sessions**: Avoids unexpected logouts and session data loss
+    * **Performance**: Maintains repository cache locality for better performance
+
+## Automatic Session Stickiness (Default)
+
+The Bitbucket Helm chart automatically enables session stickiness when using NGINX Ingress Controller:
+
+```yaml
+ingress:
+  create: true
+  nginx: true  # Automatically enables session stickiness
+  host: bitbucket.example.com
+
+bitbucket:
+  clustering:
+    enabled: true  # Required for HA deployments
+```
+
+This automatically applies these NGINX annotations:
+```yaml
+"nginx.ingress.kubernetes.io/affinity": "cookie"
+"nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+```
+
+## Custom Session Stickiness Configuration
+
+You can customize the session behavior by adding additional annotations:
+
+```yaml
+ingress:
+  create: true
+  nginx: true
+  host: bitbucket.example.com
+  annotations:
+    # Custom session cookie name (default: INGRESSCOOKIE)
+    "nginx.ingress.kubernetes.io/session-cookie-name": "BITBUCKET-SESSION"
+    # Cookie expiration time in seconds (default: 86400 = 24 hours)
+    "nginx.ingress.kubernetes.io/session-cookie-max-age": "28800"
+    # Whether to change cookie on backend failure (default: false)
+    "nginx.ingress.kubernetes.io/session-cookie-change-on-failure": "true"
+
+bitbucket:
+  clustering:
+    enabled: true
+```
+
+## Verifying Session Stickiness
+
+Test that session stickiness is working:
+
+```shell
+# Check ingress annotations
+kubectl describe ingress bitbucket -n atlassian
+
+# Test with curl (look for Set-Cookie header)
+curl -I https://bitbucket.example.com/status
+```
+
+## Troubleshooting
+
+If users are experiencing random logouts or Git operation failures:
+
+1. **Verify NGINX annotations are applied**:
+   ```shell
+   kubectl get ingress bitbucket -n atlassian -o yaml
+   ```
+
+2. **Check if requests hit the same pod**:
+   ```shell
+   kubectl logs -f -l app.kubernetes.io/name=bitbucket -n atlassian
+   ```
+
+3. **Ensure clustering is enabled**:
+   ```yaml
+   bitbucket:
+     clustering:
+       enabled: true
+   ```
+
+!!!tip "Production recommendation"
+    Set `session-cookie-max-age` to match your typical user session duration (e.g., 8 hours = 28800 seconds) to balance user experience with security. 

--- a/docs/docs/userguide/CONFIGURATION.md
+++ b/docs/docs/userguide/CONFIGURATION.md
@@ -36,36 +36,18 @@ Some key considerations to note when configuring the controller are:
 
 ## :material-account-group: Session Stickiness for High Availability
 
-When running Atlassian Data Center products in High Availability (HA) mode with multiple pods, session stickiness (also known as session affinity) is crucial for proper operation. Session stickiness ensures that once a user establishes a session with a specific pod, all subsequent requests from that user are routed to the same pod for the duration of their session.
+### NGINX Ingress Controller
 
-!!!info "Why session stickiness is important"
-    * **User session consistency**: Ensures users remain connected to the same application instance throughout their session
-    * **Application state management**: Prevents issues with in-memory session data being lost when requests are routed to different pods
-    * **Performance optimization**: Reduces overhead of session replication across the cluster
-    * **Feature compatibility**: Some features may not work correctly without sticky sessions
-
-### NGINX Ingress Controller (Default Configuration)
-
-The Helm charts are pre-configured with session stickiness when using the NGINX Ingress Controller. When `ingress.nginx: true` (the default), the following annotations are automatically applied:
+Session stickiness is automatically enabled when using NGINX Ingress Controller:
 
 ```yaml
 ingress:
   create: true
-  nginx: true  # This enables automatic session stickiness
+  nginx: true  # Automatically enables session stickiness
   host: bitbucket.example.com
 ```
 
-This automatically adds these annotations to the Ingress resource:
-
-```yaml
-annotations:
-  "nginx.ingress.kubernetes.io/affinity": "cookie"
-  "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
-```
-
-#### Customizing NGINX Session Stickiness
-
-You can customize the session stickiness behavior by adding additional annotations:
+#### Custom Configuration
 
 ```yaml
 ingress:
@@ -73,148 +55,32 @@ ingress:
   nginx: true
   host: bitbucket.example.com
   annotations:
-    # Customize cookie name (default: INGRESSCOOKIE)
-    "nginx.ingress.kubernetes.io/session-cookie-name": "BITBUCKET-AFFINITY"
-    # Set cookie expiration time (default: 86400 seconds = 24 hours)
-    "nginx.ingress.kubernetes.io/session-cookie-max-age": "43200"
-    # Change cookie path (default: /)
-    "nginx.ingress.kubernetes.io/session-cookie-path": "/bitbucket"
+    "nginx.ingress.kubernetes.io/session-cookie-name": "BITBUCKET-SESSION"
+    "nginx.ingress.kubernetes.io/session-cookie-max-age": "28800"  # 8 hours
+    "nginx.ingress.kubernetes.io/session-cookie-change-on-failure": "true"
 ```
 
-### AWS Application Load Balancer (ALB)
+#### Verify Configuration
 
-For AWS EKS clusters using the AWS Load Balancer Controller, configure session stickiness using ALB-specific annotations:
+```shell
+# Check ingress annotations
+kubectl describe ingress bitbucket -n atlassian
 
-```yaml
-ingress:
-  create: true
-  nginx: false  # Disable NGINX-specific annotations
-  className: "alb"
-  host: bitbucket.example.com
-  annotations:
-    # Enable ALB session stickiness
-    alb.ingress.kubernetes.io/target-group-attributes: |
-      stickiness.enabled=true,
-      stickiness.lb_cookie.duration_seconds=86400
-    # Target type (required for EKS with Fargate)
-    alb.ingress.kubernetes.io/target-type: ip
-    # Health check path
-    alb.ingress.kubernetes.io/healthcheck-path: /status
+# Test with curl (look for Set-Cookie header)
+curl -I https://bitbucket.example.com/status
 ```
 
-#### Multiple Target Groups with ALB
+#### Common Issues
 
-For complex routing scenarios, you can configure different stickiness settings per target group:
+| Issue | Solution |
+|-------|----------|
+| Users getting logged out randomly | Verify session stickiness annotations are applied |
+| Requests routing to different pods | Check if clustering is enabled |
+| Session cookies not working | Ensure ingress controller supports session affinity |
 
-```yaml
-ingress:
-  annotations:
-    alb.ingress.kubernetes.io/target-group-attributes: |
-      stickiness.enabled=true,
-      stickiness.lb_cookie.duration_seconds=86400,
-      stickiness.type=lb_cookie
-```
+### Other Ingress Controllers
 
-### Google Cloud Load Balancer (GKE)
-
-For Google Kubernetes Engine, session affinity is configured through BackendConfig:
-
-```yaml
-# Create a BackendConfig resource
-apiVersion: cloud.google.com/v1
-kind: BackendConfig
-metadata:
-  name: bitbucket-backend-config
-spec:
-  sessionAffinity:
-    affinityType: "CLIENT_IP_PROTO"
-    affinityCookieTtlSec: 86400
----
-# Reference it in your service
-bitbucket:
-  service:
-    annotations:
-      cloud.google.com/backend-config: '{"default": "bitbucket-backend-config"}'
-```
-
-### Azure Application Gateway
-
-For Azure Kubernetes Service with Application Gateway, enable cookie-based affinity:
-
-```yaml
-ingress:
-  create: true
-  nginx: false
-  className: "azure/application-gateway"
-  host: bitbucket.example.com
-  annotations:
-    # Enable cookie-based session affinity
-    appgw.ingress.kubernetes.io/cookie-based-affinity: "true"
-    # Optional: Set custom cookie name
-    appgw.ingress.kubernetes.io/affinity-cookie-name: "BITBUCKET-AFFINITY"
-```
-
-### Service-Level Session Affinity
-
-As an alternative or supplement to ingress-level session stickiness, you can configure session affinity at the Kubernetes service level:
-
-```yaml
-bitbucket:
-  service:
-    # Enable ClientIP-based session affinity
-    sessionAffinity: ClientIP
-    sessionAffinityConfig:
-      clientIP:
-        # Session timeout in seconds (default: 10800 = 3 hours)
-        timeoutSeconds: 10800
-```
-
-!!!note "Service vs Ingress Session Affinity"
-    * **Service-level affinity** is based on client IP and works at the network layer
-    * **Ingress-level affinity** typically uses cookies and works at the application layer
-    * Ingress-level affinity is generally preferred for web applications as it's more reliable when users are behind NAT/proxies
-
-### Verifying Session Stickiness
-
-To verify that session stickiness is working correctly:
-
-1. **Check ingress annotations**:
-   ```shell
-   kubectl describe ingress bitbucket -n atlassian
-   ```
-
-2. **Test with curl** (look for Set-Cookie headers):
-   ```shell
-   curl -I https://bitbucket.example.com/status
-   ```
-
-3. **Monitor pod traffic** during user sessions:
-   ```shell
-   kubectl logs -f bitbucket-0 -n atlassian
-   kubectl logs -f bitbucket-1 -n atlassian
-   ```
-
-4. **Check service configuration**:
-   ```shell
-   kubectl describe service bitbucket -n atlassian
-   ```
-
-### Troubleshooting Session Stickiness
-
-Common issues and solutions:
-
-| Issue | Possible Cause | Solution |
-|-------|----------------|----------|
-| Users getting logged out randomly | Session stickiness not configured | Add appropriate ingress annotations or service session affinity |
-| "Session expired" errors in HA setup | Requests routing to different pods | Verify ingress controller supports session affinity |
-| Inconsistent behavior between users | Load balancer not honoring cookies | Check load balancer configuration and cookie settings |
-| Session stickiness not working behind CDN | CDN stripping session cookies | Configure CDN to preserve session cookies |
-
-!!!warning "Important considerations"
-    * **Cookie security**: Ensure session cookies are configured with appropriate security settings (Secure, HttpOnly, SameSite)
-    * **Session duration**: Balance session duration between user convenience and security requirements
-    * **Pod scaling**: When scaling down, ensure graceful session handling to minimize user impact
-    * **Health checks**: Configure health check paths that don't interfere with session stickiness
+For other ingress controllers (AWS ALB, Google Cloud Load Balancer, Azure Application Gateway), refer to your controller's documentation for session stickiness configuration.
 
 ## :material-directions-fork: LoadBalancer/NodePort Service Type
 


### PR DESCRIPTION
## Pull request description

_- Added documentation for AWS OpenSearch Service configuration in `BITBUCKET_OPENSEARCH.md`
  - Simple configuration example using environment variables
  - Secret creation for credentials
  - IAM authentication option

- Added clear example for NGINX Ingress session stickiness in `CONFIGURATION.md`
  - Default configuration (automatically enabled)
  - Custom cookie configuration options_

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
