### PR TITLE
feat(confluence): make synchrony readinessProbe timeoutSeconds config…

### DIFF
--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -243,6 +243,7 @@ Kubernetes: `>=1.21.x-0`
 | synchrony.readinessProbe.healthcheckPath | string | `"/synchrony/heartbeat"` | The healthcheck path to check against for the Synchrony container useful when configuring behind a reverse-proxy or loadbalancer https://confluence.atlassian.com/confkb/cannot-enable-collaborative-editing-on-synchrony-cluster-962962742.html  |
 | synchrony.readinessProbe.initialDelaySeconds | int | `5` | The initial delay (in seconds) for the Synchrony container readiness probe, after which the probe will start running.  |
 | synchrony.readinessProbe.periodSeconds | int | `1` | How often (in seconds) the Synchrony container readiness probe will run  |
+| synchrony.readinessProbe.timeoutSeconds | int | `1` | Number of seconds after which the Synchrony container readiness probe times out  |
 | synchrony.replicaCount | int | `1` | Number of Synchrony pods  |
 | synchrony.resources.container.requests.cpu | string | `"2"` | Initial CPU request by Synchrony pod. Because the container CPU request value is used in -XX:ActiveProcessorCount argument to Synchrony JVM  only integers are allowed, e.g. 1, 2, 3 etc. If you want to have a small CPU claim, set it to 30m, 50m, etc. Any container cpu request value containing `m` character will be converted to -XX:ActiveProcessorCount=1  See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu  |
 | synchrony.resources.container.requests.memory | string | `"2.5G"` | Initial Memory request Synchrony pod  |

--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -111,6 +111,7 @@ spec:
               path: {{ .Values.synchrony.readinessProbe.healthcheckPath }}
             initialDelaySeconds: {{ .Values.synchrony.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.synchrony.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.synchrony.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.synchrony.readinessProbe.failureThreshold }}
           {{- with .Values.synchrony.containerSecurityContext }}
           securityContext:

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -1482,6 +1482,10 @@ synchrony:
     #
     periodSeconds: 1
 
+    # -- Number of seconds after which the Synchrony container readiness probe times out
+    #
+    timeoutSeconds: 1
+
     # -- The number of consecutive failures of the Synchrony container readiness probe
     # before the pod fails readiness checks.
     #

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -388,6 +388,7 @@ data:
         healthcheckPath: /synchrony/heartbeat
         initialDelaySeconds: 5
         periodSeconds: 1
+        timeoutSeconds: 1
       replicaCount: 1
       resources:
         container:
@@ -638,6 +639,7 @@ spec:
               path: /synchrony/heartbeat
             initialDelaySeconds: 5
             periodSeconds: 1
+            timeoutSeconds: 1
             failureThreshold: 10
           resources:
             requests:


### PR DESCRIPTION
## Pull request description
The synchrony StatefulSet's readinessProbe has no way to configure `timeoutSeconds`, so it falls back to Kubernetes' default of 1s. In our production environment the probe occasionally fails under load, and we need the ability to tune this value per-cluster.
This adds `synchrony.readinessProbe.timeoutSeconds` (default `1`, no behavior change) and wires it into the template — matching the pattern already used for `confluence.readinessProbe` / `livenessProbe`.

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [x] The E2E test has passed (use `e2e` label)
