### PR TITLE
Add a warning about ATL_FORCE_CFG_UPDATE and ZDU upgrade

### DIFF
--- a/docs/docs/userguide/upgrades/PRODUCTS_UPGRADE.md
+++ b/docs/docs/userguide/upgrades/PRODUCTS_UPGRADE.md
@@ -134,6 +134,9 @@ You can use rolling upgrade only if the target version is zero-downtime compatib
     
     
     === "Confluence"
+        !!!warning "ATL_FORCE_CFG_UPDATE"
+            Make sure `additionalEnvironmentVariables.ATL_FORCE_CFG_UPDATE` is not excplicitly set to `true` in Helm values before a ZDU upgrade.
+            Setting it to false and performing a ZDU upgrade will result in build numbers mismatch. 
         
         ### Confluence rolling upgrade
         Let's say we have Confluence version `7.12.0` deployed to our Kubernetes cluster, and we want to upgrade it to version


### PR DESCRIPTION
Upgrade failures are observed due to a change in build number when ATL_FORCE_CFG_UPDATE is set to true in Helm values:

```
additionalEnvironmentVariables:
	- name: ATL_FORCE_CFG_UPDATE
     value: "true"
```

Adding a warning to docs.