### PR TITLE
DEVPROD-3872: enabling basic auth for bitbucket kind test

### DIFF
--- a/src/test/config/kind/common-values.yaml
+++ b/src/test/config/kind/common-values.yaml
@@ -60,6 +60,7 @@ DC_APP_REPLACEME:
     - -Datlassian.darkfeature.jira.onboarding.feature.disabled=true
     - -Djira.websudo.is.disabled=true
     - -Datlassian.allow.insecure.url.parameter.login=true
+    - -Dcom.atlassian.plugins.authentication.basic.auth.filter.force.allow=true
 
   # Jira func tests will setup Jira, and during this time status will report 500
   # to avoid marking container as non-ready, let's bump failureThreshold for a readinessProbe


### PR DESCRIPTION
## Pull request description

enabling basic auth for bitbucket kind test after bitbucket version upgrade

## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

