### PR TITLE
fix: Add missing ErrorReportValve to default server.xml

### DIFF
--- a/src/main/charts/confluence/templates/configmap-server-config.yaml
+++ b/src/main/charts/confluence/templates/configmap-server-config.yaml
@@ -48,6 +48,7 @@ data:
                 defaultHost="localhost"
                 debug="0">
           <Host name="localhost"
+                <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />
                 debug="0"
                 appBase="webapps"
                 unpackWARs="true"

--- a/src/main/charts/crowd/templates/configmap-server-config.yaml
+++ b/src/main/charts/crowd/templates/configmap-server-config.yaml
@@ -47,6 +47,7 @@ data:
                 defaultHost="localhost">
 
         <Host appBase="webapps" autoDeploy="true" name="localhost" unpackWARs="true">
+           <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />
            <Context path="{{ .Values.crowd.service.contextPath | default "/crowd" }}" docBase="../../crowd-webapp" debug="0">
              <Manager pathname="" />
            </Context>

--- a/src/main/charts/jira/templates/configmap-server-config.yaml
+++ b/src/main/charts/jira/templates/configmap-server-config.yaml
@@ -66,7 +66,7 @@ data:
                 appBase="webapps"
                 unpackWARs="true"
                 autoDeploy="true">
-
+            <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />
             <Context path="{{ .Values.jira.service.contextPath | default "" }}"
                      docBase="${catalina.home}/atlassian-jira"
                      reloadable="false"


### PR DESCRIPTION
## Pull request description


Hide details and stack trace information in the error pages of Confluence




https://support.atlassian.com/confluence/kb/hide-details-and-stack-trace-information-in-the-error-pages-of-your-confluence-environment/ 
