### PR TITLE
Update CRC binary download URL

### DIFF
--- a/.github/workflows/openshift.yaml
+++ b/.github/workflows/openshift.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Fetch crc binary
         run: |
           CRC_VERSION="2.49.0"
-          wget -q https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/${CRC_VERSION}/crc-linux-amd64.tar.xz
+          wget -q https://developers.redhat.com/content-gateway/file/pub/cgw/crc/${CRC_VERSION}/crc-linux-amd64.tar.xz
           tar -xvf crc-linux-amd64.tar.xz
           sudo cp crc-linux-${CRC_VERSION}-amd64/crc /usr/bin/crc
           sudo chmod a+x /usr/bin/crc


### PR DESCRIPTION
## Pull request description

The mirror for the Red Hat CRC binaries changed

Used to work but is now broken:
https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/2.49.0/crc-linux-amd64.tar.xz

Replaced by:
https://developers.redhat.com/content-gateway/rest/mirror/pub/cgw/crc/2.49.0/crc-linux-amd64.tar.xz

This broke the microshift tests workflow (example [here](https://github.com/atlassian/data-center-helm-charts/actions/runs/34298234898))

Here is an example of the Microshift tests workflow running with this changes: https://github.com/atlassian/data-center-helm-charts/actions/runs/34301174062