### PR TITLE
DEVPROD-3881: fix configure kind sudo command

### DIFF
--- a/src/test/scripts/kind/configure_kind.sh
+++ b/src/test/scripts/kind/configure_kind.sh
@@ -99,7 +99,12 @@ EOF
   
   # Add /etc/hosts entry so dc-app.test resolves to localhost on the runner.
   echo "[INFO]: Adding dc-app.test to /etc/hosts"
-  echo "127.0.0.1 dc-app.test" | sudo tee -a /etc/hosts
+  if [ "$(id -u)" -ne 0 ]; then
+    SUDO=$(which sudo)
+    echo "127.0.0.1 dc-app.test" | ${SUDO} tee -a /etc/hosts >/dev/null
+  else
+    echo "127.0.0.1 dc-app.test" >> /etc/hosts
+  fi
 
   echo "[INFO]: Gateway API installation complete"
 else


### PR DESCRIPTION
## Pull request description

Sudo command to add hostname in etc/hosts
fix in configure_kind.sh 


## Checklist
- [ ] I have added unit tests
- [ ] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

