### PR TITLE
DEVPROD-3580: envoy proxy as NodePort for Kind tests

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -53,10 +53,6 @@ jobs:
         run: |
           src/test/scripts/kind/configure_kind.sh
 
-      - name: Configure test hostname
-        run: |
-          echo "127.0.0.1 dc-app.test" | sudo tee -a /etc/hosts
-
       - name: Deploy postgres database
         run: |
           source src/test/scripts/kind/deploy_app.sh

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -53,6 +53,10 @@ jobs:
         run: |
           src/test/scripts/kind/configure_kind.sh
 
+      - name: Configure test hostname
+        run: |
+          echo "127.0.0.1 dc-app.test" | sudo tee -a /etc/hosts
+
       - name: Deploy postgres database
         run: |
           source src/test/scripts/kind/deploy_app.sh

--- a/.github/workflows/openshift.yaml
+++ b/.github/workflows/openshift.yaml
@@ -101,9 +101,12 @@ jobs:
         run: |
           # Gateway API CRDs
           oc apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+          oc apply --server-side=true -f https://raw.githubusercontent.com/envoyproxy/gateway/v1.2.5/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+          
           oc wait --for condition=established --timeout=60s crd/gateways.gateway.networking.k8s.io
           oc wait --for condition=established --timeout=60s crd/httproutes.gateway.networking.k8s.io
           oc wait --for condition=established --timeout=60s crd/gatewayclasses.gateway.networking.k8s.io
+          oc wait --for condition=established --timeout=60s crd/envoyproxies.gateway.envoyproxy.io
 
           # Envoy Gateway (installs into envoy-gateway-system)
           # OpenShift admission can reject fixed runAsUser/seccomp settings unless the
@@ -131,7 +134,10 @@ jobs:
             --namespace envoy-gateway-system \
             --timeout=300s
 
-          # Ensure GatewayClass exists/accepted
+          # EnvoyProxy CR configures the proxy Service as ClusterIP (default for OpenShift; an OpenShift Route will handle external access).
+          oc apply -f src/test/config/openshift/envoy-proxy.yaml
+          
+          # GatewayClass references the EnvoyProxy CR via parametersRef
           cat << EOF | oc apply -f -
           apiVersion: gateway.networking.k8s.io/v1
           kind: GatewayClass
@@ -139,6 +145,11 @@ jobs:
             name: eg
           spec:
             controllerName: gateway.envoyproxy.io/gatewayclass-controller
+            parametersRef:
+              group: gateway.envoyproxy.io
+              kind: EnvoyProxy
+              name: openshift-proxy-config
+              namespace: envoy-gateway-system
           EOF
           oc wait --for=condition=Accepted gatewayclass/eg --timeout=180s || { oc get gatewayclass/eg -o yaml; oc get pods -n envoy-gateway-system -o wide || true; exit 1; }
 
@@ -157,6 +168,26 @@ jobs:
               oc get events -n envoy-gateway-system --sort-by='.lastTimestamp' | tail -n 200 || true; \
               exit 1; \
             }
+
+          # Create an OpenShift Route so atlassian.apps.crc.testing reaches the
+          # Envoy proxy Service without port-forward or Host headers.
+          ENVOY_SVC=$(oc get svc -n envoy-gateway-system \
+            -l gateway.envoyproxy.io/owning-gateway-name=atlassian-gateway \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+
+          if [ -z "${ENVOY_SVC}" ]; then
+            echo "[ERROR]: Envoy Gateway proxy service not found"
+            oc get svc -n envoy-gateway-system -o wide || true
+            exit 1
+          fi
+
+          oc -n envoy-gateway-system expose svc/${ENVOY_SVC} \
+            --name atlassian-gateway-proxy \
+            --hostname atlassian.apps.crc.testing || true
+
+          # Log the Route and Endpoint details for debugging
+          oc -n envoy-gateway-system get route atlassian-gateway-proxy -o yaml || true
+          oc -n envoy-gateway-system get endpoints ${ENVOY_SVC} -o yaml || true
 
       - name: Deploy postgres database
         run: |

--- a/src/test/config/kind/common-values.yaml
+++ b/src/test/config/kind/common-values.yaml
@@ -109,7 +109,7 @@ podAnnotations:
   normal: annotation-comes-here
 
 # KinD tests use Gateway API with Envoy Gateway.
-# Note: tests access the Gateway via kubectl port-forward (not via host ports 80/443).
+# Envoy proxy is exposed via NodePort(30080) -> hostPort(80); dc-app.test resolves via /etc/hosts.
 gateway:
   create: true
   parentRefs:

--- a/src/test/config/kind/envoy-proxy.yaml
+++ b/src/test/config/kind/envoy-proxy.yaml
@@ -1,0 +1,30 @@
+# EnvoyProxy tells Envoy Gateway *how* to create the data-plane proxy
+# for any Gateway whose GatewayClass references this resource.
+#
+# Key behaviour:
+#   - The proxy Service is created as NodePort (not the default ClusterIP/LB).
+#   - A strategic-merge patch pins nodePort: 30080 for the HTTP listener,
+#     matching the KinD extraPortMappings (host 80 → node 30080).
+#
+# This removes the need for any post-hoc `kubectl patch` in configure_kind.sh.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: kind-proxy-config
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        type: NodePort
+        # Pin the HTTP listener to a fixed NodePort so it aligns with
+        # the KinD extraPortMappings entry (host :80 → node :30080).
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              ports:
+                - port: 80
+                  nodePort: 30080
+                  protocol: TCP

--- a/src/test/config/kind/kind-config.yml
+++ b/src/test/config/kind/kind-config.yml
@@ -5,8 +5,12 @@ networking:
 nodes:
 - role: control-plane
   # Previously we mounted /dev + labelled ingress-ready to support ingress-nginx.
-  # KinD tests now run Gateway API via port-forward, so no ingress-specific node setup is required.
+  # KinD tests now run Gateway API via Envoy Gateway, exposed through a fixed NodePort.
   extraPortMappings:
+  # Route host traffic to Envoy Gateway proxy via NodePort
+  - containerPort: 30080
+    hostPort: 80
+    protocol: TCP
   # map registry NodePort to host port to be able to
   # build and push images to an internal registry
   - containerPort: 32767

--- a/src/test/config/openshift/envoy-proxy.yaml
+++ b/src/test/config/openshift/envoy-proxy.yaml
@@ -1,0 +1,19 @@
+# EnvoyProxy tells Envoy Gateway *how* to create the data-plane proxy
+# for any Gateway whose GatewayClass references this resource.
+#
+# On OpenShift/MicroShift we keep the default ClusterIP and expose
+# Envoy via an OpenShift Route (created in the workflow).
+# This resource exists so the GatewayClass can use a consistent
+# parametersRef pattern across environments.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: openshift-proxy-config
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        # ClusterIP is fine here — the OpenShift Route handles external access.
+        type: ClusterIP

--- a/src/test/scripts/kind/configure_kind.sh
+++ b/src/test/scripts/kind/configure_kind.sh
@@ -97,6 +97,10 @@ EOF
       exit 1
     }
   
+  # Add /etc/hosts entry so dc-app.test resolves to localhost on the runner.
+  echo "[INFO]: Adding dc-app.test to /etc/hosts"
+  echo "127.0.0.1 dc-app.test" | sudo tee -a /etc/hosts
+
   echo "[INFO]: Gateway API installation complete"
 else
   echo "[INFO]: Skipping Gateway API installation (SKIP_GATEWAY_API is set)"

--- a/src/test/scripts/kind/configure_kind.sh
+++ b/src/test/scripts/kind/configure_kind.sh
@@ -17,12 +17,14 @@ kubectl apply -f src/test/config/kind/registry.yaml
 if [ -z "${SKIP_GATEWAY_API}" ]; then
   echo "[INFO]: Installing Gateway API CRDs"
   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
-  
+  kubectl apply --server-side=true -f https://raw.githubusercontent.com/envoyproxy/gateway/v1.2.5/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+
   echo "[INFO]: Waiting for Gateway API CRDs to be established"
   kubectl wait --for condition=established --timeout=60s crd/gateways.gateway.networking.k8s.io
   kubectl wait --for condition=established --timeout=60s crd/httproutes.gateway.networking.k8s.io
   kubectl wait --for condition=established --timeout=60s crd/gatewayclasses.gateway.networking.k8s.io
-  
+  kubectl wait --for condition=established --timeout=60s crd/envoyproxies.gateway.envoyproxy.io
+
   echo "[INFO]: Installing Envoy Gateway"
   # Envoy Gateway uses OCI registry, not a traditional Helm repo
   helm install eg oci://docker.io/envoyproxy/gateway-helm \
@@ -40,8 +42,15 @@ if [ -z "${SKIP_GATEWAY_API}" ]; then
       --namespace envoy-gateway-system \
       --timeout=300s
 
-  # Some environments don't auto-create the GatewayClass.
-  echo "[INFO]: Ensuring GatewayClass 'eg' exists"
+  # EnvoyProxy CR tells the controller to create the data-plane proxy Service
+  # as NodePort with nodePort 30080 — matching the KinD extraPortMappings.
+  # This must be applied BEFORE the GatewayClass so the controller picks it up.
+  echo "[INFO]: Applying EnvoyProxy configuration (NodePort 30080)"
+  kubectl apply -f src/test/config/kind/envoy-proxy.yaml
+
+  # GatewayClass references the EnvoyProxy CR via parametersRef so every
+  # Gateway using this class gets the NodePort configuration automatically.
+  echo "[INFO]: Creating GatewayClass 'eg' with parametersRef"
   cat << EOF | kubectl apply -f -
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
@@ -49,6 +58,11 @@ metadata:
   name: eg
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: kind-proxy-config
+    namespace: envoy-gateway-system
 EOF
 
   echo "[INFO]: Waiting for GatewayClass 'eg' to be accepted"

--- a/src/test/scripts/kind/deploy_app.sh
+++ b/src/test/scripts/kind/deploy_app.sh
@@ -359,64 +359,17 @@ deploy_app() {
   fi
 }
 
-# Resolve the ingress/gateway hostname based on the deployment environment.
+# Resolve the routing hostname based on the deployment environment.
+#
+# - KinD: Envoy Gateway proxy is exposed via NodePort(30080) -> hostPort(80)
+#         and the workflow adds /etc/hosts so dc-app.test resolves locally.
+# - OpenShift/MicroShift: Envoy proxy is exposed via an OpenShift Route on the
+#         CRC apps domain.
 get_routing_hostname() {
   if [ -n "${OPENSHIFT_VALUES}" ]; then
     echo "atlassian.apps.crc.testing"
   else
-    echo "localhost"
-  fi
-}
-
-# Check if the gateway port-forward process is alive and forwarding.
-_check_gateway_pf_ready() {
-  kill -0 "${GATEWAY_PF_PID}" 2>/dev/null && grep -q "Forwarding from" "${PF_LOG}" 2>/dev/null
-}
-
-# Start a port-forward to the Envoy Gateway proxy and export:
-#   GATEWAY_URL    — base URL (http://127.0.0.1:<port>)
-#   GATEWAY_HOST   — hostname from the HTTPRoute (used as Host header)
-#   GATEWAY_PF_PID — PID of the background port-forward process
-start_gateway_port_forward() {
-  local pf_port="${1:-18080}"
-
-  ENVOY_SVC=$(kubectl get svc -n envoy-gateway-system \
-    -l gateway.envoyproxy.io/owning-gateway-name=atlassian-gateway \
-    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-
-  if [ -z "${ENVOY_SVC}" ]; then
-    echo "[ERROR]: Envoy Gateway proxy service not found"
-    kubectl get svc -n envoy-gateway-system -o wide || true
-    return 1
-  fi
-
-  GATEWAY_HOST=$(kubectl get httproute/${DC_APP} -n atlassian -o jsonpath='{.spec.hostnames[0]}' 2>/dev/null || true)
-  if [ -z "${GATEWAY_HOST}" ]; then
-    echo "[ERROR]: HTTPRoute ${DC_APP} has no hostname configured"
-    return 1
-  fi
-
-  PF_LOG=$(mktemp)
-  kubectl port-forward -n envoy-gateway-system "svc/${ENVOY_SVC}" "${pf_port}:80" >"${PF_LOG}" 2>&1 &
-  GATEWAY_PF_PID=$!
-
-  wait_for "port-forward to Envoy proxy" 10 1 _check_gateway_pf_ready || {
-    echo "[ERROR]: port-forward did not become ready"
-    cat "${PF_LOG}" || true
-    kill ${GATEWAY_PF_PID} 2>/dev/null || true
-    return 1
-  }
-
-  GATEWAY_URL="http://127.0.0.1:${pf_port}"
-  GATEWAY_CONNECT_TO="${GATEWAY_HOST}:80:127.0.0.1:${pf_port}"
-  echo "[INFO]: Gateway port-forward ready — ${GATEWAY_URL} (Host: ${GATEWAY_HOST})"
-}
-
-stop_gateway_port_forward() {
-  if [ -n "${GATEWAY_PF_PID}" ]; then
-    kill ${GATEWAY_PF_PID} 2>/dev/null || true
-    wait ${GATEWAY_PF_PID} 2>/dev/null || true
-    GATEWAY_PF_PID=""
+    echo "dc-app.test"
   fi
 }
 
@@ -429,20 +382,16 @@ stop_gateway_port_forward() {
 wait_for_bamboo_setup() {
   echo "[INFO]: Waiting for Bamboo server unattended setup to complete..."
 
-  start_gateway_port_forward 18080 || return 1
-  trap 'stop_gateway_port_forward' RETURN
-
+  SETUP_HOSTNAME=$(get_routing_hostname)
   SETUP_TIMEOUT=300
   SETUP_ELAPSED=0
   while [ ${SETUP_ELAPSED} -lt ${SETUP_TIMEOUT} ]; do
-    RESPONSE=$(curl -s -o /dev/null -w "%{http_code}|%{redirect_url}" --max-redirs 0 -H "Host: ${GATEWAY_HOST}" "${GATEWAY_URL}/" 2>/dev/null || echo "000|")
+    RESPONSE=$(curl -s -o /dev/null -w "%{http_code}|%{redirect_url}" --max-redirs 0 "http://${SETUP_HOSTNAME}/" 2>/dev/null || echo "000|")
     HTTP_CODE=$(echo "$RESPONSE" | cut -d'|' -f1)
     REDIRECT_URL=$(echo "$RESPONSE" | cut -d'|' -f2)
 
     if echo "${REDIRECT_URL}" | grep -q "bootstrap\|setup"; then
-      # --connect-to remaps dc-app.test:80 → 127.0.0.1:<pf_port> so curl can follow
-      # Bamboo's absolute redirects through the port-forward
-      curl -s -o /dev/null -L --max-redirs 10 -H "Host: ${GATEWAY_HOST}" --connect-to "${GATEWAY_CONNECT_TO}" "${GATEWAY_URL}/" 2>/dev/null || true
+      curl -s -o /dev/null -L --max-redirs 10 "http://${SETUP_HOSTNAME}/" 2>/dev/null || true
       echo "[INFO]: Bamboo setup in progress (HTTP ${HTTP_CODE} → ${REDIRECT_URL}). Triggering setup... (${SETUP_ELAPSED}s/${SETUP_TIMEOUT}s)"
     elif [ "${HTTP_CODE}" = "302" ] && echo "${REDIRECT_URL}" | grep -q "userlogin"; then
       echo "[INFO]: Bamboo server setup complete (redirecting to login page)"
@@ -458,7 +407,7 @@ wait_for_bamboo_setup() {
   done
 
   echo "[WARNING]: Bamboo setup did not complete within ${SETUP_TIMEOUT}s. Proceeding with agent deployment anyway."
-  curl -v -s -L --max-redirs 10 -H "Host: ${GATEWAY_HOST}" --connect-to "${GATEWAY_CONNECT_TO}" "${GATEWAY_URL}/" 2>&1 || true
+  curl -v -s -L --max-redirs 10 "http://${SETUP_HOSTNAME}/" 2>&1 || true
 }
 
 verify_gateway_ingress() {
@@ -477,41 +426,18 @@ verify_gateway_ingress() {
     exit 1
   }
 
-  start_gateway_port_forward 18080 || exit 1
-  trap 'stop_gateway_port_forward' RETURN
+  HOSTNAME=$(get_routing_hostname)
+  STATUS_URL="http://${HOSTNAME}/${STATUS_ENDPOINT_PATH}"
 
-  STATUS_URL="${GATEWAY_URL}/${STATUS_ENDPOINT_PATH}"
   wait_for "${DC_APP} HTTP 200 via Gateway" 120 10 \
-    check_http_200 "${STATUS_URL}" -H "Host: ${GATEWAY_HOST}" || {
+    check_http_200 "${STATUS_URL}" || {
     echo "[ERROR]: ${DC_APP} did not return HTTP 200 via Gateway"
-    curl -v -H "Host: ${GATEWAY_HOST}" "${STATUS_URL}"
+    curl -v "${STATUS_URL}"
     exit 1
   }
 
   echo "[INFO]: ${DC_APP} responded successfully via Gateway"
-  curl -s -H "Host: ${GATEWAY_HOST}" "${STATUS_URL}"
-  echo -e "\n"
-}
-
-verify_ingress() {
-  STATUS_ENDPOINT_PATH="status"
-  if [ ${DC_APP} == "bamboo" ]; then
-    STATUS_ENDPOINT_PATH="rest/api/latest/status"
-  elif [ ${DC_APP} == "crowd" ]; then
-    STATUS_ENDPOINT_PATH="crowd/status"
-  fi
-  echo "[INFO]: Checking ${DC_APP} status"
-  HOSTNAME=$(get_routing_hostname)
-
-  wait_for "${DC_APP} HTTP 200 via Ingress" 120 10 \
-    check_http_200 "http://${HOSTNAME}/${STATUS_ENDPOINT_PATH}" || {
-    echo "[ERROR]: ${DC_APP} did not return HTTP 200 via Ingress"
-    curl -v http://${HOSTNAME}/${STATUS_ENDPOINT_PATH}
-    exit 1
-  }
-
-  echo "[INFO]: ${DC_APP} responded successfully via Ingress"
-  curl -s http://${HOSTNAME}/${STATUS_ENDPOINT_PATH}
+  curl -s "${STATUS_URL}"
   echo -e "\n"
 }
 


### PR DESCRIPTION
## Pull request description

Making Gateway Proxy use K8s NodePort, and Openshift Route instead of port forwarding.

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

