### PR TITLE
DEVPROD-3865 Fixing e2e tests: enabled basic auth in BB

### DIFF
--- a/src/test/config/bitbucket/values.yaml
+++ b/src/test/config/bitbucket/values.yaml
@@ -25,6 +25,7 @@ bitbucket:
   sysadminCredentials:
     secretName: bitbucket-sysadmin-credentials
   additionalJvmArgs:
+    - -Dcom.atlassian.plugins.authentication.basic.auth.filter.force.allow=true
     - -Dfeature.getting.started.page=false
     - -Dupm.plugin.upload.enabled=true
     - -XX:ActiveProcessorCount=2


### PR DESCRIPTION
## Enable Basic Auth for Bitbucket 10.x e2e tests

Bitbucket 10.x disables Basic Authentication by default via the atlassian-authentication plugin. This causes all e2e REST API calls to fail with 403 "Basic Authentication has been disabled on this instance.".

Add -Dcom.atlassian.plugins.authentication.basic.auth.filter.force.allow=true to the Bitbucket e2e test JVM args — the same flag Bitbucket's own functional tests use (func-test/kubernetes/pom.xml).

### Verified locally:

- Without flag: 403 "Basic Authentication has been disabled on this instance." (matches CI failure)
- With flag: 401 "Authentication failed" (Basic Auth accepted, credentials validated)


<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

