### PR TITLE
NONE - bump PG memory 

### DIFF
--- a/src/test/infrastructure/cloudnativepg/cluster-template.yaml
+++ b/src/test/infrastructure/cloudnativepg/cluster-template.yaml
@@ -14,10 +14,10 @@ spec:
   
   resources:
     requests:
-      memory: "64Mi"
+      memory: "256Mi"
       cpu: "25m"
     limits:
-      memory: "256Mi"
+      memory: "1024Mi"
       cpu: "250m"
   
   storage:


### PR DESCRIPTION
## Pull request description

Bumping the PG memory to fix BB build failures. See slack convo for more context - https://atlassian.slack.com/archives/CFG7NBV1P/p1757906836824869

Tested the fix here - https://server-syd-bamboo.internal.atlassian.com/browse/BSERV-K8S166-2


## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
