### PR TITLE
Add service external traffic policy

### DIFF
--- a/src/main/charts/bamboo/README.md
+++ b/src/main/charts/bamboo/README.md
@@ -90,6 +90,7 @@ Kubernetes: `>=1.21.x-0`
 | bamboo.seraphConfig.generateByHelm | bool | `false` | Mount seraph-config.xml as a ConfigMap. Override configuration elements if necessary  |
 | bamboo.service.annotations | object | `{}` | Additional annotations to apply to the Service  |
 | bamboo.service.contextPath | string | `nil` | The Tomcat context path that Bamboo will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically.  |
+| bamboo.service.externalTrafficPolicy | string | `nil` | The external traffic policy for the service. Set to Local to preserve client source IPs. Only applies when service.type is NodePort or LoadBalancer.  |
 | bamboo.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer.  |
 | bamboo.service.nodePort | string | `nil` | Only applicable if service.type is NodePort. NodePort for Bamboo service  |
 | bamboo.service.port | int | `80` | The port on which the Bamboo K8s Service will listen for http traffic  |

--- a/src/main/charts/bamboo/templates/service.yaml
+++ b/src/main/charts/bamboo/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.bamboo.service.type }}
+  {{- if and .Values.bamboo.service.externalTrafficPolicy (or (eq .Values.bamboo.service.type "NodePort") (eq .Values.bamboo.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.bamboo.service.externalTrafficPolicy }}
+  {{- end }}
   sessionAffinity: {{ .Values.bamboo.service.sessionAffinity }}
   {{- if .Values.bamboo.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
   sessionAffinityConfig:

--- a/src/main/charts/bamboo/values.yaml
+++ b/src/main/charts/bamboo/values.yaml
@@ -700,6 +700,11 @@ bamboo:
     #
     type: ClusterIP
 
+    # -- The external traffic policy for the service. Set to Local to preserve
+    # client source IPs. Only applies when service.type is NodePort or LoadBalancer.
+    #
+    externalTrafficPolicy:
+
     # --  Only applicable if service.type is NodePort. NodePort for Bamboo service
     #
     nodePort:

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -129,6 +129,7 @@ Kubernetes: `>=1.21.x-0`
 | bitbucket.securityContextEnabled | bool | `true` | Whether to apply security context to pod.  |
 | bitbucket.service.annotations | object | `{}` | Additional annotations to apply to the Service  |
 | bitbucket.service.contextPath | string | `nil` | The context path that Bitbucket will use.  |
+| bitbucket.service.externalTrafficPolicy | string | `nil` | The external traffic policy for the service. Set to Local to preserve client source IPs. Only applies when service.type is NodePort or LoadBalancer.  |
 | bitbucket.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer.  |
 | bitbucket.service.nodePort | string | `nil` | Only applicable if service.type is NodePort. NodePort for Bitbucket service  |
 | bitbucket.service.port | int | `80` | The port on which the Bitbucket K8s HTTP Service will listen  |

--- a/src/main/charts/bitbucket/templates/service.yaml
+++ b/src/main/charts/bitbucket/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.bitbucket.service.type }}
+  {{- if and .Values.bitbucket.service.externalTrafficPolicy (or (eq .Values.bitbucket.service.type "NodePort") (eq .Values.bitbucket.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.bitbucket.service.externalTrafficPolicy }}
+  {{- end }}
   sessionAffinity: {{ .Values.bitbucket.service.sessionAffinity }}
   {{- if .Values.bitbucket.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
   sessionAffinityConfig:

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -676,6 +676,11 @@ bitbucket:
     #
     type: ClusterIP
 
+    # -- The external traffic policy for the service. Set to Local to preserve
+    # client source IPs. Only applies when service.type is NodePort or LoadBalancer.
+    #
+    externalTrafficPolicy:
+
     # --  Only applicable if service.type is NodePort. NodePort for Bitbucket service
     #
     nodePort:

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -91,6 +91,7 @@ Kubernetes: `>=1.21.x-0`
 | confluence.seraphConfig.generateByHelm | bool | `false` | Mount seraph-config.xml as a ConfigMap. Override configuration elements if necessary  |
 | confluence.service.annotations | object | `{}` | Additional annotations to apply to the Service  |
 | confluence.service.contextPath | string | `nil` | The Tomcat context path that Confluence will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically.  |
+| confluence.service.externalTrafficPolicy | string | `nil` | The external traffic policy for the service. Set to Local to preserve client source IPs. Only applies when service.type is NodePort or LoadBalancer.  |
 | confluence.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer.  |
 | confluence.service.nodePort | string | `nil` | Only applicable if service.type is NodePort. NodePort for Confluence service  |
 | confluence.service.port | int | `80` | The port on which the Confluence K8s Service will listen  |

--- a/src/main/charts/confluence/templates/service.yaml
+++ b/src/main/charts/confluence/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.confluence.service.type }}
+  {{- if and .Values.confluence.service.externalTrafficPolicy (or (eq .Values.confluence.service.type "NodePort") (eq .Values.confluence.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.confluence.service.externalTrafficPolicy }}
+  {{- end }}
   sessionAffinity: {{ .Values.confluence.service.sessionAffinity }}
   {{- if .Values.confluence.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
   sessionAffinityConfig:

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -717,6 +717,11 @@ confluence:
     #
     type: ClusterIP
 
+    # -- The external traffic policy for the service. Set to Local to preserve
+    # client source IPs. Only applies when service.type is NodePort or LoadBalancer.
+    #
+    externalTrafficPolicy:
+
     # --  Only applicable if service.type is NodePort. NodePort for Confluence service
     #
     nodePort:

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -73,6 +73,7 @@ Kubernetes: `>=1.21.x-0`
 | crowd.securityContextEnabled | bool | `true` | Whether to apply security context to pod.  |
 | crowd.service.annotations | object | `{}` | Additional annotations to apply to the Service  |
 | crowd.service.contextPath | string | `"/crowd"` | The Tomcat context path that Crowd will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically.  |
+| crowd.service.externalTrafficPolicy | string | `nil` | The external traffic policy for the service. Set to Local to preserve client source IPs. Only applies when service.type is NodePort or LoadBalancer.  |
 | crowd.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer.  |
 | crowd.service.nodePort | string | `nil` | Only applicable if service.type is NodePort. NodePort for Crowd service  |
 | crowd.service.port | int | `80` | The port on which the Crowd K8s Service will listen  |

--- a/src/main/charts/crowd/templates/service.yaml
+++ b/src/main/charts/crowd/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.crowd.service.type }}
+  {{- if and .Values.crowd.service.externalTrafficPolicy (or (eq .Values.crowd.service.type "NodePort") (eq .Values.crowd.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.crowd.service.externalTrafficPolicy }}
+  {{- end }}
   sessionAffinity: {{ .Values.crowd.service.sessionAffinity }}
   {{- if .Values.crowd.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
   sessionAffinityConfig:

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -117,6 +117,11 @@ crowd:
     #
     type: ClusterIP
 
+    # -- The external traffic policy for the service. Set to Local to preserve
+    # client source IPs. Only applies when service.type is NodePort or LoadBalancer.
+    #
+    externalTrafficPolicy:
+
     # --  Only applicable if service.type is NodePort. NodePort for Crowd service
     #
     nodePort:

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -139,6 +139,7 @@ Kubernetes: `>=1.21.x-0`
 | jira.seraphConfig.generateByHelm | bool | `false` | Mount seraph-config.xml as a ConfigMap. Override configuration elements if necessary  |
 | jira.service.annotations | object | `{}` | Additional annotations to apply to the Service  |
 | jira.service.contextPath | string | `nil` | The Tomcat context path that Jira will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically.  |
+| jira.service.externalTrafficPolicy | string | `nil` | The external traffic policy for the service. Set to Local to preserve client source IPs. Only applies when service.type is NodePort or LoadBalancer.  |
 | jira.service.loadBalancerIP | string | `nil` | Use specific loadBalancerIP. Only applies to service type LoadBalancer.  |
 | jira.service.nodePort | string | `nil` | Only applicable if service.type is NodePort. NodePort for Jira service  |
 | jira.service.port | int | `80` | The port on which the Jira K8s Service will listen  |

--- a/src/main/charts/jira/templates/service.yaml
+++ b/src/main/charts/jira/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.jira.service.type }}
+  {{- if and .Values.jira.service.externalTrafficPolicy (or (eq .Values.jira.service.type "NodePort") (eq .Values.jira.service.type "LoadBalancer")) }}
+  externalTrafficPolicy: {{ .Values.jira.service.externalTrafficPolicy }}
+  {{- end }}
   sessionAffinity: {{ .Values.jira.service.sessionAffinity }}
   {{- if .Values.jira.service.sessionAffinityConfig.clientIP.timeoutSeconds }}
   sessionAffinityConfig:

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -606,6 +606,11 @@ jira:
     #
     type: ClusterIP
 
+    # -- The external traffic policy for the service. Set to Local to preserve
+    # client source IPs. Only applies when service.type is NodePort or LoadBalancer.
+    #
+    externalTrafficPolicy:
+
     # --  Only applicable if service.type is NodePort. NodePort for Jira service
     #
     nodePort:

--- a/src/test/java/test/ServiceTest.java
+++ b/src/test/java/test/ServiceTest.java
@@ -118,6 +118,19 @@ class ServiceTest {
     }
 
     @ParameterizedTest
+    @EnumSource(value = Product.class, names = {"bamboo_agent"}, mode = EnumSource.Mode.EXCLUDE)
+    void service_external_traffic_policy(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".service.type", "NodePort",
+                product + ".service.externalTrafficPolicy", "Local"
+        ));
+
+        final var service = resources.get(Kind.Service, Service.class, product.getHelmReleaseName());
+
+        assertThat(service.getSpec().path("externalTrafficPolicy")).hasTextEqualTo("Local");
+    }
+
+    @ParameterizedTest
     @EnumSource(value = Product.class, names = "confluence")
     void synchrony_service_default_annotations(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(


### PR DESCRIPTION
## Pull request description

Adds optional `<product>.service.externalTrafficPolicy` support across Jira, Confluence, Bamboo, Bitbucket, and Crowd Service templates. The value only renders for `NodePort` and `LoadBalancer` services to avoid producing invalid ClusterIP Service specs. The values files, README tables, and parameterized Service test are updated with the new setting.

Fixes #1085.

## Validation

- `git diff --check`
- `helm template` render check for `jira`, `confluence`, `bamboo`, `bitbucket`, and `crowd` with `service.type=NodePort` and `service.externalTrafficPolicy=Local`
- `C:\PROJECT\tools\apache-maven-3.9.11\bin\mvn.cmd -Dtest=ServiceTest test` — `Tests run: 36, Failures: 0, Errors: 0, Skipped: 0`, `BUILD SUCCESS`

## Checklist
- [x] I have added unit tests
- [x] I have applied the change to all applicable products
- [ ] The E2E test has passed (use `e2e` label)
